### PR TITLE
🎨 Palette: Add shell alias helper to bootstrap summary

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-27 - Improving CLI Ergonomics
+**Learning:** Users often struggle with long paths for internal scripts (`~/.claude/scripts/parallel_agent.sh`). Providing a copy-pasteable alias command during setup significantly reduces friction.
+**Action:** Always offer shell aliases for tools installed in non-standard locations. Detect the user's shell to provide the correct command.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1033,6 +1033,20 @@ print_summary() {
     echo "  \$EDITOR ~/.claude/config/services.yml"
     echo ""
 
+    echo -e "${BOLD}Tip: Easy Access${NC}"
+    echo ""
+    echo "  Add an alias to run 'manifest' from anywhere:"
+    echo ""
+    if [[ "$SHELL" == *"zsh"* ]]; then
+        echo -e "  ${CYAN}echo 'alias manifest=\"~/.claude/scripts/parallel_agent.sh\"' >> ~/.zshrc && source ~/.zshrc${NC}"
+    elif [[ "$SHELL" == *"bash"* ]]; then
+        echo -e "  ${CYAN}echo 'alias manifest=\"~/.claude/scripts/parallel_agent.sh\"' >> ~/.bashrc && source ~/.bashrc${NC}"
+    else
+        echo -e "  ${CYAN}alias manifest=\"~/.claude/scripts/parallel_agent.sh\"${NC}"
+        echo "  (Add to your shell profile)"
+    fi
+    echo ""
+
     echo -e "${BOLD}Quick Start:${NC}"
     echo ""
     echo "  # Test parallel agents (uses enabled services only)"


### PR DESCRIPTION
* 💡 What: Added copy-pasteable shell alias command (`manifest`) to `bootstrap.sh` summary.
* 🎯 Why: Users struggle with long paths (`~/.claude/scripts/parallel_agent.sh`); this reduces friction.
* 📸 Before: Only showed long path in Quick Start.
* 📸 After: Shows a dedicated "Tip: Easy Access" section with shell-specific alias setup command.
* ♿ Accessibility: Reduces cognitive load and typing errors.

---
*PR created automatically by Jules for task [18265171187512297902](https://jules.google.com/task/18265171187512297902) started by @ReefBytes*