### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in parallel_agent.sh

### DIFF
--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -560,7 +560,7 @@ run_gemini() {
     echo -e "${BLUE}[Gemini CLI]${NC} Starting with model: $GEMINI_MODEL..."
     # Gemini CLI: pipe prompt via stdin for reliable handling
     run_with_retry "Gemini CLI" "$output_file" bash -c \
-        "cat '$prompt_file' | gemini --output-format text --model '$GEMINI_MODEL' ${include_args[*]}"
+        'cat "$1" | gemini --output-format text --model "$2" "${@:3}"' -- "$prompt_file" "$GEMINI_MODEL" "${include_args[@]}"
 }
 
 # Run Claude CLI with model selection
@@ -580,7 +580,7 @@ run_claude() {
 
     # Claude CLI: use prompt file as positional argument
     if ! run_with_retry_capture_stderr "Claude CLI" "$output_file" "$stderr_file" \
-        bash -c "cat '$prompt_file' | claude --print --output-format text --model '$CLAUDE_MODEL'"; then
+        bash -c 'cat "$1" | claude --print --output-format text --model "$2"' -- "$prompt_file" "$CLAUDE_MODEL"; then
 
         # Check for credit exhaustion
         if check_credit_exhaustion "$stderr_file" "Claude"; then
@@ -590,7 +590,7 @@ run_claude() {
 
             # Retry with haiku (cheapest model)
             run_with_retry "Claude CLI (fallback)" "$output_file" \
-                bash -c "cat '$prompt_file' | claude --print --output-format text --model haiku"
+                bash -c 'cat "$1" | claude --print --output-format text --model haiku' -- "$prompt_file"
         fi
     fi
 }

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-01-28 - Command Injection in Parallel Agent Script
+**Vulnerability:** Found command injection in `parallel_agent.sh` where user inputs (via environment variables or arguments) were interpolated directly into `bash -c` strings.
+**Learning:** Bash scripts using `bash -c` must never interpolate variables directly. This codebase relies heavily on bash orchestration, making it susceptible to this pattern.
+**Prevention:** Use the `bash -c 'command "$1"' -- "$arg"` pattern to pass arguments safely.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection in `parallel_agent.sh` via unsafe variable interpolation in `bash -c` commands. An attacker could inject arbitrary commands via environment variables (`GEMINI_MODEL_FLASH`, `CLAUDE_MODEL_TIER`) or command-line arguments (output directory).
🎯 Impact: Remote Code Execution (RCE) if the script is run with attacker-controlled inputs.
🔧 Fix: Refactored `run_gemini` and `run_claude` functions to pass variables as positional arguments to `bash -c`, preventing shell interpretation of the variables.
✅ Verification: Verified using `reproduce_vuln.sh` (injection blocked) and `verify_output_vuln.sh` (output dir injection blocked). Also fixed a bug where arguments with spaces were split incorrectly.

---
*PR created automatically by Jules for task [36468744086769600](https://jules.google.com/task/36468744086769600) started by @ReefBytes*