### PR TITLE
🎨 Palette: Add visual consensus bar to agent orchestration

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-01-27 - Improving CLI Ergonomics
 **Learning:** Users often struggle with long paths for internal scripts (`~/.claude/scripts/parallel_agent.sh`). Providing a copy-pasteable alias command during setup significantly reduces friction.
 **Action:** Always offer shell aliases for tools installed in non-standard locations. Detect the user's shell to provide the correct command.
+
+## 2026-01-28 - Visualizing Data in CLI
+**Learning:** CLI tools often output raw numbers that are hard to scan quickly. Adding simple ASCII/Unicode visualizations (like progress bars) significantly improves "at-a-glance" readability without requiring a GUI.
+**Action:** Look for opportunities to visualize percentage-based or status-based data in CLI outputs using text-based bars or indicators.


### PR DESCRIPTION
This change introduces a visual "micro-UX" improvement to the `parallel_agent.sh` script.

**What:**
- Added a simple text-based progress bar (e.g., `[██████····]`) to represent the consensus score percentage.
- This bar is displayed in the colored CLI output when running cross-verification.
- This bar is also included in the generated Markdown summary file.

**Why:**
- Users can more quickly scan the agreement level between agents ("High", "Medium", "Low") when supported by a visual indicator.
- It adds a touch of polish and "delight" to the tool's output.

**Technical Details:**
- Implemented a `draw_bar` function in Bash using standard loops.
- Used a global flag `CROSS_VERIFY_RAN` to ensure the summary only attempts to display the bar if verification actually ran.


---
*PR created automatically by Jules for task [12750042257500759812](https://jules.google.com/task/12750042257500759812) started by @ReefBytes*