### PR TITLE
⚡ Bolt: Optimize config parsing in parallel_agent.sh

### DIFF
--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -122,6 +122,11 @@ load_services_config() {
             if (section == "gemini") print "RUN_GEMINI=false;"
             if (section == "cursor") print "RUN_CURSOR=false;"
         }
+        /^[[:space:]]*minimum_agents:[[:space:]]*[0-9]+/ {
+            if (match($0, /[0-9]+/)) {
+                print "MIN_AGENTS=" substr($0, RSTART, RLENGTH) ";"
+            }
+        }
     ' "$SERVICES_CONFIG")
 
     if [[ -n "$config_settings" ]]; then
@@ -129,8 +134,7 @@ load_services_config() {
     fi
 
     # Check minimum agents requirement
-    local min_agents=$(grep -E "^minimum_agents:" "$SERVICES_CONFIG" | grep -oE "[0-9]+" | head -1)
-    min_agents=${min_agents:-2}
+    local min_agents=${MIN_AGENTS:-2}
 
     local enabled_count=0
     [[ "$RUN_CLAUDE" == true ]] && enabled_count=$((enabled_count + 1))

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-01-27 - Bash YAML Parsing Bottleneck
 **Learning:** The codebase relies on `parallel_agent.sh` which parses `services.yml` using multiple `sed`/`grep` passes (one per key). This is O(N*M) process spawning where N is number of keys and M is parsing overhead.
 **Action:** Replaced with single-pass `awk` parsing that outputs shell variable assignments for `eval`. This reduces process spawning from ~12 to 1 for config loading. Future bash scripts in this repo should use `awk` for config parsing if `jq` or `yq` are not guaranteed.
+
+## 2026-01-29 - Incomplete Parsing Migration
+**Learning:** Previous optimization to `parallel_agent.sh` switched to `awk` for parsing but missed `minimum_agents`, leaving expensive `grep` pipelines. "Optimized" code often has leftover unoptimized patterns.
+**Action:** thoroughly audit files for similar patterns when applying an optimization strategy, rather than assuming the existing implementation is consistent.


### PR DESCRIPTION
⚡ Bolt: Optimize config parsing

💡 What:
Moved `minimum_agents` parsing into the existing `awk` block in `load_services_config`.

🎯 Why:
The previous implementation used a pipeline of `grep | grep | head` which spawned 3 extra processes. By integrating it into `awk`, we reduce process overhead and make configuration loading faster.

📊 Impact:
Reduces process spawning for config loading.

🔬 Measurement:
Run `bash -x .claude/scripts/parallel_agent.sh --help` and verify `MIN_AGENTS` is set correctly without executing `grep`.

---
*PR created automatically by Jules for task [8450546724487936754](https://jules.google.com/task/8450546724487936754) started by @ReefBytes*