### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in bash -c usage

### DIFF
--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -558,7 +558,8 @@ run_gemini() {
     echo -e "${BLUE}[Gemini CLI]${NC} Starting with model: $GEMINI_MODEL..."
     # Gemini CLI: use input redirection for reliable handling (saves cat process)
     run_with_retry "Gemini CLI" "$output_file" bash -c \
-        "gemini --output-format text --model '$GEMINI_MODEL' ${include_args[*]} < '$prompt_file'"
+        'gemini --output-format text --model "$1" "${@:2}" < "$0"' \
+        "$prompt_file" "$GEMINI_MODEL" "${include_args[@]}"
 }
 
 # Run Claude CLI with model selection
@@ -578,7 +579,8 @@ run_claude() {
 
     # Claude CLI: use input redirection (saves cat process)
     if ! run_with_retry_capture_stderr "Claude CLI" "$output_file" "$stderr_file" \
-        bash -c "claude --print --output-format text --model '$CLAUDE_MODEL' < '$prompt_file'"; then
+        bash -c 'claude --print --output-format text --model "$1" < "$0"' \
+        "$prompt_file" "$CLAUDE_MODEL"; then
 
         # Check for credit exhaustion
         if check_credit_exhaustion "$stderr_file" "Claude"; then
@@ -588,7 +590,8 @@ run_claude() {
 
             # Retry with haiku (cheapest model)
             run_with_retry "Claude CLI (fallback)" "$output_file" \
-                bash -c "claude --print --output-format text --model haiku < '$prompt_file'"
+                bash -c 'claude --print --output-format text --model haiku < "$0"' \
+                "$prompt_file"
         fi
     fi
 }

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-01-29 - Prevent Command Injection in bash -c
+**Vulnerability:** Unsafe construction of command strings passed to `bash -c`, allowing command injection via `GEMINI_INCLUDE_DIRS` (argument injection) or potentially model names.
+**Learning:** When using `bash -c`, never interpolate variables directly into the command string. Instead, pass them as positional parameters after the command string and reference them as `$1`, `$2`, etc.
+**Prevention:** Use `bash -c 'command "$1" "$2"' -- "arg1" "arg2"` pattern.


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection in bash -c usage

🚨 Severity: CRITICAL
💡 Vulnerability: Command Injection via `GEMINI_INCLUDE_DIRS` and potentially other variables used in `bash -c` calls. An attacker controlling these environment variables or directory names could execute arbitrary commands.
🎯 Impact: Remote Code Execution (RCE) if the script is run in an environment where an attacker can influence environment variables or file paths (e.g., CI/CD, shared systems).
🔧 Fix: Refactored `run_gemini` and `run_claude` to use positional parameters for `bash -c` (e.g., `bash -c 'cmd "$1"' -- "$arg"`).
✅ Verification: Verified using a reproduction script `repro_exploit.sh` which confirmed the vulnerability was fixed. Also ran regression tests to ensure normal functionality.

---
*PR created automatically by Jules for task [2553288830452355577](https://jules.google.com/task/2553288830452355577) started by @ReefBytes*