### PR TITLE
🛡️ Sentinel: Fix insecure temporary file creation (CWE-377)

### DIFF
--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -624,14 +624,16 @@ preflight_credit_check() {
     echo -e "${BLUE}=== Pre-flight Credit Check ===${NC}"
 
     local test_prompt="Echo: test"
-    local test_output="/tmp/credit_check_$$.txt"
-    local test_stderr="/tmp/credit_check_$$_stderr.txt"
+    local test_output
+    test_output=$(mktemp)
+    local test_stderr
+    test_stderr=$(mktemp)
 
     # Check Cursor credits if using a specific model
     if [[ "$RUN_CURSOR" == true ]]; then
         resolve_cursor_model "$CURSOR_MODEL_TIER"
         if [[ -n "$CURSOR_MODEL" ]]; then
-            if ! timeout 15 cursor agent --print --model "$CURSOR_MODEL" -- "$test_prompt" \
+            if ! run_with_timeout 15 cursor agent --print --model "$CURSOR_MODEL" -- "$test_prompt" \
                 > "$test_output" 2> "$test_stderr"; then
                 if check_credit_exhaustion "$test_stderr" "Cursor"; then
                     echo -e "${YELLOW}[Pre-flight]${NC} Cursor credits exhausted for $CURSOR_MODEL, will use auto mode"
@@ -647,7 +649,7 @@ preflight_credit_check() {
     # Check Claude credits
     if [[ "$RUN_CLAUDE" == true ]]; then
         resolve_claude_model "$CLAUDE_MODEL_TIER"
-        if ! timeout 15 claude --print --output-format text --model "$CLAUDE_MODEL" -- "$test_prompt" \
+        if ! run_with_timeout 15 claude --print --output-format text --model "$CLAUDE_MODEL" -- "$test_prompt" \
             > "$test_output" 2> "$test_stderr"; then
             if check_credit_exhaustion "$test_stderr" "Claude"; then
                 echo -e "${YELLOW}[Pre-flight]${NC} Claude credits exhausted for $CLAUDE_MODEL, will use haiku"

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Unsafe construction of command strings passed to `bash -c`, allowing command injection via `GEMINI_INCLUDE_DIRS` (argument injection) or potentially model names.
 **Learning:** When using `bash -c`, never interpolate variables directly into the command string. Instead, pass them as positional parameters after the command string and reference them as `$1`, `$2`, etc.
 **Prevention:** Use `bash -c 'command "$1" "$2"' -- "arg1" "arg2"` pattern.
+
+## 2026-01-30 - Insecure Temporary File Creation in Shell Scripts
+**Vulnerability:** Predictable filenames in `/tmp` (e.g., `/tmp/file_$$.txt`) allow symlink attacks (CWE-377), enabling local attackers to overwrite files owned by the user running the script.
+**Learning:** Shell scripts using `$$` for uniqueness in `/tmp` are vulnerable.
+**Prevention:** Always use `mktemp` to create temporary files (e.g., `tmp=$(mktemp)`). It ensures unique names and safe permissions (0600).


### PR DESCRIPTION
🛡️ Sentinel Security Fix

**Vulnerability:**
The `preflight_credit_check` function in `parallel_agent.sh` used predictable temporary filenames (`/tmp/credit_check_$$.txt`), which is vulnerable to symlink attacks (CWE-377). A local attacker could pre-create these files as symlinks to overwrite arbitrary files owned by the user running the script.

**Fix:**
- Updated the script to use `mktemp` for creating temporary files, ensuring unique filenames and safe permissions (0600).
- Also addressed a portability issue by replacing direct calls to `timeout` (which might be missing or named `gtimeout` on macOS) with the existing `run_with_timeout` wrapper function.

**Verification:**
- Verified that `mktemp` is available and works.
- Verified that the script executes the preflight check correctly using a mock `claude` command.
- Verified that temporary files are created and cleaned up.
- Verified that `run_with_timeout` is defined and used correctly.

---
*PR created automatically by Jules for task [8820428300712760524](https://jules.google.com/task/8820428300712760524) started by @ReefBytes*