### PR TITLE
🎨 Palette: Add execution timer to parallel agent script

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-28 - Visualizing Data in CLI
 **Learning:** CLI tools often output raw numbers that are hard to scan quickly. Adding simple ASCII/Unicode visualizations (like progress bars) significantly improves "at-a-glance" readability without requiring a GUI.
 **Action:** Look for opportunities to visualize percentage-based or status-based data in CLI outputs using text-based bars or indicators.
+
+## 2026-01-31 - Providing Duration Feedback in CLI
+**Learning:** For long-running CLI operations, users often lack context on whether a process is stuck or just slow. Providing a duration summary at the end helps users benchmark performance and reinforces completion.
+**Action:** Add a simple execution timer to the final success message of long-running scripts.


### PR DESCRIPTION
💡 **What:** Added an execution timer to `.claude/scripts/parallel_agent.sh` that displays the total runtime in the console output, Markdown summary, and JSON results.
🎯 **Why:** Users running parallel agents need feedback on how long operations take to benchmark performance and distinguish between slow processes and hangs.
📸 **Before/After:**
*   Before: `Done! Results in: ...`
*   After: `Done! (1m 30s) Results in: ...`
♿ **Accessibility:** Improves cognitive accessibility by providing clear feedback on task duration and completion.

---
*PR created automatically by Jules for task [15194001301095413380](https://jules.google.com/task/15194001301095413380) started by @ReefBytes*