### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions on agent outputs

### DIFF
--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+# Security: Ensure all created files are only readable by the owner
+umask 0077
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUTPUT_DIR="$PROJECT_ROOT/.agent_outputs"
@@ -71,6 +74,7 @@ format_duration() {
 
 # Create output directory
 mkdir -p "$OUTPUT_DIR"
+chmod 700 "$OUTPUT_DIR" 2>/dev/null || true
 
 usage() {
     echo "Parallel Agent Orchestration"

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Command injection via `GEMINI_API_KEY` input in `bootstrap.sh`. Unsanitized user input was written to shell profiles (e.g., `.zshrc`) wrapped in double quotes. A malicious input like `foo"; rm -rf /; echo "` would execute when the shell profile is sourced.
 **Learning:** Even installation scripts need strict input validation and secure coding practices. Writing user input to shell startup files is a high-risk operation that requires robust escaping.
 **Prevention:** Always use single quotes for string literals in generated shell code. Escape single quotes in the input data before writing. Validate input format where possible.
+
+## 2026-02-01 - Insecure File Permissions on Sensitive Outputs
+**Vulnerability:** The parallel agent framework generated code analysis reports and stored them in directories with default umask permissions (often 755/644). This allowed other users on the system to read potentially sensitive code or vulnerability findings.
+**Learning:** Default directory creation in shell scripts (`mkdir -p`) respects the user's umask, which is often too permissive for security tools. Tools handling sensitive data must explicitly manage permissions.
+**Prevention:** Use `umask 0077` at the beginning of scripts handling sensitive data, and explicitly `chmod 700` directories containing sensitive outputs or configuration.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -848,6 +848,7 @@ deploy_configs() {
     # Create target directory and copy files
     print_step "Creating $TARGET_DIR"
     mkdir -p "$TARGET_DIR"
+    chmod 700 "$TARGET_DIR"
 
     print_step "Copying configuration files..."
     cp -R "$source_dir"/* "$TARGET_DIR/"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information Disclosure. The parallel agent script created sensitive output files and directories with default permissions (often 755/644), allowing other users on the system to read them.
🎯 Impact: Exposure of sensitive code analysis results and potentially secrets found in code to unauthorized local users.
🔧 Fix: Enforced `umask 0077` in `parallel_agent.sh` and added explicit `chmod 700` to output and configuration directories.
✅ Verification: Verified that `.claude/.agent_outputs` and `~/.claude` are created with `drwx------` permissions.

---
*PR created automatically by Jules for task [646259338271767243](https://jules.google.com/task/646259338271767243) started by @ReefBytes*