### PR TITLE
⚡ Bolt: Optimize validation logic in parallel_agent.sh

### DIFF
--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -189,6 +189,11 @@ RETRY_DELAY=5
 CONSENSUS_SCORE=0
 CROSS_VERIFY_RAN=false
 
+# Validation results cache
+CURSOR_VAL_RESULT=-1
+GEMINI_VAL_RESULT=-1
+CLAUDE_VAL_RESULT=-1
+
 # Model selection defaults
 CURSOR_MODEL_TIER="auto"
 CURSOR_MODEL=""
@@ -748,12 +753,9 @@ create_json_output() {
     if [[ -f "$OUTPUT_DIR/cursor_${TIMESTAMP}.txt" ]]; then
         cursor_output=$(get_output_content "$OUTPUT_DIR/cursor_${TIMESTAMP}.txt")
         cursor_status="complete"
-        if [[ "$VALIDATE" == true ]]; then
-            local validate_result
-            validate_output "$OUTPUT_DIR/cursor_${TIMESTAMP}.txt" "Cursor Agent"
-            validate_result=$?
+        if [[ "$VALIDATE" == true && "$CURSOR_VAL_RESULT" -ne -1 ]]; then
             # Accept both passed (0) and warning (2) as valid
-            [[ $validate_result -eq 0 || $validate_result -eq 2 ]] && cursor_valid=true
+            [[ $CURSOR_VAL_RESULT -eq 0 || $CURSOR_VAL_RESULT -eq 2 ]] && cursor_valid=true
         fi
     fi
 
@@ -761,11 +763,8 @@ create_json_output() {
     if [[ -f "$OUTPUT_DIR/gemini_${TIMESTAMP}.txt" ]]; then
         gemini_output=$(get_output_content "$OUTPUT_DIR/gemini_${TIMESTAMP}.txt")
         gemini_status="complete"
-        if [[ "$VALIDATE" == true ]]; then
-            local validate_result
-            validate_output "$OUTPUT_DIR/gemini_${TIMESTAMP}.txt" "Gemini CLI"
-            validate_result=$?
-            [[ $validate_result -eq 0 || $validate_result -eq 2 ]] && gemini_valid=true
+        if [[ "$VALIDATE" == true && "$GEMINI_VAL_RESULT" -ne -1 ]]; then
+            [[ $GEMINI_VAL_RESULT -eq 0 || $GEMINI_VAL_RESULT -eq 2 ]] && gemini_valid=true
         fi
     fi
 
@@ -773,11 +772,8 @@ create_json_output() {
     if [[ -f "$OUTPUT_DIR/claude_${TIMESTAMP}.txt" ]]; then
         claude_output=$(get_output_content "$OUTPUT_DIR/claude_${TIMESTAMP}.txt")
         claude_status="complete"
-        if [[ "$VALIDATE" == true ]]; then
-            local validate_result
-            validate_output "$OUTPUT_DIR/claude_${TIMESTAMP}.txt" "Claude CLI"
-            validate_result=$?
-            [[ $validate_result -eq 0 || $validate_result -eq 2 ]] && claude_valid=true
+        if [[ "$VALIDATE" == true && "$CLAUDE_VAL_RESULT" -ne -1 ]]; then
+            [[ $CLAUDE_VAL_RESULT -eq 0 || $CLAUDE_VAL_RESULT -eq 2 ]] && claude_valid=true
         fi
     fi
 
@@ -993,9 +989,6 @@ create_summary() {
         echo "## Cursor Agent Output" >> "$summary_file"
         [[ -n "$CURSOR_MODEL" ]] && echo "**Model:** $CURSOR_MODEL" >> "$summary_file"
         [[ "$CURSOR_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used fallback mode due to credit exhaustion" >> "$summary_file"
-        if [[ "$VALIDATE" == true ]]; then
-            validate_output "$OUTPUT_DIR/cursor_${TIMESTAMP}.txt" "Cursor Agent"
-        fi
         echo '```' >> "$summary_file"
         get_output_content "$OUTPUT_DIR/cursor_${TIMESTAMP}.txt" >> "$summary_file"
         echo '```' >> "$summary_file"
@@ -1004,9 +997,6 @@ create_summary() {
 
     if [[ -f "$OUTPUT_DIR/gemini_${TIMESTAMP}.txt" ]]; then
         echo "## Gemini CLI Output" >> "$summary_file"
-        if [[ "$VALIDATE" == true ]]; then
-            validate_output "$OUTPUT_DIR/gemini_${TIMESTAMP}.txt" "Gemini CLI"
-        fi
         echo '```' >> "$summary_file"
         get_output_content "$OUTPUT_DIR/gemini_${TIMESTAMP}.txt" >> "$summary_file"
         echo '```' >> "$summary_file"
@@ -1017,9 +1007,6 @@ create_summary() {
         echo "## Claude CLI Output" >> "$summary_file"
         [[ -n "$CLAUDE_MODEL" ]] && echo "**Model:** $CLAUDE_MODEL" >> "$summary_file"
         [[ "$CLAUDE_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used fallback mode due to credit exhaustion" >> "$summary_file"
-        if [[ "$VALIDATE" == true ]]; then
-            validate_output "$OUTPUT_DIR/claude_${TIMESTAMP}.txt" "Claude CLI"
-        fi
         echo '```' >> "$summary_file"
         get_output_content "$OUTPUT_DIR/claude_${TIMESTAMP}.txt" >> "$summary_file"
         echo '```' >> "$summary_file"
@@ -1109,6 +1096,24 @@ main() {
 
     if [[ $enabled_count -ge 2 ]]; then
         cross_verify
+        echo ""
+    fi
+
+    # Run validation if enabled (once)
+    if [[ "$VALIDATE" == true ]]; then
+        echo -e "${BLUE}=== Validation Results ===${NC}"
+        if [[ "$RUN_CURSOR" == true && -f "$OUTPUT_DIR/cursor_${TIMESTAMP}.txt" ]]; then
+            validate_output "$OUTPUT_DIR/cursor_${TIMESTAMP}.txt" "Cursor Agent"
+            CURSOR_VAL_RESULT=$?
+        fi
+        if [[ "$RUN_GEMINI" == true && -f "$OUTPUT_DIR/gemini_${TIMESTAMP}.txt" ]]; then
+            validate_output "$OUTPUT_DIR/gemini_${TIMESTAMP}.txt" "Gemini CLI"
+            GEMINI_VAL_RESULT=$?
+        fi
+        if [[ "$RUN_CLAUDE" == true && -f "$OUTPUT_DIR/claude_${TIMESTAMP}.txt" ]]; then
+            validate_output "$OUTPUT_DIR/claude_${TIMESTAMP}.txt" "Claude CLI"
+            CLAUDE_VAL_RESULT=$?
+        fi
         echo ""
     fi
 

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-01-31 - Grep Pipeline to Awk Optimization
 **Learning:** Replaced a loop spawning 4 processes per iteration (grep | tr) with a single awk process. This significantly reduces fork overhead in shell scripts, especially when processing multiple files.
 **Action:** Identify sequences of `grep | cut/tr/sed` inside loops and consolidate them into single-pass `awk` scripts.
+
+## 2026-02-01 - Redundant Validation Logic in Shell Scripts
+**Learning:** `parallel_agent.sh` was running validation logic (`grep`) twice per agent—once for the summary and once for JSON output—causing duplicate console output and unnecessary process forks.
+**Action:** Centralized validation logic to run once, stored results in global variables, and reused these results in subsequent steps. Always check if a computed result is needed in multiple places and cache it.


### PR DESCRIPTION
⚡ Bolt: Optimize validation logic in parallel_agent.sh

💡 What:
Refactored the validation logic to run once in `main()` after all agents complete, storing the results in global variables (`*_VAL_RESULT`). Updated `create_summary` and `create_json_output` to use these cached results instead of re-running `validate_output`.

🎯 Why:
The previous implementation called `validate_output` (which runs `grep`) multiple times: once during summary generation and again during JSON output generation. This caused:
1. Redundant process forks and file I/O.
2. Duplicated "Validation PASSED" messages in the console output when JSON output was enabled.

📊 Impact:
- Eliminates 3 redundant `grep` calls (one per agent).
- Improves UX by cleaning up duplicate status messages.

🔬 Measurement:
Verified using a reproduction script that mocks agent outputs. Confirmed that "Validation PASSED" appears exactly once per agent under the "=== Validation Results ===" header, and the JSON output correctly reflects the validation status.

---
*PR created automatically by Jules for task [3171775087403043736](https://jules.google.com/task/3171775087403043736) started by @ReefBytes*