### PR TITLE
🎨 Palette: Add elapsed time timer to agent monitor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-02-01 - Managing Concurrent CLI Output
 **Learning:** Background spinners in shell scripts often conflict with output from parallel background processes, causing visual artifacts. Redirecting background job output and using a main-thread polling loop to update a status line provides a much cleaner, artifact-free experience.
 **Action:** When orchestrating parallel tasks in CLI, suppress background job stdout and use a centralized status monitor loop that polls PIDs.
+
+## 2026-02-02 - Liveness Indicators for Long Operations
+**Learning:** For indeterminate waiting states (like waiting for external APIs), a simple spinner is insufficient as users can't tell if the process is stalled. Adding an elapsed time counter (MM:SS) provides immediate liveness feedback and helps users decide if they should abort.
+**Action:** Enhance CLI spinners with a dynamic elapsed time counter for operations expected to take more than 10 seconds.

--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -951,6 +951,7 @@ monitor_agents() {
 
     local running=true
     local spinstr='|/-\'
+    local start_time=$(date +%s)
 
     # Track states locally
     local agent_states=()
@@ -959,6 +960,13 @@ monitor_agents() {
     while $running; do
         running=false
         local status_line=""
+
+        # Calculate elapsed time
+        local current_time=$(date +%s)
+        local elapsed=$((current_time - start_time))
+        local minutes=$((elapsed / 60))
+        local seconds=$((elapsed % 60))
+        local time_str=$(printf "%02d:%02d" $minutes $seconds)
 
         # Advance spinner
         local temp=${spinstr#?}
@@ -1005,13 +1013,19 @@ monitor_agents() {
 
         if $running; then
             # \r to start, \033[K to clear line
-            printf "\rWaiting for agents:%s\033[K" "$status_line"
+            printf "\rWaiting for agents (%s):%s\033[K" "$time_str" "$status_line"
             sleep 0.1
         fi
     done
 
     # Final state
-    printf "\rWaiting for agents:%s\033[K\n" "$status_line"
+    local current_time=$(date +%s)
+    local elapsed=$((current_time - start_time))
+    local minutes=$((elapsed / 60))
+    local seconds=$((elapsed % 60))
+    local time_str=$(printf "%02d:%02d" $minutes $seconds)
+
+    printf "\rWaiting for agents (%s):%s\033[K\n" "$time_str" "$status_line"
 
     # Restore cursor
     if command -v tput &> /dev/null; then


### PR DESCRIPTION
Added an elapsed time counter to the CLI agent monitor to improve liveness feedback during long-running operations.

---
*PR created automatically by Jules for task [1606767587732021076](https://jules.google.com/task/1606767587732021076) started by @ReefBytes*