### PR TITLE
⚡ Bolt: Optimize process monitoring overhead in parallel_agent.sh

### DIFF
--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -956,6 +956,11 @@ monitor_agents() {
         has_ps=true
     fi
 
+    local use_proc=false
+    if [[ -d "/proc" ]]; then
+        use_proc=true
+    fi
+
     # Hide cursor
     if $has_tput; then
         tput civis 2>/dev/null || true
@@ -969,9 +974,11 @@ monitor_agents() {
     local agent_states=()
     for i in "${!pids[@]}"; do agent_states[i]="running"; done
 
+    local loop_count=0
     while $running; do
         running=false
         local status_line=""
+        loop_count=$((loop_count + 1))
 
         # Calculate elapsed time
         local current_time=$(date +%s)
@@ -994,12 +1001,30 @@ monitor_agents() {
                 local is_alive=false
                 if kill -0 "$pid" 2>/dev/null; then
                     is_alive=true
-                    # Check for zombie state if ps is available
-                    if $has_ps; then
-                        local ps_state
-                        ps_state=$(ps -o state= -p "$pid" 2>/dev/null || true)
-                        if [[ "$ps_state" == *"Z"* ]]; then
-                             is_alive=false
+                    # Check for zombie state (process finished but not waited)
+                    # This check is critical to avoid infinite loops, but 'ps' is expensive
+                    if $use_proc && [[ -r "/proc/$pid/stat" ]]; then
+                        # Linux optimization: Read directly from /proc (fast, no fork)
+                        local content
+                        if content=$(< "/proc/$pid/stat" 2>/dev/null); then
+                             # Remove everything up to last ')' to handle comm with spaces
+                             local right_side="${content##*)}"
+                             # Read first field from the rest (state char)
+                             local state_char
+                             read -r state_char _ <<< "$right_side"
+                             if [[ "$state_char" == "Z" ]]; then
+                                 is_alive=false
+                             fi
+                        fi
+                    elif $has_ps; then
+                        # Fallback (e.g. macOS): use ps command (expensive, needs throttling)
+                        # Only check every 10th iteration (1 second) to save CPU
+                        if (( loop_count % 10 == 0 )); then
+                            local ps_state
+                            ps_state=$(ps -o state= -p "$pid" 2>/dev/null || true)
+                            if [[ "$ps_state" == *"Z"* ]]; then
+                                 is_alive=false
+                            fi
                         fi
                     fi
                 fi

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-02-01 - Redundant Validation Logic in Shell Scripts
 **Learning:** `parallel_agent.sh` was running validation logic (`grep`) twice per agent—once for the summary and once for JSON output—causing duplicate console output and unnecessary process forks.
 **Action:** Centralized validation logic to run once, stored results in global variables, and reused these results in subsequent steps. Always check if a computed result is needed in multiple places and cache it.
+
+## 2026-02-02 - Shell Process Monitoring Overhead
+**Learning:** Checking process state via `ps` inside a 10Hz loop caused ~30 forks/sec for 3 agents, creating unnecessary CPU load.
+**Action:** Implemented a dual-strategy: zero-overhead `/proc` parsing for Linux and throttled `ps` checks (1Hz) for macOS. Always prefer `/proc` reads over `ps` in shell scripts when available.


### PR DESCRIPTION
⚡ Bolt: Optimized `monitor_agents` loop in `parallel_agent.sh`

💡 **What:**
- Replaced the unconditional `ps` call in the `monitor_agents` loop with a dual-strategy approach.
- **Linux:** Reads `/proc/$pid/stat` directly using Bash builtins (no external process forks).
- **macOS/Fallback:** Throttles the `ps` command to run only once every 10 iterations (1 second) instead of every 0.1 seconds.

🎯 **Why:**
- The previous implementation forked a `ps` process 10 times per second for *each* active agent to check for zombie states.
- For 3 concurrent agents, this resulted in ~30 process forks per second, consuming unnecessary CPU cycles during the "waiting" phase.
- Zombie detection is critical to avoid infinite loops, but it does not need to be checked at 10Hz.

📊 **Impact:**
- **Linux:** Reduces monitoring overhead to near zero (file I/O only).
- **macOS:** Reduces monitoring overhead by **90%** (from 10 forks/sec/agent to 1 fork/sec/agent).

🔬 **Measurement:**
- Verified utilizing a test script to confirm `/proc` parsing logic handles edge cases (process names with spaces/parens).
- Verified syntax correctness with `bash -n`.
- Confirmed correct fallback logic for non-Linux environments.

---
*PR created automatically by Jules for task [10599865392588090304](https://jules.google.com/task/10599865392588090304) started by @ReefBytes*