### PR TITLE
🎨 Palette: Robust cleanup and colored spinner for parallel agent CLI

### DIFF
--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -42,7 +42,35 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
 NC='\033[0m' # No Color
+
+# Global array to track background process IDs
+pids=()
+
+# Cleanup function to restore cursor and kill background processes
+cleanup() {
+    local exit_code=$?
+
+    # Restore cursor
+    if command -v tput &> /dev/null; then
+        tput cnorm 2>/dev/null || true
+    fi
+
+    # Kill background processes if they exist
+    if [[ -n "${pids[*]}" ]]; then
+        for pid in "${pids[@]}"; do
+            if kill -0 "$pid" 2>/dev/null; then
+                kill "$pid" 2>/dev/null || true
+            fi
+        done
+    fi
+
+    exit "$exit_code"
+}
+
+# Trap exit to ensure cleanup
+trap cleanup EXIT
 
 # Draw a progress bar
 draw_bar() {
@@ -1005,7 +1033,7 @@ monitor_agents() {
                 fi
 
                 if $is_alive; then
-                    status_line="$status_line $name [${spin_char}]"
+                    status_line="$status_line $name [${CYAN}${spin_char}${NC}]"
                     running=true
                 else
                     # Process finished
@@ -1138,7 +1166,7 @@ main() {
     fi
 
     # Run agents in parallel using background processes
-    pids=()
+    # pids array is defined globally
     agent_names=()
 
     if [[ "$RUN_CURSOR" == true && -n "$CURSOR_PROMPT" ]]; then


### PR DESCRIPTION
This PR enhances the UX and robustness of the parallel agent CLI. 
It adds a cleanup trap to ensure the terminal cursor is restored if the script is interrupted (Ctrl+C), and kills any orphaned background agent processes. 
It also adds a splash of Cyan color to the progress spinner for a more polished look.

---
*PR created automatically by Jules for task [9911622112975067526](https://jules.google.com/task/9911622112975067526) started by @ReefBytes*