### PR TITLE
🎨 Palette: Improve CLI spinner and cursor handling

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-02-02 - Liveness Indicators for Long Operations
 **Learning:** For indeterminate waiting states (like waiting for external APIs), a simple spinner is insufficient as users can't tell if the process is stalled. Adding an elapsed time counter (MM:SS) provides immediate liveness feedback and helps users decide if they should abort.
 **Action:** Enhance CLI spinners with a dynamic elapsed time counter for operations expected to take more than 10 seconds.
+
+## 2026-02-04 - Accessible CLI Cursor Handling
+**Learning:** CLI tools that hide the cursor (`tput civis`) often fail to restore it if interrupted by the user (Ctrl+C), leaving the terminal in an unusable state. This is a major accessibility failure.
+**Action:** Always wrap cursor hiding logic in a `trap 'tput cnorm' EXIT` block to guarantee restoration regardless of exit reason.

--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -42,6 +42,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
+BOLD='\033[1m'
 NC='\033[0m' # No Color
 
 # Draw a progress bar
@@ -956,13 +957,18 @@ monitor_agents() {
         has_ps=true
     fi
 
+    # UX: Ensure cursor is restored if script is interrupted
+    trap 'tput cnorm 2>/dev/null || true' EXIT
+
     # Hide cursor
     if $has_tput; then
         tput civis 2>/dev/null || true
     fi
 
     local running=true
-    local spinstr='|/-\'
+    # Braille spinner for smoother animation
+    local spinner=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+    local spin_idx=0
     local start_time=$(date +%s)
 
     # Track states locally
@@ -981,9 +987,8 @@ monitor_agents() {
         local time_str=$(printf "%02d:%02d" $minutes $seconds)
 
         # Advance spinner
-        local temp=${spinstr#?}
-        local spin_char="${spinstr:0:1}"
-        spinstr=$temp${spinstr%"$temp"}
+        local spin_char="${spinner[$spin_idx]}"
+        spin_idx=$(( (spin_idx + 1) % ${#spinner[@]} ))
 
         for i in "${!pids[@]}"; do
             local pid=${pids[$i]}
@@ -1025,7 +1030,7 @@ monitor_agents() {
 
         if $running; then
             # \r to start, \033[K to clear line
-            printf "\rWaiting for agents (%s):%s\033[K" "$time_str" "$status_line"
+            printf "\r${BOLD}Waiting for agents (%s):${NC}%s\033[K" "$time_str" "$status_line"
             sleep 0.1
         fi
     done
@@ -1037,7 +1042,7 @@ monitor_agents() {
     local seconds=$((elapsed % 60))
     local time_str=$(printf "%02d:%02d" $minutes $seconds)
 
-    printf "\rWaiting for agents (%s):%s\033[K\n" "$time_str" "$status_line"
+    printf "\r${BOLD}Waiting for agents (%s):${NC}%s\033[K\n" "$time_str" "$status_line"
 
     # Restore cursor
     if $has_tput; then


### PR DESCRIPTION
This PR improves the UX of the `parallel_agent.sh` CLI by replacing the ASCII spinner with a Braille spinner, making the status text bold, and ensuring the cursor is restored if the script is interrupted. This addresses a potential accessibility issue where the user's cursor could remain hidden after a Ctrl+C interruption.

---
*PR created automatically by Jules for task [616573269551652490](https://jules.google.com/task/616573269551652490) started by @ReefBytes*