### PR TITLE
🛡️ Sentinel: Fix insecure secret prompt in bootstrap.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The parallel agent framework generated code analysis reports and stored them in directories with default umask permissions (often 755/644). This allowed other users on the system to read potentially sensitive code or vulnerability findings.
 **Learning:** Default directory creation in shell scripts (`mkdir -p`) respects the user's umask, which is often too permissive for security tools. Tools handling sensitive data must explicitly manage permissions.
 **Prevention:** Use `umask 0077` at the beginning of scripts handling sensitive data, and explicitly `chmod 700` directories containing sensitive outputs or configuration.
+
+## 2026-02-05 - Insecure Secret Prompt in Shell Scripts
+**Vulnerability:** Interactive shell scripts using `read` without the `-s` flag to prompt for sensitive information (like API keys) expose the secret in plain text on the terminal screen and potentially in screen recordings or shoulder surfing scenarios.
+**Learning:** UX convenience should not compromise security. Users often copy-paste keys, and seeing them echoed back is a security risk.
+**Prevention:** Always use `read -rs` (silent mode) when prompting for secrets. Remember to echo a newline `echo ""` afterwards as silent mode suppresses the user's enter key newline.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -759,7 +759,8 @@ setup_gemini_auth() {
     echo ""
     if prompt_yes_no "Set up Gemini API key instead?"; then
         echo ""
-        read -r -p "Enter your Gemini API key: " api_key
+        read -rs -p "Enter your Gemini API key: " api_key
+        echo ""
 
         if [[ -n "$api_key" ]]; then
             # Escape single quotes for safe single-quoted string


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix insecure secret prompt

🚨 Severity: HIGH
💡 Vulnerability: Interactive shell script echoed sensitive API key to the terminal during setup.
🎯 Impact: API keys could be exposed to shoulder surfing or screen recordings.
🔧 Fix: Updated `read` command to use `-s` (silent) flag and added a newline echo.
✅ Verification: Verified using `grep` that `read -rs` is now used for the API key prompt.

---
*PR created automatically by Jules for task [11948365165768278240](https://jules.google.com/task/11948365165768278240) started by @ReefBytes*