### PR TITLE
⚡ Bolt: Optimize agent monitoring loop by reading /proc directly

### DIFF
--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -994,8 +994,19 @@ monitor_agents() {
                 local is_alive=false
                 if kill -0 "$pid" 2>/dev/null; then
                     is_alive=true
-                    # Check for zombie state if ps is available
-                    if $has_ps; then
+                    # Check for zombie state
+                    # Optimization: On Linux, read /proc directly to avoid 'ps' fork overhead
+                    if [[ -r "/proc/$pid/stat" ]]; then
+                        local stat_line
+                        read -r stat_line < "/proc/$pid/stat" 2>/dev/null || true
+                        # The command name (comm) is in parens and can contain spaces/parens.
+                        # Everything after the last ')' starts with space then state.
+                        local stat_rest="${stat_line##*)}"
+                        local state_char="${stat_rest:1:1}"
+                        if [[ "$state_char" == "Z" ]]; then
+                             is_alive=false
+                        fi
+                    elif $has_ps; then
                         local ps_state
                         ps_state=$(ps -o state= -p "$pid" 2>/dev/null || true)
                         if [[ "$ps_state" == *"Z"* ]]; then

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-02-01 - Redundant Validation Logic in Shell Scripts
 **Learning:** `parallel_agent.sh` was running validation logic (`grep`) twice per agent—once for the summary and once for JSON output—causing duplicate console output and unnecessary process forks.
 **Action:** Centralized validation logic to run once, stored results in global variables, and reused these results in subsequent steps. Always check if a computed result is needed in multiple places and cache it.
+
+## 2026-02-04 - Busy Loop Process Forking
+**Learning:** `parallel_agent.sh` checked process state using `ps` inside a 100ms polling loop. This caused ~30 forks/second for 3 agents, creating unnecessary CPU load.
+**Action:** Implemented Linux-specific `/proc/[pid]/stat` parsing using built-ins (`read` and parameter expansion) to eliminate forks in the hot loop, while keeping `ps` as a fallback for macOS.


### PR DESCRIPTION
⚡ Bolt: Optimize agent monitoring loop by reading /proc directly

💡 What:
Replaced `ps` command invocation with direct `/proc/[pid]/stat` reading in the `monitor_agents` loop on Linux.
Retained `ps` as a fallback for non-Linux environments.

🎯 Why:
The `monitor_agents` loop runs every 100ms. For each active agent, it was spawning a `ps` process to check for zombie state. With 3 agents, this resulted in ~30 process forks per second, creating unnecessary CPU overhead and system call noise.

📊 Impact:
- Reduces process forks by ~30/sec during agent execution on Linux.
- Reduces CPU usage of the orchestration script.

🔬 Measurement:
- Verified logic with a test script covering edge cases (nested parentheses in process names).
- Verified functional correctness by running with dummy agents.
- Confirmed no syntax errors with `bash -n`.

---
*PR created automatically by Jules for task [10780649804533610359](https://jules.google.com/task/10780649804533610359) started by @ReefBytes*