### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure temporary directory creation (CWE-377)

### DIFF
--- a/.claude/scripts/parallel_agent.sh
+++ b/.claude/scripts/parallel_agent.sh
@@ -27,12 +27,28 @@ else
         # Try Linux/GNU style (template argument)
         OUTPUT_DIR=$(mktemp -d "/tmp/claude_agent_outputs.XXXXXX" 2>/dev/null) || \
         # Try macOS/BSD style (-t prefix)
-        OUTPUT_DIR=$(mktemp -d -t claude_agent_outputs 2>/dev/null)
+        OUTPUT_DIR=$(mktemp -d -t claude_agent_outputs 2>/dev/null) || \
+        true
     fi
 
     # Final fallback if mktemp fails or is missing
     if [[ -z "$OUTPUT_DIR" ]]; then
-        OUTPUT_DIR="/tmp/.claude_agent_outputs_$RANDOM$RANDOM"
+        # Use openssl if available for higher entropy, otherwise combine multiple random sources
+        random_suffix=""
+        if command -v openssl &> /dev/null; then
+            random_suffix=$(openssl rand -hex 6)
+        else
+            random_suffix="$RANDOM$RANDOM$(date +%s)"
+        fi
+
+        OUTPUT_DIR="/tmp/.claude_agent_outputs_$random_suffix"
+
+        # Security: Atomically create directory with 700 permissions
+        # This prevents symlink attacks (CWE-377) because mkdir fails if target exists
+        if ! mkdir -m 700 "$OUTPUT_DIR" 2>/dev/null; then
+            echo "Error: Failed to create secure output directory in /tmp" >&2
+            exit 1
+        fi
     fi
 
     echo "Warning: Using fallback output directory: $OUTPUT_DIR" >&2


### PR DESCRIPTION
This PR addresses a high-priority security issue (CWE-377) where the fallback mechanism for creating temporary output directories in `parallel_agent.sh` was vulnerable to symlink attacks due to predictable naming and non-atomic creation.

Changes:
1.  **Secure Fallback:** Replaced the logic that fell back to `/tmp/.claude_agent_outputs_$RANDOM$RANDOM` with a more robust approach.
    *   Uses `openssl rand -hex 6` for high entropy if available.
    *   Falls back to `$RANDOM$RANDOM$(date +%s)` for better entropy than before.
    *   Uses `mkdir -m 700 "$OUTPUT_DIR"` to atomically create the directory with restrictive permissions. If the directory (or a symlink) already exists, `mkdir` fails, preventing the attack.
2.  **Robustness:** Added `|| true` to `mktemp` calls to prevent the script from exiting immediately if `mktemp` fails (due to `set -e`), ensuring the secure fallback logic is actually reachable.

Verification:
- Verified using a reproduction script `tests/repro_issue.sh` that mocks `mktemp` failure and confirms the fallback directory is created with `drwx------` permissions and a randomized name.

---
*PR created automatically by Jules for task [16076428936895156391](https://jules.google.com/task/16076428936895156391) started by @ReefBytes*