### PR TITLE
Fix TOCTOU vulnerability in secure file creation

### DIFF
--- a/bootstrap/lib/auth.sh
+++ b/bootstrap/lib/auth.sh
@@ -233,6 +233,7 @@ configure_shell_profile_state() {
             ;;
     esac
 
+    # shellcheck disable=SC2016
     local export_line='export MANIFEST_STATE_ROOT="${MANIFEST_STATE_ROOT:-$HOME/.manifest}"'
     # shellcheck disable=SC2034
     SHELL_PROFILE_FILE="$profile_file"

--- a/bootstrap/lib/auth.sh
+++ b/bootstrap/lib/auth.sh
@@ -90,11 +90,9 @@ setup_gemini_auth() {
                 # Escape single quotes to prevent injection
                 local safe_key="${api_key//\'/\'\\\'\'}"
 
-                # Create file with restrictive permissions
-                touch "$env_file"
-                chmod 600 "$env_file"
-
-                echo "export GEMINI_API_KEY='$safe_key'" > "$env_file"
+                # Create file with restrictive permissions atomically
+                rm -f "$env_file"
+                (umask 077; echo "export GEMINI_API_KEY='$safe_key'" > "$env_file")
                 print_success "API key saved to $env_file (mode 600)"
 
                 # Source it for current session

--- a/bootstrap/lib/install.sh
+++ b/bootstrap/lib/install.sh
@@ -10,6 +10,7 @@ check_platform() {
         linux)
             local version=""
             if [[ -f /etc/os-release ]]; then
+                # shellcheck disable=SC1091
                 . /etc/os-release
                 version="$PRETTY_NAME"
             else
@@ -288,7 +289,7 @@ install_node() {
                         sudo apt-get install -y nodejs
                     elif [[ "$PKG_MANAGER" == "dnf" || "$PKG_MANAGER" == "yum" ]]; then
                         curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -
-                        sudo $PKG_MANAGER install -y nodejs
+                        sudo "$PKG_MANAGER" install -y nodejs
                     else
                         print_warning "NodeSource not available for $PKG_MANAGER"
                         print_info "Please install Node.js manually from https://nodejs.org"

--- a/bootstrap/lib/mcp.sh
+++ b/bootstrap/lib/mcp.sh
@@ -245,14 +245,14 @@ configure_cursor_mcp_config() {
         json_entries+=$'\n'"    \"${name}\": {"$'\n'"      \"url\": \"${url}\""$'\n'"    }"
     done
 
-    cat > "$cursor_mcp_file" << EOF
+    rm -f "$cursor_mcp_file"
+    (umask 077; cat > "$cursor_mcp_file" << EOF
 {
   "mcpServers": {${json_entries}
   }
 }
 EOF
-
-    chmod 600 "$cursor_mcp_file" 2> /dev/null || true
+    )
     print_success "Configured Cursor MCP servers in $cursor_mcp_file"
 }
 

--- a/bootstrap/lib/platform.sh
+++ b/bootstrap/lib/platform.sh
@@ -12,6 +12,7 @@ detect_platform() {
             PLATFORM="linux"
             # Detect Linux distribution
             if [[ -f /etc/os-release ]]; then
+                # shellcheck disable=SC1091
                 . /etc/os-release
                 DISTRO="$ID"
             elif [[ -f /etc/debian_version ]]; then

--- a/configs/claude/scripts/generate_cursor_rules.sh
+++ b/configs/claude/scripts/generate_cursor_rules.sh
@@ -46,6 +46,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     if head -1 "$skill_file" | grep -q '^---'; then
         front_matter=$(sed -n '2,/^---$/p' "$skill_file" | sed '$d')
         desc_line=$(echo "$front_matter" | grep '^description:' | head -1)
+        # shellcheck disable=SC2001
         desc_value=$(echo "$desc_line" | sed 's/^description:[[:space:]]*//')
 
         if [[ "$desc_value" == "|" || "$desc_value" == "|-" || -z "$desc_value" ]]; then

--- a/configs/claude/scripts/learning_capture.sh
+++ b/configs/claude/scripts/learning_capture.sh
@@ -543,7 +543,7 @@ cmd_sync_docs() {
     mkdir -p "$docs_dir"
     local output_file="${docs_dir}/KNOWLEDGE_BASE.md"
 
-    python3 - "$KNOWLEDGE_BASE_FILE" "$output_file" << 'PYTHON'
+    if python3 - "$KNOWLEDGE_BASE_FILE" "$output_file" << 'PYTHON'
 import sys
 import yaml
 from datetime import datetime
@@ -698,8 +698,7 @@ with open(output_file, "w") as f:
 
 print(f"Regenerated {output_file} with {len(entries)} entries.")
 PYTHON
-
-    if [[ $? -eq 0 ]]; then
+    then
         success_msg "docs/KNOWLEDGE_BASE.md regenerated from YAML source of truth"
     fi
 }

--- a/configs/claude/scripts/linear_ops.sh
+++ b/configs/claude/scripts/linear_ops.sh
@@ -2,6 +2,7 @@
 # linear_ops.sh - Linear MCP wrapper for platform-agnostic issue operations
 # Usage: linear_ops.sh <subcommand> [args...]
 
+# shellcheck disable=SC2016
 set -euo pipefail
 
 # Colors for output
@@ -25,7 +26,6 @@ success() {
 }
 
 # Check if Linear MCP is configured
-# shellcheck disable=SC2016
 check_linear_mcp() {
     # Check if Linear is in MCP servers config
     if [[ -f ~/.claude/config/mcp_servers.yml ]]; then

--- a/configs/claude/scripts/linear_ops.sh
+++ b/configs/claude/scripts/linear_ops.sh
@@ -25,6 +25,7 @@ success() {
 }
 
 # Check if Linear MCP is configured
+# shellcheck disable=SC2016
 check_linear_mcp() {
     # Check if Linear is in MCP servers config
     if [[ -f ~/.claude/config/mcp_servers.yml ]]; then

--- a/configs/claude/scripts/parallel_agent.sh
+++ b/configs/claude/scripts/parallel_agent.sh
@@ -903,6 +903,7 @@ run_gemini() {
     # Run from a temp directory to avoid loading project-level .gemini/ settings
     # (e.g., GEMINI.md orchestration guide) which can cause Gemini to
     # "investigate the environment" instead of answering the prompt.
+    # shellcheck disable=SC2016
     run_with_retry "Gemini CLI" "$GEMINI_OUTPUT_FILE" bash -c \
         'cd "$(mktemp -d)" && gemini --output-format text --model "$1" -p "" "${@:2}" < "$0"' \
         "$GEMINI_PROMPT_FILE" "$GEMINI_MODEL" "${include_args[@]}"
@@ -921,6 +922,7 @@ run_claude() {
     echo -e "${BLUE}[Claude CLI]${NC} Starting with model: $CLAUDE_MODEL..."
 
     # Claude CLI: use input redirection (saves cat process)
+    # shellcheck disable=SC2016
     if ! run_with_retry_capture_stderr "Claude CLI" "$CLAUDE_OUTPUT_FILE" "$CLAUDE_STDERR_FILE" \
         bash -c 'claude --print --output-format text --model "$1" --append-system-prompt "$2" < "$0"' \
         "$CLAUDE_PROMPT_FILE" "$CLAUDE_MODEL" \
@@ -933,6 +935,7 @@ run_claude() {
             CLAUDE_MODEL="haiku"
 
             # Retry with haiku (cheapest model)
+            # shellcheck disable=SC2016
             run_with_retry "Claude CLI (fallback)" "$CLAUDE_OUTPUT_FILE" \
                 bash -c 'claude --print --output-format text --model haiku --append-system-prompt "$1" < "$0"' \
                 "$CLAUDE_PROMPT_FILE" \
@@ -1462,11 +1465,11 @@ monitor_agents() {
                     code=$?
                     set -e
                     if [[ $code -eq 0 ]]; then
-                        agent_states[$i]="${GREEN}✔${NC}"
+                        agent_states[i]="${GREEN}✔${NC}"
                     else
-                        agent_states[$i]="${RED}✘${NC}"
+                        agent_states[i]="${RED}✘${NC}"
                     fi
-                    status_line="$status_line $display_name [${agent_states[$i]}]"
+                    status_line="$status_line $display_name [${agent_states[i]}]"
                 fi
             else
                 status_line="$status_line $display_name [$state]"
@@ -1499,57 +1502,59 @@ monitor_agents() {
 create_summary() {
     local summary_file="$SUMMARY_FILE"
 
-    echo "# Parallel Agent Results - $TIMESTAMP" > "$summary_file"
-    echo "" >> "$summary_file"
-    echo "**Mode:** $MODE" >> "$summary_file"
-    echo "**Duration:** $DURATION_FORMATTED" >> "$summary_file"
-    echo "**Prompt/Target:** ${PROMPT:-$TARGET}" >> "$summary_file"
+    {
+        echo "# Parallel Agent Results - $TIMESTAMP"
+        echo ""
+        echo "**Mode:** $MODE"
+        echo "**Duration:** $DURATION_FORMATTED"
+        echo "**Prompt/Target:** ${PROMPT:-$TARGET}"
 
-    if [[ "$CROSS_VERIFY_RAN" == true ]]; then
-        local bar
-        bar=$(draw_bar $CONSENSUS_SCORE)
-        echo "**Consensus:** $CONSENSUS_SCORE% \`$bar\`" >> "$summary_file"
-    fi
+        if [[ "$CROSS_VERIFY_RAN" == true ]]; then
+            local bar
+            bar=$(draw_bar "$CONSENSUS_SCORE")
+            echo "**Consensus:** $CONSENSUS_SCORE% \`$bar\`"
+        fi
 
-    echo "" >> "$summary_file"
+        echo ""
 
-    if [[ -f "$CURSOR_OUTPUT_FILE" ]]; then
-        echo "## Cursor Agent Output" >> "$summary_file"
-        [[ -n "$CURSOR_MODEL" ]] && echo "**Model:** $CURSOR_MODEL" >> "$summary_file"
-        [[ "$CURSOR_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used fallback mode due to credit exhaustion" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        get_output_content "$CURSOR_OUTPUT_FILE" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        echo "" >> "$summary_file"
-    fi
+        if [[ -f "$CURSOR_OUTPUT_FILE" ]]; then
+            echo "## Cursor Agent Output"
+            [[ -n "$CURSOR_MODEL" ]] && echo "**Model:** $CURSOR_MODEL"
+            [[ "$CURSOR_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used fallback mode due to credit exhaustion"
+            echo '```'
+            get_output_content "$CURSOR_OUTPUT_FILE"
+            echo '```'
+            echo ""
+        fi
 
-    if [[ -f "$GEMINI_OUTPUT_FILE" ]]; then
-        echo "## Gemini CLI Output" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        get_output_content "$GEMINI_OUTPUT_FILE" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        echo "" >> "$summary_file"
-    fi
+        if [[ -f "$GEMINI_OUTPUT_FILE" ]]; then
+            echo "## Gemini CLI Output"
+            echo '```'
+            get_output_content "$GEMINI_OUTPUT_FILE"
+            echo '```'
+            echo ""
+        fi
 
-    if [[ -f "$CLAUDE_OUTPUT_FILE" ]]; then
-        echo "## Claude CLI Output" >> "$summary_file"
-        [[ -n "$CLAUDE_MODEL" ]] && echo "**Model:** $CLAUDE_MODEL" >> "$summary_file"
-        [[ "$CLAUDE_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used fallback mode due to credit exhaustion" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        get_output_content "$CLAUDE_OUTPUT_FILE" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        echo "" >> "$summary_file"
-    fi
+        if [[ -f "$CLAUDE_OUTPUT_FILE" ]]; then
+            echo "## Claude CLI Output"
+            [[ -n "$CLAUDE_MODEL" ]] && echo "**Model:** $CLAUDE_MODEL"
+            [[ "$CLAUDE_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used fallback mode due to credit exhaustion"
+            echo '```'
+            get_output_content "$CLAUDE_OUTPUT_FILE"
+            echo '```'
+            echo ""
+        fi
 
-    if [[ -f "$CODEX_OUTPUT_FILE" ]]; then
-        echo "## Codex CLI Output" >> "$summary_file"
-        [[ -n "$CODEX_MODEL" ]] && echo "**Model:** $CODEX_MODEL (tier: $CODEX_MODEL_TIER)" >> "$summary_file"
-        [[ "$CODEX_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used default model due to credit exhaustion" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        get_output_content "$CODEX_OUTPUT_FILE" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        echo "" >> "$summary_file"
-    fi
+        if [[ -f "$CODEX_OUTPUT_FILE" ]]; then
+            echo "## Codex CLI Output"
+            [[ -n "$CODEX_MODEL" ]] && echo "**Model:** $CODEX_MODEL (tier: $CODEX_MODEL_TIER)"
+            [[ "$CODEX_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used default model due to credit exhaustion"
+            echo '```'
+            get_output_content "$CODEX_OUTPUT_FILE"
+            echo '```'
+            echo ""
+        fi
+    } > "$summary_file"
 
     echo -e "${GREEN}Summary:${NC} $summary_file"
 
@@ -1574,7 +1579,7 @@ print_results_table() {
     if [[ "$VALIDATE" == true ]]; then
         printf " | %-10s" "Validation"
     fi
-    printf "${NC}\n"
+    printf "%s\n" "${NC}"
 
     printf "%s\n" "-----------|------------|----------------------$(if [[ "$VALIDATE" == true ]]; then echo "-|------------"; fi)"
 

--- a/tests/test_auth_security.sh
+++ b/tests/test_auth_security.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+
+# Mock environment
+TARGET_DIR=$(mktemp -d)
+CURSOR_TARGET_DIR="$TARGET_DIR/cursor"
+export TARGET_DIR
+export CURSOR_TARGET_DIR
+export BOLD=""
+export NC=""
+export CYAN=""
+export GREEN=""
+export YELLOW=""
+export RED=""
+export BLUE=""
+export SCRIPT_DIR="$PWD"
+
+# Mock common.sh functions
+print_step() { echo "STEP: $1"; }
+print_success() { echo "SUCCESS: $1"; }
+print_warning() { echo "WARNING: $1"; }
+print_error() { echo "ERROR: $1"; }
+print_info() { echo "INFO: $1"; }
+prompt_yes_no() { echo "YESNO: $1"; return 0; } # Assume Yes
+command_exists() { command -v "$1" &> /dev/null; }
+
+# Mock variables for mcp.sh
+MCP_SELECTED_INDICES=(0)
+MCP_SERVER_NAMES=("test_server")
+MCP_SERVER_URLS=("http://test.url")
+MCP_SERVER_TRANSPORTS=("sse")
+MCP_SERVER_PURPOSES=("testing")
+
+# Source libraries
+# We need to temporarily disable shellcheck for sourcing
+# shellcheck source=/dev/null
+source bootstrap/lib/auth.sh
+# shellcheck source=/dev/null
+source bootstrap/lib/mcp.sh
+
+FAILURES=0
+
+test_gemini_auth_new() {
+    echo "Testing setup_gemini_auth (new file)..."
+    # Input: 2 (API Key), then the key
+    (echo "2"; echo "my-secret-key") | setup_gemini_auth > /dev/null
+
+    ENV_FILE="$TARGET_DIR/gemini_env.sh"
+    if [[ -f "$ENV_FILE" ]]; then
+        if [[ "$(uname)" == "Darwin" ]]; then
+            PERMS=$(stat -f "%OLp" "$ENV_FILE")
+        else
+            PERMS=$(stat -c "%a" "$ENV_FILE")
+        fi
+
+        echo "Permissions: $PERMS"
+        if [[ "$PERMS" != "600" ]]; then
+            echo "FAIL: Permissions are not 600"
+            FAILURES=$((FAILURES + 1))
+        else
+            echo "PASS: Permissions are 600"
+        fi
+
+        CONTENT=$(cat "$ENV_FILE")
+        if [[ "$CONTENT" == "export GEMINI_API_KEY='my-secret-key'" ]]; then
+             echo "PASS: Content matches"
+        else
+             echo "FAIL: Content mismatch: $CONTENT"
+             FAILURES=$((FAILURES + 1))
+        fi
+    else
+        echo "FAIL: File not created"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+test_gemini_auth_existing() {
+    echo "Testing setup_gemini_auth (existing insecure file)..."
+    ENV_FILE="$TARGET_DIR/gemini_env.sh"
+    touch "$ENV_FILE"
+    chmod 644 "$ENV_FILE"
+    echo "old_content" > "$ENV_FILE"
+
+    # Input: 2 (API Key), then the key
+    (echo "2"; echo "new-secret-key") | setup_gemini_auth > /dev/null
+
+    if [[ -f "$ENV_FILE" ]]; then
+        if [[ "$(uname)" == "Darwin" ]]; then
+            PERMS=$(stat -f "%OLp" "$ENV_FILE")
+        else
+            PERMS=$(stat -c "%a" "$ENV_FILE")
+        fi
+
+        echo "Permissions: $PERMS"
+        if [[ "$PERMS" != "600" ]]; then
+            echo "FAIL: Permissions are not 600 (was likely 644)"
+            FAILURES=$((FAILURES + 1))
+        else
+            echo "PASS: Permissions are 600"
+        fi
+
+        CONTENT=$(cat "$ENV_FILE")
+        if [[ "$CONTENT" == "export GEMINI_API_KEY='new-secret-key'" ]]; then
+             echo "PASS: Content matches"
+        else
+             echo "FAIL: Content mismatch: $CONTENT"
+             FAILURES=$((FAILURES + 1))
+        fi
+    else
+        echo "FAIL: File not created"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+test_cursor_mcp_new() {
+    echo "Testing configure_cursor_mcp_config (new file)..."
+    # Ensure dir is clean
+    rm -rf "$CURSOR_TARGET_DIR"
+    configure_cursor_mcp_config > /dev/null
+
+    MCP_FILE="$CURSOR_TARGET_DIR/mcp.json"
+    if [[ -f "$MCP_FILE" ]]; then
+        if [[ "$(uname)" == "Darwin" ]]; then
+            PERMS=$(stat -f "%OLp" "$MCP_FILE")
+        else
+            PERMS=$(stat -c "%a" "$MCP_FILE")
+        fi
+
+        echo "Permissions: $PERMS"
+        if [[ "$PERMS" != "600" ]]; then
+            echo "FAIL: Permissions are not 600"
+            FAILURES=$((FAILURES + 1))
+        else
+            echo "PASS: Permissions are 600"
+        fi
+
+        if grep -q "test_server" "$MCP_FILE"; then
+             echo "PASS: Content contains server name"
+        else
+             echo "FAIL: Content missing server name"
+             cat "$MCP_FILE"
+             FAILURES=$((FAILURES + 1))
+        fi
+    else
+        echo "FAIL: File not created"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+test_cursor_mcp_existing() {
+    echo "Testing configure_cursor_mcp_config (existing insecure file)..."
+    mkdir -p "$CURSOR_TARGET_DIR"
+    MCP_FILE="$CURSOR_TARGET_DIR/mcp.json"
+    touch "$MCP_FILE"
+    chmod 644 "$MCP_FILE"
+    echo "{}" > "$MCP_FILE"
+
+    # Mock is_cursor_mcp_current to return false so it overwrites
+    # We rely on the fact that is_cursor_mcp_current checks for content, and we put empty content
+    # But wait, our mock in common.sh/mcp.sh works.
+    # is_cursor_mcp_current uses jq or grep. If file is empty or {}, it fails the check, so it proceeds to overwrite.
+
+    configure_cursor_mcp_config > /dev/null
+
+    if [[ -f "$MCP_FILE" ]]; then
+        if [[ "$(uname)" == "Darwin" ]]; then
+            PERMS=$(stat -f "%OLp" "$MCP_FILE")
+        else
+            PERMS=$(stat -c "%a" "$MCP_FILE")
+        fi
+
+        echo "Permissions: $PERMS"
+        if [[ "$PERMS" != "600" ]]; then
+            echo "FAIL: Permissions are not 600 (was likely 644)"
+            FAILURES=$((FAILURES + 1))
+        else
+            echo "PASS: Permissions are 600"
+        fi
+
+        if grep -q "test_server" "$MCP_FILE"; then
+             echo "PASS: Content contains server name"
+        else
+             echo "FAIL: Content missing server name"
+             cat "$MCP_FILE"
+             FAILURES=$((FAILURES + 1))
+        fi
+    else
+        echo "FAIL: File not created"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# Run tests
+test_gemini_auth_new
+test_gemini_auth_existing
+test_cursor_mcp_new
+test_cursor_mcp_existing
+
+# Cleanup
+rm -rf "$TARGET_DIR"
+
+if [[ $FAILURES -eq 0 ]]; then
+    echo "All tests passed"
+    exit 0
+else
+    echo "$FAILURES tests failed"
+    exit 1
+fi


### PR DESCRIPTION
Identified and fixed a Time-of-Check-to-Time-of-Use (TOCTOU) vulnerability in `bootstrap/lib/auth.sh` and `bootstrap/lib/mcp.sh` where sensitive files (API keys, MCP config) were created with default permissions (potentially world-readable) and then restricted with `chmod 600`. This created a race condition window.

The fix involves:
1.  Explicitly removing the target file (`rm -f`) to ensure we are not overwriting an existing file with insecure permissions (which would preserve those permissions).
2.  Creating the file within a subshell with `umask 077` to ensure it is created with 0600 permissions atomically.

Added `tests/test_auth_security.sh` to verify:
- New files are created with 0600 permissions.
- Existing insecure files (0644) are replaced with secure files (0600).

---
*PR created automatically by Jules for task [1450692988446438389](https://jules.google.com/task/1450692988446438389) started by @ReefBytes*