### PR TITLE
🎨 Palette: Add loading spinner to bootstrap operations

### DIFF
--- a/bootstrap/lib/auth.sh
+++ b/bootstrap/lib/auth.sh
@@ -235,6 +235,7 @@ configure_shell_profile_state() {
             ;;
     esac
 
+    # shellcheck disable=SC2016
     local export_line='export MANIFEST_STATE_ROOT="${MANIFEST_STATE_ROOT:-$HOME/.manifest}"'
     # shellcheck disable=SC2034
     SHELL_PROFILE_FILE="$profile_file"

--- a/bootstrap/lib/common.sh
+++ b/bootstrap/lib/common.sh
@@ -58,22 +58,51 @@ command_exists() {
 run_with_spinner() {
     local cmd="$1"
     local msg="${2:-Working}"
-    local pid
+    local log_file
+    log_file=$(mktemp)
+
+    # Run command in background, redirecting output
+    eval "$cmd" > "$log_file" 2>&1 &
+    local pid=$!
+
     local spin='-\|/'
     local i=0
 
-    eval "$cmd" &
-    pid=$!
+    # Check if we are in an interactive terminal
+    if [[ -t 1 && "$TERM" != "dumb" && -z "$NO_COLOR" ]]; then
+        # Hide cursor
+        tput civis 2>/dev/null
 
-    while kill -0 "$pid" 2> /dev/null; do
-        i=$(((i + 1) % 4))
-        printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
-        sleep 0.2
-    done
+        while kill -0 "$pid" 2> /dev/null; do
+            i=$(((i + 1) % 4))
+            printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
+            sleep 0.1
+        done
+
+        # Restore cursor
+        tput cnorm 2>/dev/null
+        # Clear line
+        printf "\r\033[K"
+    else
+        # Non-interactive mode: just print message and wait
+        echo "Running: $msg"
+        wait "$pid"
+    fi
 
     wait "$pid"
     local exit_code=$?
-    printf "\r\033[K"
+
+    if [[ $exit_code -eq 0 ]]; then
+        print_success "$msg"
+    else
+        print_error "$msg failed"
+        if [[ -s "$log_file" ]]; then
+            echo -e "${RED}Error output:${NC}"
+            cat "$log_file"
+        fi
+    fi
+
+    rm -f "$log_file"
     return $exit_code
 }
 

--- a/bootstrap/lib/common.sh
+++ b/bootstrap/lib/common.sh
@@ -86,7 +86,6 @@ run_with_spinner() {
     else
         # Non-interactive mode: just print message and wait
         echo "Running: $msg"
-        wait "$pid"
     fi
 
     wait "$pid"

--- a/bootstrap/lib/install.sh
+++ b/bootstrap/lib/install.sh
@@ -10,6 +10,7 @@ check_platform() {
         linux)
             local version=""
             if [[ -f /etc/os-release ]]; then
+                # shellcheck disable=SC1091
                 . /etc/os-release
                 version="$PRETTY_NAME"
             else
@@ -287,7 +288,7 @@ install_node() {
                         sudo apt-get install -y nodejs
                     elif [[ "$PKG_MANAGER" == "dnf" || "$PKG_MANAGER" == "yum" ]]; then
                         curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -
-                        sudo $PKG_MANAGER install -y nodejs
+                        sudo "$PKG_MANAGER" install -y nodejs
                     else
                         print_warning "NodeSource not available for $PKG_MANAGER"
                         print_info "Please install Node.js manually from https://nodejs.org"

--- a/bootstrap/lib/install.sh
+++ b/bootstrap/lib/install.sh
@@ -37,8 +37,7 @@ install_package_manager() {
 
         if command_exists brew; then
             print_success "Homebrew is installed"
-            print_step "Updating Homebrew..."
-            brew update --quiet
+            run_with_spinner "brew update --quiet" "Updating Homebrew" || return 1
         else
             print_warning "Homebrew not found"
             if prompt_yes_no "Install Homebrew?"; then
@@ -218,8 +217,8 @@ install_python_dependencies() {
     print_info "Using: $python_cmd"
 
     # Try to install with --user flag and prefer binary wheels
-    if $python_cmd -m pip install --user --prefer-binary -q -r "$requirements_file" 2>&1; then
-        print_success "Python dependencies installed"
+    if run_with_spinner "$python_cmd -m pip install --user --prefer-binary -q -r \"$requirements_file\"" "Installing Python dependencies"; then
+        :
     else
         print_warning "Failed to install Python dependencies"
         print_info "Some packages may require compilation or may not support this Python version"
@@ -324,9 +323,7 @@ install_claude() {
 
         if prompt_yes_no "Install Claude Code CLI via npm?"; then
             if command_exists npm; then
-                print_step "Installing Claude Code CLI..."
-                npm install -g @anthropic-ai/claude-code
-                print_success "Claude Code CLI installed"
+                run_with_spinner "npm install -g @anthropic-ai/claude-code" "Installing Claude Code CLI" || return 1
             else
                 print_error "npm not found. Please install Node.js first."
                 return 1
@@ -361,9 +358,7 @@ install_gemini() {
 
         if prompt_yes_no "Install Gemini CLI via npm?"; then
             if command_exists npm; then
-                print_step "Installing Gemini CLI..."
-                npm install -g @google/gemini-cli
-                print_success "Gemini CLI installed"
+                run_with_spinner "npm install -g @google/gemini-cli" "Installing Gemini CLI" || return 1
             else
                 print_error "npm not found. Please install Node.js first."
                 return 1
@@ -403,9 +398,7 @@ install_codex() {
 
         if prompt_yes_no "Install Codex CLI via npm?"; then
             if command_exists npm; then
-                print_step "Installing Codex CLI..."
-                npm install -g @openai/codex
-                print_success "Codex CLI installed"
+                run_with_spinner "npm install -g @openai/codex" "Installing Codex CLI" || return 1
             else
                 print_error "npm not found. Please install Node.js first."
                 return 1
@@ -475,9 +468,7 @@ install_github_cli() {
             case "$PLATFORM" in
                 macos)
                     if command_exists brew; then
-                        print_step "Installing GitHub CLI via Homebrew..."
-                        brew install gh
-                        print_success "GitHub CLI installed"
+                        run_with_spinner "brew install gh" "Installing GitHub CLI" || return 1
                     else
                         print_error "Homebrew not found. Please install Homebrew first."
                         return 1
@@ -572,9 +563,7 @@ install_gitlab_cli() {
             case "$PLATFORM" in
                 macos)
                     if command_exists brew; then
-                        print_step "Installing GitLab CLI via Homebrew..."
-                        brew install glab
-                        print_success "GitLab CLI installed"
+                        run_with_spinner "brew install glab" "Installing GitLab CLI" || return 1
                     else
                         print_error "Homebrew not found. Please install Homebrew first."
                         return 1
@@ -653,9 +642,7 @@ check_jq() {
             case "$PLATFORM" in
                 macos)
                     if command_exists brew; then
-                        print_step "Installing jq via Homebrew..."
-                        brew install jq
-                        print_success "jq installed"
+                        run_with_spinner "brew install jq" "Installing jq" || return 1
                     else
                         print_error "Homebrew not found."
                         return 1

--- a/bootstrap/lib/platform.sh
+++ b/bootstrap/lib/platform.sh
@@ -12,6 +12,7 @@ detect_platform() {
             PLATFORM="linux"
             # Detect Linux distribution
             if [[ -f /etc/os-release ]]; then
+                # shellcheck disable=SC1091
                 . /etc/os-release
                 DISTRO="$ID"
             elif [[ -f /etc/debian_version ]]; then

--- a/configs/claude/scripts/generate_cursor_rules.sh
+++ b/configs/claude/scripts/generate_cursor_rules.sh
@@ -46,6 +46,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     if head -1 "$skill_file" | grep -q '^---'; then
         front_matter=$(sed -n '2,/^---$/p' "$skill_file" | sed '$d')
         desc_line=$(echo "$front_matter" | grep '^description:' | head -1)
+        # shellcheck disable=SC2001
         desc_value=$(echo "$desc_line" | sed 's/^description:[[:space:]]*//')
 
         if [[ "$desc_value" == "|" || "$desc_value" == "|-" || -z "$desc_value" ]]; then

--- a/configs/claude/scripts/learning_capture.sh
+++ b/configs/claude/scripts/learning_capture.sh
@@ -699,6 +699,7 @@ with open(output_file, "w") as f:
 print(f"Regenerated {output_file} with {len(entries)} entries.")
 PYTHON
 
+    # shellcheck disable=SC2181
     if [[ $? -eq 0 ]]; then
         success_msg "docs/KNOWLEDGE_BASE.md regenerated from YAML source of truth"
     fi

--- a/configs/claude/scripts/linear_ops.sh
+++ b/configs/claude/scripts/linear_ops.sh
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
+# shellcheck disable=SC2016
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/configs/claude/scripts/linear_ops.sh
+++ b/configs/claude/scripts/linear_ops.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
+# shellcheck disable=SC2016
 # linear_ops.sh - Linear MCP wrapper for platform-agnostic issue operations
 # Usage: linear_ops.sh <subcommand> [args...]
 
 set -euo pipefail
-
-# shellcheck disable=SC2016
 
 # Colors for output
 RED='\033[0;31m'

--- a/configs/claude/scripts/parallel_agent.sh
+++ b/configs/claude/scripts/parallel_agent.sh
@@ -903,6 +903,7 @@ run_gemini() {
     # Run from a temp directory to avoid loading project-level .gemini/ settings
     # (e.g., GEMINI.md orchestration guide) which can cause Gemini to
     # "investigate the environment" instead of answering the prompt.
+    # shellcheck disable=SC2016
     run_with_retry "Gemini CLI" "$GEMINI_OUTPUT_FILE" bash -c \
         'cd "$(mktemp -d)" && gemini --output-format text --model "$1" -p "" "${@:2}" < "$0"' \
         "$GEMINI_PROMPT_FILE" "$GEMINI_MODEL" "${include_args[@]}"
@@ -921,6 +922,7 @@ run_claude() {
     echo -e "${BLUE}[Claude CLI]${NC} Starting with model: $CLAUDE_MODEL..."
 
     # Claude CLI: use input redirection (saves cat process)
+    # shellcheck disable=SC2016
     if ! run_with_retry_capture_stderr "Claude CLI" "$CLAUDE_OUTPUT_FILE" "$CLAUDE_STDERR_FILE" \
         bash -c 'claude --print --output-format text --model "$1" --append-system-prompt "$2" < "$0"' \
         "$CLAUDE_PROMPT_FILE" "$CLAUDE_MODEL" \
@@ -933,6 +935,7 @@ run_claude() {
             CLAUDE_MODEL="haiku"
 
             # Retry with haiku (cheapest model)
+            # shellcheck disable=SC2016
             run_with_retry "Claude CLI (fallback)" "$CLAUDE_OUTPUT_FILE" \
                 bash -c 'claude --print --output-format text --model haiku --append-system-prompt "$1" < "$0"' \
                 "$CLAUDE_PROMPT_FILE" \
@@ -1462,9 +1465,9 @@ monitor_agents() {
                     code=$?
                     set -e
                     if [[ $code -eq 0 ]]; then
-                        agent_states[$i]="${GREEN}✔${NC}"
+                        agent_states[i]="${GREEN}✔${NC}"
                     else
-                        agent_states[$i]="${RED}✘${NC}"
+                        agent_states[i]="${RED}✘${NC}"
                     fi
                     status_line="$status_line $display_name [${agent_states[$i]}]"
                 fi
@@ -1499,11 +1502,13 @@ monitor_agents() {
 create_summary() {
     local summary_file="$SUMMARY_FILE"
 
-    echo "# Parallel Agent Results - $TIMESTAMP" > "$summary_file"
-    echo "" >> "$summary_file"
-    echo "**Mode:** $MODE" >> "$summary_file"
-    echo "**Duration:** $DURATION_FORMATTED" >> "$summary_file"
-    echo "**Prompt/Target:** ${PROMPT:-$TARGET}" >> "$summary_file"
+    {
+        echo "# Parallel Agent Results - $TIMESTAMP"
+        echo ""
+        echo "**Mode:** $MODE"
+        echo "**Duration:** $DURATION_FORMATTED"
+        echo "**Prompt/Target:** ${PROMPT:-$TARGET}"
+    } > "$summary_file"
 
     if [[ "$CROSS_VERIFY_RAN" == true ]]; then
         local bar
@@ -1514,41 +1519,49 @@ create_summary() {
     echo "" >> "$summary_file"
 
     if [[ -f "$CURSOR_OUTPUT_FILE" ]]; then
-        echo "## Cursor Agent Output" >> "$summary_file"
-        [[ -n "$CURSOR_MODEL" ]] && echo "**Model:** $CURSOR_MODEL" >> "$summary_file"
-        [[ "$CURSOR_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used fallback mode due to credit exhaustion" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        get_output_content "$CURSOR_OUTPUT_FILE" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        echo "" >> "$summary_file"
+        {
+            echo "## Cursor Agent Output"
+            [[ -n "$CURSOR_MODEL" ]] && echo "**Model:** $CURSOR_MODEL"
+            [[ "$CURSOR_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used fallback mode due to credit exhaustion"
+            echo '```'
+            get_output_content "$CURSOR_OUTPUT_FILE"
+            echo '```'
+            echo ""
+        } >> "$summary_file"
     fi
 
     if [[ -f "$GEMINI_OUTPUT_FILE" ]]; then
-        echo "## Gemini CLI Output" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        get_output_content "$GEMINI_OUTPUT_FILE" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        echo "" >> "$summary_file"
+        {
+            echo "## Gemini CLI Output"
+            echo '```'
+            get_output_content "$GEMINI_OUTPUT_FILE"
+            echo '```'
+            echo ""
+        } >> "$summary_file"
     fi
 
     if [[ -f "$CLAUDE_OUTPUT_FILE" ]]; then
-        echo "## Claude CLI Output" >> "$summary_file"
-        [[ -n "$CLAUDE_MODEL" ]] && echo "**Model:** $CLAUDE_MODEL" >> "$summary_file"
-        [[ "$CLAUDE_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used fallback mode due to credit exhaustion" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        get_output_content "$CLAUDE_OUTPUT_FILE" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        echo "" >> "$summary_file"
+        {
+            echo "## Claude CLI Output"
+            [[ -n "$CLAUDE_MODEL" ]] && echo "**Model:** $CLAUDE_MODEL"
+            [[ "$CLAUDE_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used fallback mode due to credit exhaustion"
+            echo '```'
+            get_output_content "$CLAUDE_OUTPUT_FILE"
+            echo '```'
+            echo ""
+        } >> "$summary_file"
     fi
 
     if [[ -f "$CODEX_OUTPUT_FILE" ]]; then
-        echo "## Codex CLI Output" >> "$summary_file"
-        [[ -n "$CODEX_MODEL" ]] && echo "**Model:** $CODEX_MODEL (tier: $CODEX_MODEL_TIER)" >> "$summary_file"
-        [[ "$CODEX_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used default model due to credit exhaustion" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        get_output_content "$CODEX_OUTPUT_FILE" >> "$summary_file"
-        echo '```' >> "$summary_file"
-        echo "" >> "$summary_file"
+        {
+            echo "## Codex CLI Output"
+            [[ -n "$CODEX_MODEL" ]] && echo "**Model:** $CODEX_MODEL (tier: $CODEX_MODEL_TIER)"
+            [[ "$CODEX_CREDIT_FALLBACK" == true ]] && echo "**Note:** Used default model due to credit exhaustion"
+            echo '```'
+            get_output_content "$CODEX_OUTPUT_FILE"
+            echo '```'
+            echo ""
+        } >> "$summary_file"
     fi
 
     echo -e "${GREEN}Summary:${NC} $summary_file"
@@ -1611,6 +1624,7 @@ print_results_table() {
             fi
             printf " | %-10b" "$val_status"
         fi
+    # shellcheck disable=SC2059
         printf "\n"
     fi
 

--- a/configs/claude/scripts/parallel_agent.sh
+++ b/configs/claude/scripts/parallel_agent.sh
@@ -1587,6 +1587,7 @@ print_results_table() {
     if [[ "$VALIDATE" == true ]]; then
         printf " | %-10s" "Validation"
     fi
+    # shellcheck disable=SC2059
     printf "${NC}\n"
 
     printf "%s\n" "-----------|------------|----------------------$(if [[ "$VALIDATE" == true ]]; then echo "-|------------"; fi)"


### PR DESCRIPTION
🎨 **Palette: Add loading spinner to bootstrap operations**

**What:**
- Enhanced `run_with_spinner` utility in `bootstrap/lib/common.sh` to be more robust:
    - Captures `stdout`/`stderr` to a temporary log.
    - Displays a spinner animation in interactive terminals.
    - Suppresses output on success (showing a green `✓`).
    - Displays full error output on failure (showing a red `✗`).
- Applied `run_with_spinner` to long-running installation commands in `bootstrap/lib/install.sh`:
    - `brew update`
    - `npm install` (Claude, Gemini, Codex)
    - `pip install` (Python dependencies)
    - `brew install` (GitHub/GitLab CLIs)

**Why:**
The previous bootstrap output was noisy and mixed progress indicators with raw command output. The spinner provides a cleaner, more professional CLI experience while ensuring error details are still available when needed.

**Accessibility:**
- The spinner logic detects non-interactive terminals (CI/CD) and falls back to plain text logging to avoid log pollution.
- Colors are used for status indicators (Green/Red) but text labels ("Working", "failed") ensure meaning is conveyed without color.

---
*PR created automatically by Jules for task [3916608263738466778](https://jules.google.com/task/3916608263738466778) started by @ReefBytes-Owner*