### PR TITLE
🎨 Palette: [UX improvement] Fix CLI spinner corruption during loading states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,17 @@
 # Palette's Journal
 
 ## 2026-02-06 - Initial Setup
+
 **Learning:** UX improvements in CLI tools are just as critical as web UIs.
-**Action:** When working on CLI scripts, prioritize readability (colors, spacing) and explicit user guidance (defaults, help text).
+**Action:** When working on CLI scripts, prioritize readability (colors,
+spacing) and explicit user guidance (defaults, help text).
+
+## 2026-02-11 - Robust CLI Spinners
+
+**Learning:** Background process output easily corrupts interactive CLI loading
+animations, leading to a degraded UX when users see broken terminal lines or
+interleaved text.
+**Action:** When implementing CLI spinners, always hide the terminal cursor
+(`tput civis`), redirect command output to a temporary log file, restore the
+cursor upon exit (`tput cnorm`), and only print the log contents if the command
+ultimately fails.

--- a/bootstrap/lib/common.sh
+++ b/bootstrap/lib/common.sh
@@ -61,19 +61,45 @@ run_with_spinner() {
     local pid
     local spin='-\|/'
     local i=0
+    local exit_code=0
 
-    eval "$cmd" &
-    pid=$!
+    # Hide cursor
+    tput civis 2> /dev/null || true
 
-    while kill -0 "$pid" 2> /dev/null; do
-        i=$(((i + 1) % 4))
-        printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
-        sleep 0.2
-    done
+    # Redirect output to prevent interleaved output breaking the spinner
+    local tmp_log
+    tmp_log="$(mktemp -t spinner.XXXXXX)"
 
-    wait "$pid"
-    local exit_code=$?
-    printf "\r\033[K"
+    # Run in a subshell with a trap to ensure cursor is restored on Ctrl+C
+    (
+        trap 'tput cnorm 2> /dev/null || true; rm -f "$tmp_log"' EXIT
+
+        eval "$cmd" > "$tmp_log" 2>&1 &
+        pid=$!
+
+        while kill -0 "$pid" 2> /dev/null; do
+            i=$(((i + 1) % 4))
+            printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
+            sleep 0.2
+        done
+
+        wait "$pid" || exit_code=$?
+
+        # Clear spinner line
+        printf "\r\033[K"
+
+        # Print output only if command failed
+        if [[ $exit_code -ne 0 ]] && [[ -s "$tmp_log" ]]; then
+            cat "$tmp_log"
+        fi
+
+        exit "$exit_code"
+    )
+    exit_code=$?
+
+    # Restore cursor in the parent shell as well just in case
+    tput cnorm 2> /dev/null || true
+
     return $exit_code
 }
 


### PR DESCRIPTION
💡 **What:** 
- Hidden terminal cursor (`tput civis`) while the CLI spinner is active and safely restored it on exit (`tput cnorm`) via a trap.
- Redirected the evaluation of background commands to a temporary file, and only logged the file if the command fails.

🎯 **Why:** 
CLI spinners in shell scripts often become broken and visually messy when the background process being tracked attempts to write to `stdout` or `stderr`. Output interleaved with carriage returns (`\r`) corrupts the loading UI. Hiding the cursor additionally prevents irritating flickering.

♿ **Accessibility & UX:** 
Makes the script output cleaner and more professional. Prevents screen readers from interpreting broken terminal lines. Ensures users do not experience random terminal disruptions if they `Ctrl+C` the script midway through execution.

---
*PR created automatically by Jules for task [17971651156910473465](https://jules.google.com/task/17971651156910473465) started by @ReefBytes-Owner*