### PR TITLE
🎨 Palette: Improve CLI spinner UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,18 +1,5 @@
 # Palette's Journal
 
 ## 2026-02-06 - Initial Setup
-
 **Learning:** UX improvements in CLI tools are just as critical as web UIs.
-**Action:** When working on CLI scripts, prioritize readability (colors,
-spacing) and explicit user guidance (defaults, help text).
-
-## 2024-04-13 - CLI Spinner UX and Log Output Interleaving
-
-**Learning:** When building CLI spinners that wrap background jobs, interleaving
-standard output/error from the job with the carriage-return (`\r`) spinner
-characters creates severe visual artifacting and screen reader confusion. The
-cursor flashing also creates unnecessary visual noise.
-**Action:** Always decouple command execution from UI rendering in spinners. Run
-the command in a subshell, hide the cursor (`tput civis`), trap `EXIT` to
-restore it, and redirect all stdout/stderr to a temp file, only printing the
-log output if the background command fails.
+**Action:** When working on CLI scripts, prioritize readability (colors, spacing) and explicit user guidance (defaults, help text).

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,18 @@
 # Palette's Journal
 
 ## 2026-02-06 - Initial Setup
+
 **Learning:** UX improvements in CLI tools are just as critical as web UIs.
-**Action:** When working on CLI scripts, prioritize readability (colors, spacing) and explicit user guidance (defaults, help text).
+**Action:** When working on CLI scripts, prioritize readability (colors,
+spacing) and explicit user guidance (defaults, help text).
+
+## 2024-04-13 - CLI Spinner UX and Log Output Interleaving
+
+**Learning:** When building CLI spinners that wrap background jobs, interleaving
+standard output/error from the job with the carriage-return (`\r`) spinner
+characters creates severe visual artifacting and screen reader confusion. The
+cursor flashing also creates unnecessary visual noise.
+**Action:** Always decouple command execution from UI rendering in spinners. Run
+the command in a subshell, hide the cursor (`tput civis`), trap `EXIT` to
+restore it, and redirect all stdout/stderr to a temp file, only printing the
+log output if the background command fails.

--- a/bootstrap/lib/common.sh
+++ b/bootstrap/lib/common.sh
@@ -78,6 +78,7 @@ run_with_spinner() {
 
         while kill -0 "$pid" 2> /dev/null; do
             i=$(((i + 1) % 4))
+            # shellcheck disable=SC2059
             printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
             sleep 0.2
         done

--- a/bootstrap/lib/common.sh
+++ b/bootstrap/lib/common.sh
@@ -58,23 +58,41 @@ command_exists() {
 run_with_spinner() {
     local cmd="$1"
     local msg="${2:-Working}"
-    local pid
-    local spin='-\|/'
-    local i=0
+    local exit_code=0
 
-    eval "$cmd" &
-    pid=$!
+    (
+        # Hide cursor for cleaner UX
+        tput civis 2> /dev/null || true
+        # Restore cursor unconditionally
+        trap 'tput cnorm 2> /dev/null || true' EXIT
 
-    while kill -0 "$pid" 2> /dev/null; do
-        i=$(((i + 1) % 4))
-        printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
-        sleep 0.2
-    done
+        local log_file
+        log_file="$(mktemp -t script.XXXXXX)"
 
-    wait "$pid"
-    local exit_code=$?
-    printf "\r\033[K"
-    return $exit_code
+        local pid
+        local spin='-\|/'
+        local i=0
+
+        eval "$cmd" > "$log_file" 2>&1 &
+        pid=$!
+
+        while kill -0 "$pid" 2> /dev/null; do
+            i=$(((i + 1) % 4))
+            printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
+            sleep 0.2
+        done
+
+        wait "$pid" || exit_code=$?
+        printf "\r\033[K"
+
+        # Only print logs if the command failed, to avoid interleaving with spinner
+        if [ "$exit_code" -ne 0 ]; then
+            cat "$log_file"
+        fi
+        rm -f "$log_file"
+
+        return "$exit_code"
+    )
 }
 
 # Create/recreate a symlink at link_path pointing to target


### PR DESCRIPTION
💡 What: Modified the `run_with_spinner` function in `bootstrap/lib/common.sh` to execute the target command in a subshell, hide the terminal cursor (`tput civis`), gracefully restore the cursor on EXIT, and redirect all command standard output/error to a temporary file. Log output is only printed to the console if the background command fails.

🎯 Why: To prevent standard output or error messages from interleaving with the carriage-return (`\r`) spinner characters. This interleaving causes severe visual artifacting, spinner corruption, and leaves the terminal in a messy state during installations or setup steps. 

📸 Before/After: Before, background tasks that emitted logs would break the spinner rendering. After, the spinner renders cleanly on a single line and failures neatly dump logs on exit.

♿ Accessibility: Removes distracting terminal cursor flashing and prevents screen readers from redundantly reading chaotic interleaved log and spinner outputs.

---
*PR created automatically by Jules for task [13594855106192479459](https://jules.google.com/task/13594855106192479459) started by @ReefBytes-Owner*