### PR TITLE
🎨 Palette: Improve CLI spinner UX in bootstrap

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,15 @@
 # Palette's Journal
 
 ## 2026-02-06 - Initial Setup
+
 **Learning:** UX improvements in CLI tools are just as critical as web UIs.
-**Action:** When working on CLI scripts, prioritize readability (colors, spacing) and explicit user guidance (defaults, help text).
+**Action:** When working on CLI scripts, prioritize readability (colors,
+spacing) and explicit user guidance (defaults, help text).
+
+## 2026-02-12 - CLI Spinner UX
+
+**Learning:** Background spinners in CLI scripts easily get corrupted when
+stdout or stderr prints text.
+**Action:** When implementing CLI spinners with background tasks, use a subshell
+to trap exits, redirect output to a temp file (\`mktemp\`), hide the cursor
+(\`tput civis\`), and only display logs if the command fails to ensure smooth UX.

--- a/bootstrap/lib/common.sh
+++ b/bootstrap/lib/common.sh
@@ -58,23 +58,33 @@ command_exists() {
 run_with_spinner() {
     local cmd="$1"
     local msg="${2:-Working}"
-    local pid
-    local spin='-\|/'
-    local i=0
 
-    eval "$cmd" &
-    pid=$!
+    (
+        local log_file
+        log_file="$(mktemp -t spinner.XXXXXX)"
+        trap 'tput cnorm; rm -f "$log_file"' EXIT
+        tput civis
 
-    while kill -0 "$pid" 2> /dev/null; do
-        i=$(((i + 1) % 4))
-        printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
-        sleep 0.2
-    done
+        eval "$cmd" > "$log_file" 2>&1 &
+        local pid=$!
+        local spinner=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+        local i=0
 
-    wait "$pid"
-    local exit_code=$?
-    printf "\r\033[K"
-    return $exit_code
+        while kill -0 "$pid" 2> /dev/null; do
+            i=$(((i + 1) % ${#spinner[@]}))
+            printf "\r%b%s%b %s..." "${CYAN}" "${spinner[i]}" "${NC}" "$msg"
+            sleep 0.1
+        done
+
+        local exit_code=0
+        wait "$pid" || exit_code=$?
+        printf "\r\033[K"
+
+        if [ $exit_code -ne 0 ]; then
+            cat "$log_file"
+        fi
+        exit $exit_code
+    )
 }
 
 # Create/recreate a symlink at link_path pointing to target


### PR DESCRIPTION
**🎨 Palette: Improve CLI spinner UX in bootstrap**

💡 **What:** Improved the UX of the CLI loading spinner in the shared `run_with_spinner` function (used in bootstrapping/setup scripts). Switched to a smoother Braille spinner, hide the cursor during animation, run in a trapped subshell, and redirect stdout/stderr to a temporary log file.

🎯 **Why:** To prevent output text from background commands (like `npm install` or curl) from corrupting the spinner animation on the console, ensuring a cleaner visual experience. Errors are still reliably displayed when a command actually fails.

📸 **Before/After:**
*Before:* Spinner spins on characters (`-\|/`), but text output prints over it and ruins the line output.
*After:* A smooth Braille spinner (`⠋⠙⠹...`) with a hidden cursor. Text logs are routed away to a temporary file, and only explicitly dumped to the terminal if the target background command fails.

♿ **Accessibility:** Reduces unnecessary terminal flicker and visual noise, allowing screen reader and terminal tools to avoid reading fragmented loading text output.

---
*PR created automatically by Jules for task [6775656861994170974](https://jules.google.com/task/6775656861994170974) started by @ReefBytes-Owner*