### PR TITLE
feat: add sync-skills native CLI command

### DIFF
--- a/bootstrap/lib/auth.sh
+++ b/bootstrap/lib/auth.sh
@@ -256,8 +256,11 @@ configure_shell_profile_state() {
     # Write MANIFEST_ROOT — always update in case bootstrap is re-run from a new path.
     # Cross-platform safe: avoids sed -i BSD/GNU incompatibility on macOS.
     if [[ -f "$profile_file" ]]; then
-        grep -v 'export MANIFEST_ROOT=' "$profile_file" > "${profile_file}.tmp" || true
-        mv "${profile_file}.tmp" "$profile_file"
+        if grep -v 'export MANIFEST_ROOT=' "$profile_file" > "${profile_file}.tmp" 2>/dev/null; then
+            mv "${profile_file}.tmp" "$profile_file"
+        else
+            rm -f "${profile_file}.tmp"
+        fi
     fi
     {
         echo ""

--- a/bootstrap/lib/auth.sh
+++ b/bootstrap/lib/auth.sh
@@ -252,6 +252,19 @@ configure_shell_profile_state() {
         } >> "$profile_file"
         print_success "Added MANIFEST_STATE_ROOT export to $profile_file"
     fi
+
+    # Write MANIFEST_ROOT — always update in case bootstrap is re-run from a new path.
+    # Cross-platform safe: avoids sed -i BSD/GNU incompatibility on macOS.
+    if [[ -f "$profile_file" ]]; then
+        grep -v 'export MANIFEST_ROOT=' "$profile_file" > "${profile_file}.tmp" || true
+        mv "${profile_file}.tmp" "$profile_file"
+    fi
+    {
+        echo ""
+        echo "# Manifest repository root (managed by bootstrap.sh)"
+        echo "export MANIFEST_ROOT=\"$SCRIPT_DIR\""
+    } >> "$profile_file"
+    print_success "Updated MANIFEST_ROOT in $profile_file"
 }
 
 # Prepare shared runtime state directories under ~/.manifest

--- a/bootstrap/lib/deploy.sh
+++ b/bootstrap/lib/deploy.sh
@@ -54,6 +54,7 @@ deploy_configs() {
                     deploy_codex_configs
                     deploy_antigravity_configs
                     sync_skillshare_targets
+                    deploy_sync_skills
                     return 0
                     ;;
                 3 | *)
@@ -110,6 +111,9 @@ deploy_configs() {
 
     # Project-scoped Copilot sync (non-blocking)
     sync_skillshare_targets
+
+    # Deploy sync-skills CLI
+    deploy_sync_skills
 
     # List deployed files
     echo ""
@@ -240,6 +244,29 @@ sync_skillshare_targets() {
     else
         print_warning "skillshare sync failed (non-fatal) — home deploy unaffected"
     fi
+}
+
+# Deploy sync-skills CLI to ~/.local/bin/ and ensure it is on PATH.
+# Depends on SHELL_PROFILE_FILE being set by configure_shell_profile_state.
+deploy_sync_skills() {
+    print_step "Deploying sync-skills CLI..."
+    mkdir -p "$HOME/.local/bin"
+    cp "$SCRIPT_DIR/configs/claude/scripts/sync-skills.sh" "$HOME/.local/bin/sync-skills"
+    chmod +x "$HOME/.local/bin/sync-skills"
+
+    if ! grep -Fq 'export PATH="$HOME/.local/bin:$PATH"' "$SHELL_PROFILE_FILE" 2>/dev/null; then
+        {
+            echo ""
+            echo "# User-installed tools (managed by bootstrap.sh)"
+            echo 'export PATH="$HOME/.local/bin:$PATH"'
+        } >> "$SHELL_PROFILE_FILE"
+    fi
+
+    # Update PATH for the current bootstrap session (PATH Catch-22: profile not
+    # sourced until next terminal open, but the user may run sync-skills right away).
+    export PATH="$HOME/.local/bin:$PATH"
+
+    print_success "Deployed sync-skills to $HOME/.local/bin/sync-skills"
 }
 
 # Verify installation

--- a/bootstrap/lib/deploy.sh
+++ b/bootstrap/lib/deploy.sh
@@ -254,7 +254,7 @@ deploy_sync_skills() {
     cp "$SCRIPT_DIR/configs/claude/scripts/sync-skills.sh" "$HOME/.local/bin/sync-skills"
     chmod +x "$HOME/.local/bin/sync-skills"
 
-    if ! grep -Fq 'export PATH="$HOME/.local/bin:$PATH"' "$SHELL_PROFILE_FILE" 2>/dev/null; then
+    if ! grep -Eq '\.local/bin' "$SHELL_PROFILE_FILE" 2>/dev/null; then
         {
             echo ""
             echo "# User-installed tools (managed by bootstrap.sh)"

--- a/configs/claude/scripts/parallel_agent.py
+++ b/configs/claude/scripts/parallel_agent.py
@@ -1958,12 +1958,21 @@ async def main():
     command = None
 
     if args.review:
+        if not Path(args.review).exists():
+            print(f"Error: file not found: {args.review}", file=sys.stderr)
+            sys.exit(1)
         mode = "review"
         prompt = f"Review this file for code quality, security, and best practices: {args.review}"
     elif args.analyze:
+        if not Path(args.analyze).exists():
+            print(f"Error: file not found: {args.analyze}", file=sys.stderr)
+            sys.exit(1)
         mode = "analyze"
         prompt = f"Analyze this file for bugs and security issues: {args.analyze}"
     elif args.improve:
+        if not Path(args.improve).exists():
+            print(f"Error: file not found: {args.improve}", file=sys.stderr)
+            sys.exit(1)
         mode = "improve"
         prompt = f"Review and improve this observation YAML: {args.improve}"
     elif args.prompt:

--- a/configs/claude/scripts/sync-skills.sh
+++ b/configs/claude/scripts/sync-skills.sh
@@ -14,9 +14,20 @@ else
     echo "Warning: skillshare not installed — skipping Copilot sync"
 fi
 
-# Home targets — parallel rsync so total time = slowest single target
-rsync -a --delete "$SKILLS_SRC/" "$HOME/.claude/skills/" &
+# Home targets — parallel rsync, PID-tracked so failures are visible
+pids=()
+targets=()
+
+rsync -a --delete "$SKILLS_SRC/" "$HOME/.claude/skills/" & pids+=($!) targets+=("$HOME/.claude/skills")
 for dir in "$HOME/.cursor/skills" "$HOME/.gemini/skills" "$HOME/.codex/skills"; do
-    [[ -d "$dir" ]] && rsync -a --delete "$SKILLS_SRC/" "$dir/" &
+    [[ -d "$dir" ]] && { rsync -a --delete "$SKILLS_SRC/" "$dir/" & pids+=($!) targets+=("$dir"); }
 done
-wait
+
+failed=0
+for i in "${!pids[@]}"; do
+    if ! wait "${pids[$i]}"; then
+        echo "Warning: rsync to ${targets[$i]} failed" >&2
+        [[ "${targets[$i]}" == "$HOME/.claude/skills" ]] && failed=1
+    fi
+done
+[[ $failed -eq 0 ]] || exit 1

--- a/configs/claude/scripts/sync-skills.sh
+++ b/configs/claude/scripts/sync-skills.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ -z "${MANIFEST_ROOT:-}" ]] && { echo "Error: MANIFEST_ROOT not set. Re-run bootstrap.sh." >&2; exit 1; }
+[[ ! -d "$MANIFEST_ROOT" ]]  && { echo "Error: MANIFEST_ROOT '$MANIFEST_ROOT' not found." >&2; exit 1; }
+
+SKILLS_SRC="$MANIFEST_ROOT/.skillshare/skills"
+[[ ! -d "$SKILLS_SRC" ]] && { echo "Error: skills source not found: $SKILLS_SRC" >&2; exit 1; }
+
+# Copilot sync via skillshare (warn and continue if not installed or fails)
+if command -v skillshare > /dev/null 2>&1; then
+    (cd "$MANIFEST_ROOT" && skillshare sync) || echo "Warning: skillshare sync failed — continuing"
+else
+    echo "Warning: skillshare not installed — skipping Copilot sync"
+fi
+
+# Home targets — parallel rsync so total time = slowest single target
+rsync -a --delete "$SKILLS_SRC/" "$HOME/.claude/skills/" &
+for dir in "$HOME/.cursor/skills" "$HOME/.gemini/skills" "$HOME/.codex/skills"; do
+    [[ -d "$dir" ]] && rsync -a --delete "$SKILLS_SRC/" "$dir/" &
+done
+wait

--- a/docs/superpowers/plans/2026-05-30-sync-skills-cli.md
+++ b/docs/superpowers/plans/2026-05-30-sync-skills-cli.md
@@ -1,0 +1,514 @@
+# sync-skills CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `sync-skills` native CLI command that syncs `.skillshare/skills/` to all home targets and runs `skillshare sync` for the Copilot target, enabling fast day-to-day skill iteration without running bootstrap.
+
+**Architecture:** Bootstrap deploys a thin shell script to `~/.local/bin/sync-skills` and exports `MANIFEST_ROOT` in the shell profile. The script reads `$MANIFEST_ROOT` to locate the repo, calls `skillshare sync` (non-blocking) for the Copilot target, then runs parallel `rsync --delete` to all home targets. Bootstrap's existing `deploy_home_skills` (additive, no `--delete`) is unchanged — it handles cold install; `sync-skills` handles iteration.
+
+**Tech Stack:** Bash (`set -euo pipefail`), rsync, BATS (bats-support + bats-assert)
+
+---
+
+### Task 1: `scripts/sync-skills.sh` — source script and tests
+
+**Files:**
+- Create: `scripts/sync-skills.sh`
+- Create: `tests/bats/sync_skills.bats`
+
+- [ ] **Step 1: Create `tests/bats/sync_skills.bats` with failing tests**
+
+```bash
+#!/usr/bin/env bats
+# Tests for scripts/sync-skills.sh
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SCRIPT="$REPO_ROOT/scripts/sync-skills.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    SANDBOX=$(mktemp -d "$BATS_TMPDIR/sync_skills.XXXXXX")
+    MOCK_BIN="$SANDBOX/bin"
+    mkdir -p "$MOCK_BIN"
+
+    # Mock rsync: log every invocation, succeed
+    cat > "$MOCK_BIN/rsync" <<'STUB'
+#!/usr/bin/env bash
+echo "rsync $*" >> "$RSYNC_LOG"
+STUB
+    chmod +x "$MOCK_BIN/rsync"
+    export RSYNC_LOG="$SANDBOX/rsync.log"
+
+    # Fake manifest root with a skills source
+    export MANIFEST_ROOT="$SANDBOX/repo"
+    mkdir -p "$MANIFEST_ROOT/.skillshare/skills/demo-skill"
+    echo "body" > "$MANIFEST_ROOT/.skillshare/skills/demo-skill/SKILL.md"
+
+    # Fake home with required ~/.claude/skills target
+    export HOME="$SANDBOX/home"
+    mkdir -p "$HOME/.claude/skills"
+
+    export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown() {
+    [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+@test "exits non-zero with clear message when MANIFEST_ROOT is unset" {
+    run env -u MANIFEST_ROOT bash "$SCRIPT"
+    assert_failure
+    assert_output --partial "MANIFEST_ROOT not set"
+}
+
+@test "exits non-zero when MANIFEST_ROOT does not exist" {
+    run env MANIFEST_ROOT="/nonexistent/path" bash "$SCRIPT"
+    assert_failure
+    assert_output --partial "not found"
+}
+
+@test "exits non-zero when .skillshare/skills/ is missing" {
+    rm -rf "$MANIFEST_ROOT/.skillshare/skills"
+    run bash "$SCRIPT"
+    assert_failure
+    assert_output --partial "skills source not found"
+}
+
+@test "runs rsync to ~/.claude/skills/ when skillshare is absent" {
+    PATH="$MOCK_BIN" run bash "$SCRIPT"
+    assert_success
+    assert_output --partial "skillshare not installed"
+    grep -q ".claude/skills" "$RSYNC_LOG"
+}
+
+@test "calls skillshare sync when skillshare is on PATH" {
+    export SKILLSHARE_LOG="$SANDBOX/ss.log"
+    cat > "$MOCK_BIN/skillshare" <<'STUB'
+#!/usr/bin/env bash
+echo "skillshare $*" >> "$SKILLSHARE_LOG"
+STUB
+    chmod +x "$MOCK_BIN/skillshare"
+
+    run bash "$SCRIPT"
+    assert_success
+    grep -q "skillshare sync" "$SKILLSHARE_LOG"
+}
+
+@test "skips IDE target when directory does not exist" {
+    # ~/.cursor/skills does NOT exist under the fake HOME
+    run bash "$SCRIPT"
+    assert_success
+    if [[ -f "$RSYNC_LOG" ]]; then
+        run grep ".cursor/skills" "$RSYNC_LOG"
+        assert_failure
+    fi
+}
+
+@test "syncs IDE target when directory exists" {
+    mkdir -p "$HOME/.cursor/skills"
+    run bash "$SCRIPT"
+    assert_success
+    grep -q ".cursor/skills" "$RSYNC_LOG"
+}
+
+@test "passes --delete flag to rsync" {
+    run bash "$SCRIPT"
+    assert_success
+    grep -q -- "--delete" "$RSYNC_LOG"
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they all fail**
+
+```bash
+bats tests/bats/sync_skills.bats
+```
+
+Expected: all 8 tests fail — `scripts/sync-skills.sh` does not exist yet.
+
+- [ ] **Step 3: Create `scripts/sync-skills.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ -z "${MANIFEST_ROOT:-}" ]] && { echo "Error: MANIFEST_ROOT not set. Re-run bootstrap.sh." >&2; exit 1; }
+[[ ! -d "$MANIFEST_ROOT" ]]  && { echo "Error: MANIFEST_ROOT '$MANIFEST_ROOT' not found." >&2; exit 1; }
+
+SKILLS_SRC="$MANIFEST_ROOT/.skillshare/skills"
+[[ ! -d "$SKILLS_SRC" ]] && { echo "Error: skills source not found: $SKILLS_SRC" >&2; exit 1; }
+
+# Copilot sync via skillshare (warn and continue if not installed or fails)
+if command -v skillshare > /dev/null 2>&1; then
+    (cd "$MANIFEST_ROOT" && skillshare sync) || echo "Warning: skillshare sync failed — continuing"
+else
+    echo "Warning: skillshare not installed — skipping Copilot sync"
+fi
+
+# Home targets — parallel rsync so total time = slowest single target
+rsync -a --delete "$SKILLS_SRC/" "$HOME/.claude/skills/" &
+for dir in "$HOME/.cursor/skills" "$HOME/.gemini/skills" "$HOME/.codex/skills"; do
+    [[ -d "$dir" ]] && rsync -a --delete "$SKILLS_SRC/" "$dir/" &
+done
+wait
+```
+
+Make it executable:
+
+```bash
+chmod +x scripts/sync-skills.sh
+```
+
+- [ ] **Step 4: Run tests to confirm they all pass**
+
+```bash
+bats tests/bats/sync_skills.bats
+```
+
+Expected: all 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sync-skills.sh tests/bats/sync_skills.bats
+git commit -m "feat: add sync-skills source script and BATS tests"
+```
+
+---
+
+### Task 2: `bootstrap/lib/auth.sh` — write `MANIFEST_ROOT` to shell profile
+
+**Files:**
+- Modify: `bootstrap/lib/auth.sh` (inside `configure_shell_profile_state`, after line 253)
+- Modify: `tests/bats/deploy_skills.bats` (append two new tests)
+
+- [ ] **Step 1: Append failing tests to `tests/bats/deploy_skills.bats`**
+
+Add the following at the bottom of `tests/bats/deploy_skills.bats`:
+
+```bash
+# ── configure_shell_profile_state — MANIFEST_ROOT ───────────────────────────
+
+@test "configure_shell_profile_state writes MANIFEST_ROOT to shell profile" {
+    local fake_home="$SANDBOX/home"
+    mkdir -p "$fake_home"
+    export HOME="$fake_home"
+    export SHELL="/bin/bash"
+    export PLATFORM="linux"
+    export SCRIPT_DIR="/fake/manifest/path"
+
+    print_step()    { :; }
+    print_success() { :; }
+    print_info()    { :; }
+    print_warning() { :; }
+    print_error()   { :; }
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/auth.sh"
+    configure_shell_profile_state
+
+    grep -q 'export MANIFEST_ROOT=' "$fake_home/.bashrc"
+    grep -q '/fake/manifest/path' "$fake_home/.bashrc"
+}
+
+@test "configure_shell_profile_state updates MANIFEST_ROOT on re-run with no duplicate lines" {
+    local fake_home="$SANDBOX/home"
+    mkdir -p "$fake_home"
+    echo 'export MANIFEST_ROOT="/old/path"' > "$fake_home/.bashrc"
+    export HOME="$fake_home"
+    export SHELL="/bin/bash"
+    export PLATFORM="linux"
+    export SCRIPT_DIR="/new/path"
+
+    print_step()    { :; }
+    print_success() { :; }
+    print_info()    { :; }
+    print_warning() { :; }
+    print_error()   { :; }
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/auth.sh"
+    configure_shell_profile_state
+
+    run grep -c 'export MANIFEST_ROOT=' "$fake_home/.bashrc"
+    assert_output "1"
+    grep -q '/new/path' "$fake_home/.bashrc"
+}
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+bats tests/bats/deploy_skills.bats
+```
+
+Expected: the two new `configure_shell_profile_state` tests fail; existing tests still pass.
+
+- [ ] **Step 3: Modify `configure_shell_profile_state` in `bootstrap/lib/auth.sh`**
+
+In `bootstrap/lib/auth.sh`, directly before the closing `}` of `configure_shell_profile_state` (after line 253 — the `print_success "Added MANIFEST_STATE_ROOT..."` line), add:
+
+```bash
+    # Write MANIFEST_ROOT — always update in case bootstrap is re-run from a new path.
+    # Cross-platform safe: avoids sed -i BSD/GNU incompatibility on macOS.
+    if [[ -f "$profile_file" ]]; then
+        grep -v 'export MANIFEST_ROOT=' "$profile_file" > "${profile_file}.tmp" || true
+        mv "${profile_file}.tmp" "$profile_file"
+    fi
+    {
+        echo ""
+        echo "# Manifest repository root (managed by bootstrap.sh)"
+        echo "export MANIFEST_ROOT=\"$SCRIPT_DIR\""
+    } >> "$profile_file"
+    print_success "Updated MANIFEST_ROOT in $profile_file"
+```
+
+- [ ] **Step 4: Run tests to confirm they all pass**
+
+```bash
+bats tests/bats/deploy_skills.bats
+```
+
+Expected: all tests pass including the two new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bootstrap/lib/auth.sh tests/bats/deploy_skills.bats
+git commit -m "feat: write MANIFEST_ROOT to shell profile in configure_shell_profile_state"
+```
+
+---
+
+### Task 3: `bootstrap/lib/deploy.sh` — `deploy_sync_skills()` and wiring
+
+**Files:**
+- Modify: `bootstrap/lib/deploy.sh` (add function after `sync_skillshare_targets`, call it in both deploy paths)
+- Modify: `tests/bats/deploy_skills.bats` (add three new tests, update `deploy_configs` stub)
+
+- [ ] **Step 1: Append failing tests to `tests/bats/deploy_skills.bats`**
+
+Add the following at the bottom of `tests/bats/deploy_skills.bats`:
+
+```bash
+# ── deploy_sync_skills ───────────────────────────────────────────────────────
+
+@test "deploy_sync_skills copies script to ~/.local/bin/sync-skills and makes it executable" {
+    local fake_home="$SANDBOX/home"
+    export HOME="$fake_home"
+    mkdir -p "$fake_home"
+    local fake_profile="$SANDBOX/profile"
+    touch "$fake_profile"
+    export SHELL_PROFILE_FILE="$fake_profile"
+    export SCRIPT_DIR="$REPO_ROOT"
+
+    print_step()    { :; }
+    print_success() { :; }
+    print_info()    { :; }
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh"
+
+    run deploy_sync_skills
+    assert_success
+
+    [ -f "$fake_home/.local/bin/sync-skills" ]
+    [ -x "$fake_home/.local/bin/sync-skills" ]
+}
+
+@test "deploy_sync_skills adds ~/.local/bin to PATH in shell profile" {
+    local fake_home="$SANDBOX/home"
+    export HOME="$fake_home"
+    mkdir -p "$fake_home"
+    local fake_profile="$SANDBOX/profile"
+    touch "$fake_profile"
+    export SHELL_PROFILE_FILE="$fake_profile"
+    export SCRIPT_DIR="$REPO_ROOT"
+
+    print_step()    { :; }
+    print_success() { :; }
+    print_info()    { :; }
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh"
+
+    run deploy_sync_skills
+    assert_success
+
+    grep -q ".local/bin" "$fake_profile"
+}
+
+@test "deploy_sync_skills PATH entry is idempotent on re-run" {
+    local fake_home="$SANDBOX/home"
+    export HOME="$fake_home"
+    mkdir -p "$fake_home"
+    local fake_profile="$SANDBOX/profile"
+    touch "$fake_profile"
+    export SHELL_PROFILE_FILE="$fake_profile"
+    export SCRIPT_DIR="$REPO_ROOT"
+
+    print_step()    { :; }
+    print_success() { :; }
+    print_info()    { :; }
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh"
+
+    deploy_sync_skills
+    deploy_sync_skills  # second run — must not duplicate the PATH line
+
+    run grep -c ".local/bin" "$fake_profile"
+    assert_output "1"
+}
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+bats tests/bats/deploy_skills.bats
+```
+
+Expected: the three new `deploy_sync_skills` tests fail; all existing tests still pass.
+
+- [ ] **Step 3: Add `deploy_sync_skills()` to `bootstrap/lib/deploy.sh`**
+
+Add the following function directly after the closing `}` of `sync_skillshare_targets` (after line ~242):
+
+```bash
+# Deploy sync-skills CLI to ~/.local/bin/ and ensure it is on PATH.
+# Depends on SHELL_PROFILE_FILE being set by configure_shell_profile_state.
+deploy_sync_skills() {
+    print_step "Deploying sync-skills CLI..."
+    mkdir -p "$HOME/.local/bin"
+    cp "$SCRIPT_DIR/scripts/sync-skills.sh" "$HOME/.local/bin/sync-skills"
+    chmod +x "$HOME/.local/bin/sync-skills"
+
+    if ! grep -Fq ".local/bin" "$SHELL_PROFILE_FILE" 2>/dev/null; then
+        {
+            echo ""
+            echo "# ~/.local/bin for user-installed tools (managed by bootstrap.sh)"
+            echo 'export PATH="$HOME/.local/bin:$PATH"'
+        } >> "$SHELL_PROFILE_FILE"
+    fi
+
+    # Update PATH for the current bootstrap session (PATH Catch-22: profile not
+    # sourced until next terminal open, but the user may run sync-skills right away).
+    export PATH="$HOME/.local/bin:$PATH"
+
+    print_success "Deployed sync-skills to $HOME/.local/bin/sync-skills"
+}
+```
+
+- [ ] **Step 4: Run the three new tests to confirm they pass**
+
+```bash
+bats tests/bats/deploy_skills.bats
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Wire `deploy_sync_skills` into both deploy paths**
+
+In `bootstrap/lib/deploy.sh`, add a `deploy_sync_skills` call after each `sync_skillshare_targets` call.
+
+**Merge path** (around line 56 — the `2)` merge case, just before `return 0`):
+
+```bash
+                    sync_skillshare_targets
+                    deploy_sync_skills
+                    return 0
+```
+
+**Fresh-install path** (around line 112 — after the Copilot sync comment block):
+
+```bash
+    # Project-scoped Copilot sync (non-blocking)
+    sync_skillshare_targets
+
+    # Deploy sync-skills CLI
+    deploy_sync_skills
+```
+
+- [ ] **Step 6: Update the `deploy_configs (fresh)` test stub in `tests/bats/deploy_skills.bats`**
+
+In the existing `@test "deploy_configs (fresh) puts real skill dirs in TARGET and no '~' junk"` test, add `deploy_sync_skills() { :; }` alongside the other stubs:
+
+```bash
+    write_services_config() { :; }
+    deploy_cursor_configs() { :; }
+    deploy_gemini_configs() { :; }
+    deploy_codex_configs() { :; }
+    deploy_antigravity_configs() { :; }
+    sync_skillshare_targets() { :; }
+    deploy_sync_skills() { :; }
+```
+
+- [ ] **Step 7: Run the full BATS suite to confirm nothing regressed**
+
+```bash
+bats tests/bats/
+```
+
+Expected: all tests pass. Count should be prior count + 5 new tests (2 auth + 3 deploy).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add bootstrap/lib/deploy.sh tests/bats/deploy_skills.bats
+git commit -m "feat: add deploy_sync_skills() and wire into bootstrap deploy paths"
+```
+
+---
+
+### Task 4: Integration smoke test
+
+- [ ] **Step 1: Re-run bootstrap to pick up all three changes**
+
+```bash
+./bootstrap.sh --skip-install --skip-auth
+```
+
+Expected: output includes "Updated MANIFEST_ROOT in ~/.zshrc" and "Deployed sync-skills to ~/.local/bin/sync-skills".
+
+- [ ] **Step 2: Confirm `MANIFEST_ROOT` is in shell profile with no duplicates**
+
+```bash
+grep "MANIFEST_ROOT" ~/.zshrc   # or ~/.bashrc / ~/.bash_profile
+```
+
+Expected: exactly one line, e.g. `export MANIFEST_ROOT="/Users/.../Manifest"`.
+
+- [ ] **Step 3: Confirm `sync-skills` is deployed and executable**
+
+```bash
+ls -la ~/.local/bin/sync-skills
+```
+
+Expected: file exists with execute bit set.
+
+- [ ] **Step 4: Source the shell profile and run `sync-skills` from a different directory**
+
+```bash
+source ~/.zshrc   # or ~/.bashrc
+cd /tmp
+sync-skills
+```
+
+Expected: runs without error, syncs skills to `~/.claude/skills/`, warns if skillshare is not installed, exits 0.
+
+- [ ] **Step 5: Verify `~/.claude/skills/` was updated**
+
+```bash
+ls ~/.claude/skills/
+```
+
+Expected: skill directories match `.skillshare/skills/` contents.
+
+- [ ] **Step 6: Push to remote**
+
+```bash
+git push
+```

--- a/docs/superpowers/specs/2026-05-30-sync-skills-cli-design.md
+++ b/docs/superpowers/specs/2026-05-30-sync-skills-cli-design.md
@@ -1,0 +1,187 @@
+# sync-skills CLI Design
+
+**Date:** 2026-05-30
+**Status:** Approved
+**Scope:** Developer-workflow skill sync — `sync-skills` native CLI command
+
+---
+
+## Problem
+
+Adding or editing a skill in `.skillshare/skills/` currently requires running `./bootstrap.sh`
+to push the change to `~/.claude/skills/` and other home targets. Bootstrap is a full machine
+provisioning tool; it is too heavy for a daily edit→sync loop. Developers need a fast,
+globally-accessible command that syncs skills without re-running bootstrap.
+
+---
+
+## Goal
+
+A native CLI command (`sync-skills`) available from any directory that:
+
+1. Syncs `.skillshare/skills/` to all home targets (`~/.claude/`, `~/.cursor/`, `~/.gemini/`,
+   `~/.codex/`).
+2. Also runs `skillshare sync` for the project-scoped Copilot target (`.github/skills/`).
+3. Requires no manual maintenance of the rsync logic — skillshare is the known application;
+   rsync is the implementation detail inside a thin wrapper.
+
+---
+
+## Architecture
+
+```
+Manifest repo
+└── scripts/sync-skills.sh        ← source (new file)
+
+Bootstrap
+├── bootstrap/lib/auth.sh         ← extend configure_shell_profile_state
+│                                    to write MANIFEST_ROOT export
+└── bootstrap/lib/deploy.sh       ← add deploy_sync_skills()
+                                     copies script + ensures ~/.local/bin on PATH
+
+Runtime (after bootstrap)
+└── ~/.local/bin/sync-skills      ← deployed executable, runs from anywhere
+```
+
+**Data flow:**
+
+```
+edit .skillshare/skills/my-skill/SKILL.md
+          ↓
+sync-skills  (any directory)
+          ↓  reads $MANIFEST_ROOT, cd to repo
+          ├── skillshare sync    →  .github/skills/      (Copilot)
+          └── rsync ×1–4        →  ~/.claude/skills/     (always)
+                                   ~/.cursor/skills/      (if dir exists)
+                                   ~/.gemini/skills/      (if dir exists)
+                                   ~/.codex/skills/       (if dir exists)
+```
+
+Antigravity is covered automatically — bootstrap creates `~/.antigravity/skills` as a symlink
+to `~/.claude/skills/`, so it inherits every rsync update without a separate target.
+
+**Relationship to bootstrap:** `deploy_home_skills` in bootstrap remains for cold install (additive,
+no `--delete` — safe when merging into an existing home dir). `sync-skills` uses `--delete` because
+it is designed for iteration: if a skill is removed from the repo, it should disappear from all
+targets.
+
+---
+
+## Components
+
+### `scripts/sync-skills.sh` (new)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ -z "${MANIFEST_ROOT:-}" ]] && { echo "Error: MANIFEST_ROOT not set. Re-run bootstrap.sh." >&2; exit 1; }
+[[ ! -d "$MANIFEST_ROOT" ]]  && { echo "Error: MANIFEST_ROOT '$MANIFEST_ROOT' not found." >&2; exit 1; }
+
+SKILLS_SRC="$MANIFEST_ROOT/.skillshare/skills"
+[[ ! -d "$SKILLS_SRC" ]] && { echo "Error: skills source not found: $SKILLS_SRC" >&2; exit 1; }
+
+# Copilot sync via skillshare (warn and continue if not installed)
+if command -v skillshare > /dev/null 2>&1; then
+    (cd "$MANIFEST_ROOT" && skillshare sync) || echo "Warning: skillshare sync failed — continuing"
+else
+    echo "Warning: skillshare not installed — skipping Copilot sync"
+fi
+
+# Home targets — parallel rsync so total time = slowest single target
+rsync -a --delete "$SKILLS_SRC/" "$HOME/.claude/skills/" &
+for dir in "$HOME/.cursor/skills" "$HOME/.gemini/skills" "$HOME/.codex/skills"; do
+    [[ -d "$dir" ]] && rsync -a --delete "$SKILLS_SRC/" "$dir/" &
+done
+wait
+```
+
+Key decisions:
+- `~/.claude/skills/` is always synced; IDE targets only if the directory exists.
+- `--delete` propagates skill removals. Bootstrap's `deploy_home_skills` stays additive.
+- Parallel `&` + `wait` bounds total time to the slowest single target.
+- `skillshare sync` runs in a subshell so the calling script's `cwd` is never changed.
+
+### `bootstrap/lib/auth.sh` — extend `configure_shell_profile_state`
+
+Add `MANIFEST_ROOT` export after the existing `MANIFEST_STATE_ROOT` block. Unlike
+`MANIFEST_STATE_ROOT` (which has a safe per-machine default), `MANIFEST_ROOT` must store the
+actual checkout path and must be updated if bootstrap is re-run from a different location.
+
+Cross-platform safe update (avoids `sed -i` BSD/GNU incompatibility on macOS):
+
+```bash
+# Remove any existing MANIFEST_ROOT line, then append current path
+if [[ -f "$profile_file" ]]; then
+    grep -v 'export MANIFEST_ROOT=' "$profile_file" > "${profile_file}.tmp" || true
+    mv "${profile_file}.tmp" "$profile_file"
+fi
+echo "export MANIFEST_ROOT=\"$SCRIPT_DIR\"" >> "$profile_file"
+```
+
+### `bootstrap/lib/deploy.sh` — add `deploy_sync_skills()`
+
+Called at the end of `deploy_configs` (after `sync_skillshare_targets`). Depends on
+`SHELL_PROFILE_FILE` being set, which `configure_shell_profile_state` in `auth.sh` already
+provides — bootstrap calls that function before `deploy_configs`.
+
+```bash
+deploy_sync_skills() {
+    print_step "Deploying sync-skills CLI..."
+    mkdir -p "$HOME/.local/bin"
+    cp "$SCRIPT_DIR/scripts/sync-skills.sh" "$HOME/.local/bin/sync-skills"
+    chmod +x "$HOME/.local/bin/sync-skills"
+
+    # Ensure ~/.local/bin is on PATH in shell profile (idempotent)
+    if ! grep -Fq ".local/bin" "$SHELL_PROFILE_FILE" 2>/dev/null; then
+        {
+            echo ""
+            echo "# ~/.local/bin for user-installed tools (managed by bootstrap.sh)"
+            echo 'export PATH="$HOME/.local/bin:$PATH"'
+        } >> "$SHELL_PROFILE_FILE"
+    fi
+
+    # Fix PATH for the current bootstrap session (PATH Catch-22)
+    export PATH="$HOME/.local/bin:$PATH"
+
+    print_success "Deployed sync-skills to $HOME/.local/bin/sync-skills"
+}
+```
+
+---
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| `MANIFEST_ROOT` not set | Fatal error with re-run hint |
+| `MANIFEST_ROOT` path missing | Fatal error with path in message |
+| `.skillshare/skills/` missing | Fatal error |
+| `skillshare` not installed | Warning, skip Copilot sync, continue |
+| `skillshare sync` fails | Warning, continue with home targets |
+| IDE target dir missing | Skip silently (`[[ -d ]]` guard) |
+| `~/.claude/skills/` missing | rsync creates it |
+
+---
+
+## Testing
+
+New BATS tests in `tests/bats/`:
+
+- `sync-skills.sh` exits non-zero and prints a clear error when `MANIFEST_ROOT` is unset.
+- `sync-skills.sh` exits non-zero when `MANIFEST_ROOT` points to a non-existent directory.
+- `sync-skills.sh` runs rsync home targets when `skillshare` is not on PATH.
+- `configure_shell_profile_state` writes `MANIFEST_ROOT` to the shell profile.
+- `configure_shell_profile_state` updates `MANIFEST_ROOT` on re-run with a new path (no duplicate lines).
+- `deploy_sync_skills` copies script to `~/.local/bin/sync-skills` and makes it executable.
+- `deploy_sync_skills` adds `~/.local/bin` to PATH in shell profile (idempotent).
+
+---
+
+## Out of Scope
+
+- Windows support (bootstrap is macOS/Linux only).
+- `sync-skills` managing bootstrap's initial cold-install (`deploy_home_skills` owns that).
+- Parallelising `skillshare sync` with the rsync targets (skillshare must run from
+  `$MANIFEST_ROOT`; the rsync targets are independent — mixing them adds complexity for
+  minimal gain).

--- a/tests/bats/deploy_skills.bats
+++ b/tests/bats/deploy_skills.bats
@@ -85,6 +85,7 @@ teardown() {
     deploy_codex_configs() { :; }
     deploy_antigravity_configs() { :; }
     sync_skillshare_targets() { :; }
+    deploy_sync_skills() { :; }
 
     run deploy_configs
     assert_success
@@ -198,4 +199,74 @@ STUB
     run grep -c 'export MANIFEST_ROOT=' "$fake_home/.bashrc"
     assert_output "1"
     grep -q '/new/path' "$fake_home/.bashrc"
+}
+
+# ── deploy_sync_skills ───────────────────────────────────────────────────────
+
+@test "deploy_sync_skills copies script to ~/.local/bin/sync-skills and makes it executable" {
+    local fake_home="$SANDBOX/home"
+    export HOME="$fake_home"
+    mkdir -p "$fake_home"
+    local fake_profile="$SANDBOX/profile"
+    touch "$fake_profile"
+    export SHELL_PROFILE_FILE="$fake_profile"
+    export SCRIPT_DIR="$REPO_ROOT"
+
+    print_step()    { :; }
+    print_success() { :; }
+    print_info()    { :; }
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh"
+
+    run deploy_sync_skills
+    assert_success
+
+    [ -f "$fake_home/.local/bin/sync-skills" ]
+    [ -x "$fake_home/.local/bin/sync-skills" ]
+}
+
+@test "deploy_sync_skills adds ~/.local/bin to PATH in shell profile" {
+    local fake_home="$SANDBOX/home"
+    export HOME="$fake_home"
+    mkdir -p "$fake_home"
+    local fake_profile="$SANDBOX/profile"
+    touch "$fake_profile"
+    export SHELL_PROFILE_FILE="$fake_profile"
+    export SCRIPT_DIR="$REPO_ROOT"
+
+    print_step()    { :; }
+    print_success() { :; }
+    print_info()    { :; }
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh"
+
+    run deploy_sync_skills
+    assert_success
+
+    grep -q ".local/bin" "$fake_profile"
+}
+
+@test "deploy_sync_skills PATH entry is idempotent on re-run" {
+    local fake_home="$SANDBOX/home"
+    export HOME="$fake_home"
+    mkdir -p "$fake_home"
+    local fake_profile="$SANDBOX/profile"
+    touch "$fake_profile"
+    export SHELL_PROFILE_FILE="$fake_profile"
+    export SCRIPT_DIR="$REPO_ROOT"
+
+    print_step()    { :; }
+    print_success() { :; }
+    print_info()    { :; }
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh"
+
+    deploy_sync_skills
+    deploy_sync_skills  # second run — must not duplicate the PATH line
+
+    run grep -c ".local/bin" "$fake_profile"
+    assert_output "1"
 }

--- a/tests/bats/deploy_skills.bats
+++ b/tests/bats/deploy_skills.bats
@@ -152,3 +152,51 @@ STUB
     assert_success
     assert_output --partial "skipping"
 }
+
+# ── configure_shell_profile_state — MANIFEST_ROOT ───────────────────────────
+
+@test "configure_shell_profile_state writes MANIFEST_ROOT to shell profile" {
+    local fake_home="$SANDBOX/home"
+    mkdir -p "$fake_home"
+    export HOME="$fake_home"
+    export SHELL="/bin/bash"
+    export PLATFORM="linux"
+    export SCRIPT_DIR="/fake/manifest/path"
+
+    print_step()    { :; }
+    print_success() { :; }
+    print_info()    { :; }
+    print_warning() { :; }
+    print_error()   { :; }
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/auth.sh"
+    configure_shell_profile_state
+
+    grep -q 'export MANIFEST_ROOT=' "$fake_home/.bashrc"
+    grep -q '/fake/manifest/path' "$fake_home/.bashrc"
+}
+
+@test "configure_shell_profile_state updates MANIFEST_ROOT on re-run with no duplicate lines" {
+    local fake_home="$SANDBOX/home"
+    mkdir -p "$fake_home"
+    echo 'export MANIFEST_ROOT="/old/path"' > "$fake_home/.bashrc"
+    export HOME="$fake_home"
+    export SHELL="/bin/bash"
+    export PLATFORM="linux"
+    export SCRIPT_DIR="/new/path"
+
+    print_step()    { :; }
+    print_success() { :; }
+    print_info()    { :; }
+    print_warning() { :; }
+    print_error()   { :; }
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/auth.sh"
+    configure_shell_profile_state
+
+    run grep -c 'export MANIFEST_ROOT=' "$fake_home/.bashrc"
+    assert_output "1"
+    grep -q '/new/path' "$fake_home/.bashrc"
+}

--- a/tests/bats/deploy_skills.bats
+++ b/tests/bats/deploy_skills.bats
@@ -267,6 +267,6 @@ STUB
     deploy_sync_skills
     deploy_sync_skills  # second run — must not duplicate the PATH line
 
-    run grep -c ".local/bin" "$fake_profile"
+    run grep -c 'export PATH="$HOME/.local/bin:$PATH"' "$fake_profile"
     assert_output "1"
 }

--- a/tests/bats/deploy_skills.bats
+++ b/tests/bats/deploy_skills.bats
@@ -173,8 +173,7 @@ STUB
     source "$REPO_ROOT/bootstrap/lib/auth.sh"
     configure_shell_profile_state
 
-    grep -q 'export MANIFEST_ROOT=' "$fake_home/.bashrc"
-    grep -q '/fake/manifest/path' "$fake_home/.bashrc"
+    grep -q 'export MANIFEST_ROOT="/fake/manifest/path"' "$fake_home/.bashrc"
 }
 
 @test "configure_shell_profile_state updates MANIFEST_ROOT on re-run with no duplicate lines" {

--- a/tests/bats/sync_skills.bats
+++ b/tests/bats/sync_skills.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+# Tests for configs/claude/scripts/sync-skills.sh
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SCRIPT="$REPO_ROOT/configs/claude/scripts/sync-skills.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    SANDBOX=$(mktemp -d "$BATS_TMPDIR/sync_skills.XXXXXX")
+    MOCK_BIN="$SANDBOX/bin"
+    mkdir -p "$MOCK_BIN"
+
+    # Mock rsync: log every invocation, succeed
+    cat > "$MOCK_BIN/rsync" <<'STUB'
+#!/usr/bin/env bash
+echo "rsync $*" >> "$RSYNC_LOG"
+STUB
+    chmod +x "$MOCK_BIN/rsync"
+    export RSYNC_LOG="$SANDBOX/rsync.log"
+
+    # Fake manifest root with a skills source
+    export MANIFEST_ROOT="$SANDBOX/repo"
+    mkdir -p "$MANIFEST_ROOT/.skillshare/skills/demo-skill"
+    echo "body" > "$MANIFEST_ROOT/.skillshare/skills/demo-skill/SKILL.md"
+
+    # Fake home with required ~/.claude/skills target
+    export HOME="$SANDBOX/home"
+    mkdir -p "$HOME/.claude/skills"
+
+    export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown() {
+    [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+@test "exits non-zero with clear message when MANIFEST_ROOT is unset" {
+    run env -u MANIFEST_ROOT bash "$SCRIPT"
+    assert_failure
+    assert_output --partial "MANIFEST_ROOT not set"
+}
+
+@test "exits non-zero when MANIFEST_ROOT does not exist" {
+    run env MANIFEST_ROOT="/nonexistent/path" bash "$SCRIPT"
+    assert_failure
+    assert_output --partial "not found"
+}
+
+@test "exits non-zero when .skillshare/skills/ is missing" {
+    rm -rf "$MANIFEST_ROOT/.skillshare/skills"
+    run bash "$SCRIPT"
+    assert_failure
+    assert_output --partial "skills source not found"
+}
+
+@test "runs rsync to ~/.claude/skills/ when skillshare is absent" {
+    # Use minimal PATH that excludes system skillshare
+    PATH="$MOCK_BIN:/usr/bin:/bin" run bash "$SCRIPT"
+    assert_success
+    assert_output --partial "skillshare not installed"
+    grep -q ".claude/skills" "$RSYNC_LOG"
+}
+
+@test "calls skillshare sync when skillshare is on PATH" {
+    export SKILLSHARE_LOG="$SANDBOX/ss.log"
+    cat > "$MOCK_BIN/skillshare" <<'STUB'
+#!/usr/bin/env bash
+echo "skillshare $*" >> "$SKILLSHARE_LOG"
+STUB
+    chmod +x "$MOCK_BIN/skillshare"
+
+    run bash "$SCRIPT"
+    assert_success
+    grep -q "skillshare sync" "$SKILLSHARE_LOG"
+}
+
+@test "skips IDE target when directory does not exist" {
+    # ~/.cursor/skills does NOT exist under the fake HOME
+    run bash "$SCRIPT"
+    assert_success
+    if [[ -f "$RSYNC_LOG" ]]; then
+        run grep ".cursor/skills" "$RSYNC_LOG"
+        assert_failure
+    fi
+}
+
+@test "syncs IDE target when directory exists" {
+    mkdir -p "$HOME/.cursor/skills"
+    run bash "$SCRIPT"
+    assert_success
+    grep -q ".cursor/skills" "$RSYNC_LOG"
+}
+
+@test "passes --delete flag to rsync" {
+    run bash "$SCRIPT"
+    assert_success
+    grep -q -- "--delete" "$RSYNC_LOG"
+}

--- a/tests/bats/sync_skills.bats
+++ b/tests/bats/sync_skills.bats
@@ -57,7 +57,8 @@ teardown() {
 }
 
 @test "runs rsync to ~/.claude/skills/ when skillshare is absent" {
-    # Use minimal PATH that excludes system skillshare
+    # Use restricted PATH that excludes Homebrew (/usr/local/bin, /opt/homebrew/bin)
+    # to ensure skillshare is not found and the "not installed" path is tested
     PATH="$MOCK_BIN:/usr/bin:/bin" run bash "$SCRIPT"
     assert_success
     assert_output --partial "skillshare not installed"


### PR DESCRIPTION
## Summary

- Adds `sync-skills` CLI command deployed to `~/.local/bin/sync-skills` via bootstrap
- Exports `MANIFEST_ROOT` to shell profile so the command locates the repo from any directory
- `sync-skills` calls `skillshare sync` (Copilot target) then parallel `rsync --delete` to `~/.claude/skills/` and available IDE targets (`~/.cursor/`, `~/.gemini/`, `~/.codex/`)
- Bootstrap's `deploy_home_skills` (additive, no `--delete`) unchanged — handles cold install; `sync-skills` handles day-to-day iteration
- rsync failures are PID-tracked: `~/.claude/skills/` failure is fatal, IDE target failures are warnings

## Test Plan

- [ ] `npx bats tests/bats/` — 117 tests pass
- [ ] `./bootstrap.sh --skip-install --skip-auth --force` — output includes "Updated MANIFEST_ROOT" and "Deployed sync-skills to ~/.local/bin/sync-skills"
- [ ] `grep MANIFEST_ROOT ~/.zshrc` — exactly one line with the repo path
- [ ] `ls -la ~/.local/bin/sync-skills` — file exists, executable
- [ ] `source ~/.zshrc && cd /tmp && sync-skills` — runs from outside the repo, syncs skills, exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)