### PR TITLE
fix: manifest housekeeping — docs, CI drift guard, and test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,3 +225,14 @@ jobs:
           fi
 
           echo "Structure validation passed: $SKILL_COUNT skills, $SCRIPT_COUNT scripts"
+
+      - name: Verify Cursor rules are up-to-date with skills
+        run: |
+          bash configs/claude/scripts/generate_cursor_rules.sh
+          if ! git diff --exit-code configs/cursor/rules/; then
+            echo ""
+            echo "FAIL: Cursor rules are out of sync with skills."
+            echo "Run 'configs/claude/scripts/generate_cursor_rules.sh' and commit the result."
+            exit 1
+          fi
+          echo "Cursor rules are up-to-date"

--- a/.skillshare/skills/health-check/SKILL.md
+++ b/.skillshare/skills/health-check/SKILL.md
@@ -10,6 +10,11 @@ description: |
 Run a comprehensive diagnostic of the Manifest agent environment to detect
 misconfiguration, missing tools, broken symlinks, or authentication issues.
 
+> **Scope note:** This skill covers config syntax, MCP connectivity, symlinks,
+> labels, and script executability. For a quick terminal check of parallel
+> orchestration readiness (enabled agents, state directories), run:
+> `~/.claude/scripts/check_status.sh` (also available as `parallel_agent.py --status`).
+
 ## Checks
 
 Execute each check category below. Collect results into a summary table.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,7 @@ The following slash commands are available in Claude Code:
 | `/issue-triage` | Linear issue audit: duplicates, staleness, priority validation | CONDITIONAL (scenario-based) |
 | `/plan-manage` | Plan lifecycle with parallel agent orchestration for create/review | CONDITIONAL |
 | `/browser-test` | AI-powered E2E browser testing via browser-use YAML test prompts | CONDITIONAL |
+| `sync-skills` | Sync .skillshare/skills/ to all home targets (daily skill dev workflow) | NO |
 
 ## Testing Changes
 

--- a/configs/claude/CLAUDE.md
+++ b/configs/claude/CLAUDE.md
@@ -149,6 +149,7 @@ These integrate with the parallel agent orchestration framework.
 | `/checkpoint` | Create compact checkpoint summary when context usage is high | NO |
 | `/health-check` | Verify CLI tools, auth, config syntax, MCP, symlinks | NO |
 | `/sync-configs` | Detect cross-platform config drift and broken symlinks | NO |
+| `/sync-skills` | Sync .skillshare/skills/ to all home targets (daily skill dev workflow) | NO |
 
 ### Command Usage
 
@@ -176,6 +177,9 @@ These integrate with the parallel agent orchestration framework.
 
 # Context management
 /checkpoint                  # Save session state when context is high
+
+# Skill sync (daily dev workflow)
+sync-skills                  # Push .skillshare/skills/ changes to all home targets
 ```
 
 ### Auto-Triggered Skill

--- a/configs/claude/scripts/check_status.sh
+++ b/configs/claude/scripts/check_status.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
-# System Health Check for Parallel Agent Orchestration
+# Parallel Agent Orchestration Readiness Check
 # Usage: ./check_status.sh [--verbose]
+#
+# Scope: services.yml enabled agents, CLI availability, auth, Codex session
+#        storage, and Manifest state directories.  Reports whether the system
+#        has enough agents ready for parallel orchestration.
+#
+# Also invoked by: parallel_agent.py --status
+#
+# For full environment audit (MCP, symlinks, config syntax, labels):
+#   use the /health-check skill in Claude Code.
 
 # Colors
 GREEN='\033[0;32m'

--- a/configs/cursor/rules/a11y-audit.mdc
+++ b/configs/cursor/rules/a11y-audit.mdc
@@ -12,3 +12,4 @@ Focused accessibility audit against WCAG 2.2 AA standards. Checks ARIA best prac
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/a11y-audit/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/ai-hooks-integration.mdc
+++ b/configs/cursor/rules/ai-hooks-integration.mdc
@@ -12,3 +12,4 @@ Integrate lifecycle hooks across AI coding tools (Claude Code, Gemini CLI, Curso
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/ai-hooks-integration/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/antipattern-detect.mdc
+++ b/configs/cursor/rules/antipattern-detect.mdc
@@ -1,14 +1,15 @@
 ---
-description: "Auto-triggered skill that analyzes linting failures, test results, and code review feedback to detect recurring antipatterns. Stores findings in docs/KNOWLEDGE_BASE.md for team-wide visibility."
+description: "Auto-triggered skill that analyzes linting failures, test results, and code review feedback to detect recurring antipatterns. Stores findings in knowledge_base.yml (YAML source of truth) via learning_capture.sh."
 globs: ".claude/skills/antipattern-detect/**"
 alwaysApply: false
 ---
 
 # antipattern-detect
 
-Auto-triggered skill that analyzes linting failures, test results, and code review feedback to detect recurring antipatterns. Stores findings in docs/KNOWLEDGE_BASE.md for team-wide visibility.
+Auto-triggered skill that analyzes linting failures, test results, and code review feedback to detect recurring antipatterns. Stores findings in knowledge_base.yml (YAML source of truth) via learning_capture.sh.
 
 <!-- Auto-generated from .claude/skills/antipattern-detect/SKILL.md -->
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/antipattern-detect/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/browser-test.mdc
+++ b/configs/cursor/rules/browser-test.mdc
@@ -12,3 +12,4 @@ Create, update, and manage browser-use YAML test prompts for E2E browser testing
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/browser-test/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/checkpoint.mdc
+++ b/configs/cursor/rules/checkpoint.mdc
@@ -12,3 +12,4 @@ Create a compact checkpoint summary of the current session so work can continue 
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/checkpoint/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/ci-setup.mdc
+++ b/configs/cursor/rules/ci-setup.mdc
@@ -12,3 +12,4 @@ Configure CI/CD pipelines for a target repository based on detected languages, p
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/ci-setup/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/code-quality.mdc
+++ b/configs/cursor/rules/code-quality.mdc
@@ -12,3 +12,4 @@ Auto-trigger when detecting security-sensitive code (auth, crypto, secrets, inpu
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/code-quality/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/dashboard.mdc
+++ b/configs/cursor/rules/dashboard.mdc
@@ -12,3 +12,4 @@ Visualize agent efficiency metrics: task completion rates, common error patterns
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/dashboard/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/docs-diagrams.mdc
+++ b/configs/cursor/rules/docs-diagrams.mdc
@@ -12,3 +12,4 @@ Generate and maintain Mermaid architecture diagrams that reflect current system 
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/docs-diagrams/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/docs-improve.mdc
+++ b/configs/cursor/rules/docs-improve.mdc
@@ -12,3 +12,4 @@ Audit and improve project documentation using Diataxis and documentation quality
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/docs-improve/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/docs-readme.mdc
+++ b/configs/cursor/rules/docs-readme.mdc
@@ -12,3 +12,4 @@ Analyze and improve repository README documentation using code-derived facts, cl
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/docs-readme/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/health-check.mdc
+++ b/configs/cursor/rules/health-check.mdc
@@ -12,3 +12,4 @@ Verify CLI tool availability, authentication status, config syntax, MCP connecti
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/health-check/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/issue-prioritize.mdc
+++ b/configs/cursor/rules/issue-prioritize.mdc
@@ -12,3 +12,4 @@ Fetch open issues from GitHub, GitLab, or Linear, score them by impact/urgency/r
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/issue-prioritize/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/issue-triage.mdc
+++ b/configs/cursor/rules/issue-triage.mdc
@@ -12,3 +12,4 @@ Comprehensive Linear issue audit: validate prioritization, identify duplicates a
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/issue-triage/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/learning-loop.mdc
+++ b/configs/cursor/rules/learning-loop.mdc
@@ -12,3 +12,4 @@ Capture structured lessons learned after major tasks. Categories: pattern, antip
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/learning-loop/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/performance-check.mdc
+++ b/configs/cursor/rules/performance-check.mdc
@@ -12,3 +12,4 @@ Frontend performance audit: bundle size analysis, Core Web Vitals targets, lazy 
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/performance-check/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/plan-manage.mdc
+++ b/configs/cursor/rules/plan-manage.mdc
@@ -12,3 +12,4 @@ Manage plan lifecycle in .claude/.plans with create, review, execute, archive, a
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/plan-manage/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/project-commit.mdc
+++ b/configs/cursor/rules/project-commit.mdc
@@ -12,3 +12,4 @@ Run the end-to-end commit pipeline: docs refresh, sync with remote, checks, stag
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/project-commit/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/refactor-go.mdc
+++ b/configs/cursor/rules/refactor-go.mdc
@@ -12,3 +12,4 @@ Perform security, architecture, and quality analysis for Go codebases and return
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/refactor-go/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/refactor-node.mdc
+++ b/configs/cursor/rules/refactor-node.mdc
@@ -12,3 +12,4 @@ Perform security, architecture, and quality analysis for Node.js/TypeScript code
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/refactor-node/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/refactor-python.mdc
+++ b/configs/cursor/rules/refactor-python.mdc
@@ -12,3 +12,4 @@ Perform security, architecture, and quality analysis for Python codebases and re
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/refactor-python/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/refactor-shell.mdc
+++ b/configs/cursor/rules/refactor-shell.mdc
@@ -12,3 +12,4 @@ Perform security and quality analysis for Bash/Shell scripts and produce a prior
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/refactor-shell/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/refactor-terraform.mdc
+++ b/configs/cursor/rules/refactor-terraform.mdc
@@ -12,3 +12,4 @@ Perform security, modularity, and quality analysis for Terraform/OpenTofu IaC co
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/refactor-terraform/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/scaffold.mdc
+++ b/configs/cursor/rules/scaffold.mdc
@@ -12,3 +12,4 @@ Initialize new projects with language-specific quality gates, linting configs, t
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/scaffold/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/sync-configs.mdc
+++ b/configs/cursor/rules/sync-configs.mdc
@@ -12,3 +12,4 @@ Verify cross-platform configuration consistency, check symlink integrity, and de
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/sync-configs/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/token-economy.mdc
+++ b/configs/cursor/rules/token-economy.mdc
@@ -12,3 +12,4 @@ Switch the current session into terse, surgical, clarify-first mode to cut token
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/token-economy/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/ux-review.mdc
+++ b/configs/cursor/rules/ux-review.mdc
@@ -12,3 +12,4 @@ Automated UX audit covering accessibility (WCAG 2.2), responsive design, perform
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/ux-review/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/verify.mdc
+++ b/configs/cursor/rules/verify.mdc
@@ -12,3 +12,4 @@ Run linters, unit tests, and security scans in parallel for a target project. Au
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
 
 Refer to `.cursor/skills/verify/SKILL.md` for the full skill definition.
+

--- a/tests/python/test_parallel_agent.py
+++ b/tests/python/test_parallel_agent.py
@@ -698,3 +698,52 @@ class TestDefaultConfigCodex:
         fallback = config.get("credit_fallback.codex")
         assert fallback is not None
         assert fallback == ["advanced", "flash", "mini"]
+
+
+# ---------------------------------------------------------------------------
+# File existence validation tests (--review / --analyze / --improve)
+# ---------------------------------------------------------------------------
+
+
+class TestFileExistenceValidation:
+    """Test that --review, --analyze, and --improve fail fast on missing files."""
+
+    SCRIPT = str(REPO_ROOT / "configs" / "claude" / "scripts" / "parallel_agent.py")
+
+    def _run(self, flag: str, path: str):
+        import subprocess
+        return subprocess.run(
+            [sys.executable, self.SCRIPT, flag, path],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_review_nonexistent_file_exits_nonzero(self, tmp_path):
+        """--review with a missing file must exit 1 before contacting any agent."""
+        result = self._run("--review", str(tmp_path / "missing.py"))
+        assert result.returncode == 1
+
+    def test_review_nonexistent_file_prints_error(self, tmp_path):
+        """--review with a missing file must print an error message to stderr."""
+        result = self._run("--review", str(tmp_path / "missing.py"))
+        assert "file not found" in result.stderr.lower() or "error" in result.stderr.lower()
+
+    def test_analyze_nonexistent_file_exits_nonzero(self, tmp_path):
+        """--analyze with a missing file must exit 1 before contacting any agent."""
+        result = self._run("--analyze", str(tmp_path / "missing.py"))
+        assert result.returncode == 1
+
+    def test_analyze_nonexistent_file_prints_error(self, tmp_path):
+        """--analyze with a missing file must print an error message to stderr."""
+        result = self._run("--analyze", str(tmp_path / "missing.py"))
+        assert "file not found" in result.stderr.lower() or "error" in result.stderr.lower()
+
+    def test_improve_nonexistent_file_exits_nonzero(self, tmp_path):
+        """--improve with a missing file must exit 1 before contacting any agent."""
+        result = self._run("--improve", str(tmp_path / "missing.py"))
+        assert result.returncode == 1
+
+    def test_improve_nonexistent_file_prints_error(self, tmp_path):
+        """--improve with a missing file must print an error message to stderr."""
+        result = self._run("--improve", str(tmp_path / "missing.py"))
+        assert "file not found" in result.stderr.lower() or "error" in result.stderr.lower()


### PR DESCRIPTION
## Summary

- **`sync-skills` documented** — added to skills tables and usage blocks in both `configs/claude/CLAUDE.md` and `CLAUDE.md`; was shipped in #258 but never surfaced in docs
- **CI Cursor rules drift guard** — `validate` job now runs `generate_cursor_rules.sh` and fails if any `.mdc` would change, preventing silent skill/rule divergence
- **Python tests for file-existence validation** — 6 new pytest cases (`TestFileExistenceValidation`) covering `--review`, `--analyze`, and `--improve` exit-1 behavior on missing files; the fix landed in #257 with no test coverage
- **`check_status.sh` vs `/health-check` scope clarified** — audit showed consolidation would break `parallel_agent.py --status`; added cross-references in both so the distinction is explicit going forward

## Test Plan

- [ ] CI passes (lint + bats + pytest + validate jobs)
- [ ] New `TestFileExistenceValidation` pytest class: 6/6 pass locally
- [ ] Cursor rules drift check: `generate_cursor_rules.sh` runs clean with no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)