### PR TITLE
feat: add version-pin, docs-all, pr-review, branch-clean skills

### DIFF
--- a/.skillshare/skills/branch-clean/SKILL.md
+++ b/.skillshare/skills/branch-clean/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: branch-clean
+description: |
+  Identify and safely prune stale git branches — merged into the default branch,
+  tracking a deleted remote ([gone]), or stale beyond a threshold. Dry-run by
+  default, local-only by default (remote deletion is opt-in), and never touches
+  protected or currently checked-out branches.
+---
+
+# Branch Cleanup
+
+Find local branches that are safe to delete and remove them with confirmation.
+Groups candidates by reason and previews before doing anything destructive.
+
+This skill is backed by `~/.claude/scripts/branch_clean.sh`. Protected globs and
+the staleness threshold come from the `branch_clean` block of
+`config/command_config.yml`.
+
+## When to use
+
+- Your local branch list has accumulated merged / abandoned branches.
+- After merging several PRs, to clear out the merged source branches.
+- To find branches whose remote was deleted (`[gone]`).
+
+## Task
+
+1. **Preview first** (dry-run is the default — deletes nothing):
+
+   ```bash
+   ~/.claude/scripts/branch_clean.sh
+   ```
+
+   Candidates are grouped by reason: **Merged into <default>**, **Gone upstream**,
+   **Stale > Nd**. Protected and current branches are listed as never-deleted.
+
+2. **Apply, with confirmation:**
+
+   ```bash
+   # Delete the local candidates (prompts for confirmation)
+   ~/.claude/scripts/branch_clean.sh --apply
+
+   # Also delete the matching remote branches (opt-in)
+   ~/.claude/scripts/branch_clean.sh --apply --include-remote
+
+   # Tune staleness / add protected patterns
+   ~/.claude/scripts/branch_clean.sh --stale-days 60 --protect 'wip/*'
+   ```
+
+3. **Review the outcome.** Each deletion reports `deleted` or `FAILED`. A
+   `FAILED` on a `[gone]` or `stale` branch usually means it has unmerged commits
+   — the safe path (`git branch -d`) refuses to force-delete it. Delete it
+   manually with `git branch -D <name>` only if you are sure the work is
+   disposable.
+
+## Safety guarantees
+
+- **Local-only by default** (FR-016a): remote branches are deleted only with
+  `--include-remote`.
+- **Dry-run by default** (FR-018): nothing is deleted without `--apply` +
+  confirmation (use `--yes` in non-interactive contexts).
+- **Never touches** the default branch, configured protected globs, or the
+  currently checked-out branch (FR-017).
+- **Never force-deletes** unmerged branches via the default path (FR-020); such
+  attempts fail safely and are reported, not swallowed (FR-019).

--- a/.skillshare/skills/docs-all/SKILL.md
+++ b/.skillshare/skills/docs-all/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: docs-all
+description: |
+  Run all documentation skills (docs-readme, docs-diagrams, docs-improve) in one
+  command, dispatching each as a sub-agent in an order chosen per run (with a
+  documented default precedence as fallback), and return a single consolidated
+  report. Use to refresh the whole doc set at once.
+---
+
+# All-in-One Documentation Refresh
+
+Orchestrate the three existing documentation skills in a single pass instead of
+running them by hand. Each runs as an independent sub-agent; results are merged
+into one report.
+
+## When to use
+
+- You want to refresh README, architecture diagrams, and the Diataxis docs audit
+  together after a meaningful change.
+- You don't want to remember the right order to run them in.
+
+## Task
+
+1. **Decide the order for this run.** Inspect what changed (recent diff / the
+   target path) and choose an order, honoring the one hard dependency:
+   **`docs-improve` runs last** (its quality audit should see the README and
+   diagram updates the other two produce).
+
+   - **Default precedence (fallback when no strong signal):**
+     `docs-readme` → `docs-diagrams` → `docs-improve`.
+   - **Signal-based adjustments:**
+     - Changes concentrated in architecture/module structure or imports →
+       prioritize `docs-diagrams` early.
+     - Changes mostly in prose/onboarding → prioritize `docs-readme` early.
+     - Either way, keep `docs-improve` last.
+   - If the user passed `--order a,b,c`, use it verbatim (still keep the
+     dependency in mind and warn if it is violated).
+
+2. **Dispatch each docs skill as a sub-agent** using the Task tool, one per
+   skill, passing through the target path. Run them per the order from step 1.
+   Independent skills may run concurrently; `docs-improve` waits for the others.
+
+3. **Continue on failure.** If one sub-agent fails, capture its error and still
+   run the remaining skills — never abort the whole run because one failed.
+
+4. **Emit one consolidated report:**
+
+   ```text
+   docs-all report
+   Order: <a> → <b> → <c>   (reason: <signal | default fallback>)
+   - docs-readme    : success — <1-line summary>
+   - docs-diagrams  : success — <1-line summary>
+   - docs-improve   : failed  — <error>
+   ```
+
+   The report MUST state the order used, why that order was chosen, and each
+   sub-skill's outcome (FR-010/FR-011).
+
+## Notes
+
+- This skill writes no files itself and runs no shell script — it is pure
+  sub-agent orchestration over `docs-readme`, `docs-diagrams`, `docs-improve`.
+- If one of the three skills is unavailable, run the others and report the gap.
+- Verification scenario: see `specs/002-new-agent-skills/quickstart.md` (docs-all
+  section) for how to confirm ordering, rationale, and failure-surfacing.

--- a/.skillshare/skills/pr-review/SKILL.md
+++ b/.skillshare/skills/pr-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: pr-review
+description: |
+  Review all open pull/merge requests on the active platform (GitHub/GitLab),
+  assess each for mergeability, checks, staleness, and whether it is still
+  needed, and recommend a disposition (keep, merge, close, needs-rebase) per PR.
+  Analysis-only — performs no mutations.
+---
+
+# Open Pull Request Review
+
+Triage the entire open-PR queue in one pass so you can quickly see which PRs are
+ready, which are stale or superseded, and which need work. Reuses the repo's
+platform abstraction (`git_platform.sh` / `git_ops.sh`).
+
+This skill is backed by `~/.claude/scripts/pr_review.sh`.
+
+## When to use
+
+- You want an overview of every open PR and a recommended action for each.
+- Before a cleanup pass on the PR queue.
+- To identify PRs that are no longer needed (already merged or superseded).
+
+## Task
+
+1. **Run the review** (analysis-only by default — it never merges or closes):
+
+   ```bash
+   # Triage every open PR on the auto-detected platform
+   ~/.claude/scripts/pr_review.sh
+
+   # Custom staleness window + machine-readable output
+   ~/.claude/scripts/pr_review.sh --stale-days 14 --json
+
+   # Force a platform
+   ~/.claude/scripts/pr_review.sh --platform gitlab
+   ```
+
+2. **Read the recommendations.** Each PR gets a disposition with a one-line
+   rationale:
+   - `merge` — mergeable, checks passing, not a draft.
+   - `needs-rebase` — merge conflicts or failing checks.
+   - `close` — branch already merged, or superseded by an earlier open PR on the
+     same branch.
+   - `keep` — active work (draft, pending checks, or simply ongoing).
+
+3. **Act with confirmation.** This skill recommends; it does not change PRs. To
+   act on a recommendation, use `git_ops.sh pr-merge` / the platform CLI
+   explicitly, confirming each action with the user first.
+
+## Notes
+
+- **Analysis-only by default** (FR-014): no PR is merged, closed, or edited
+  without an explicit, separate, confirmed action.
+- **Empty queue** is reported cleanly; an **unauthenticated / missing CLI** is
+  reported distinctly (not as a misleading "clean" result) so you know the
+  difference between "no PRs" and "couldn't look".
+- To customize how PRs are fetched (internal mirrors, CI), set `PR_REVIEW_FETCH`
+  to an executable that prints the normalized PR JSON array.

--- a/.skillshare/skills/version-pin/SKILL.md
+++ b/.skillshare/skills/version-pin/SKILL.md
@@ -51,8 +51,11 @@ types and their resolvers are defined in the `version_pin` block of
    - `compliant` — already pinned with a hash (left unchanged).
    - `bypassed` — carries the bypass marker (left byte-for-byte unchanged).
    - `unresolved` — version/hash could not be resolved (non-fatal warning; file
-     untouched). Common causes: missing native tool, offline, or a mutable
-     `latest` tag with no inferable version (supply `--requested`).
+     untouched). Common causes: missing native tool, offline, or a required
+     hash/digest that could not be obtained (the file is left as-is rather than
+     pinned without integrity). A mutable `latest` Docker tag is pinned **by
+     digest** (tag preserved, e.g. `postgres:latest@sha256:…`); pass
+     `--requested name=VERSION` to also pin a specific version label.
 
 3. **Apply or confirm.** On-demand runs already rewrote the file. If you ran
    `--check`, re-run without `--check` (or with `--requested` as needed) to apply.

--- a/.skillshare/skills/version-pin/SKILL.md
+++ b/.skillshare/skills/version-pin/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: version-pin
+description: |
+  Enforce specific, hashed version pins in dependency files (requirements.txt,
+  docker-compose.yaml, Dockerfiles). Detects loose references (latest, missing
+  version, unbounded range, missing hash), resolves a specific version plus
+  integrity hash via native package managers, and auto-fixes on demand or
+  warns on the save hook. Supports an explicit per-entry bypass.
+---
+
+# Version Pinning Enforcement
+
+Detect and fix loose dependency references so builds are reproducible and
+supply-chain-safe. Pins to a **specific version** (latest stable by default, or
+a requested version) and includes an **integrity hash/digest** wherever the
+ecosystem supports it.
+
+This skill is backed by `~/.claude/scripts/version_pin.sh`. The recognized file
+types and their resolvers are defined in the `version_pin` block of
+`config/command_config.yml` (extensible without code changes).
+
+## When to use
+
+- A `requirements.txt`, `docker-compose.yaml`/`.yml`, or `Dockerfile` references
+  a dependency as `latest`, with no version, an unbounded range, or no hash.
+- You want to audit or pin every recognized file in a tree.
+- The automatic save hook reported a violation and you want to apply the fix.
+
+## Task
+
+1. **Run the script** against the target. Default (on-demand) mode rewrites
+   files in place; `--check` is warn-only (no edits) and is what the save hook
+   uses.
+
+   ```bash
+   # Audit + auto-fix every recognized file in the working tree
+   ~/.claude/scripts/version_pin.sh
+
+   # One file, warn-only (no edits) — same mode the hook runs
+   ~/.claude/scripts/version_pin.sh requirements.txt --check
+
+   # Pin a specific requested version instead of latest stable
+   ~/.claude/scripts/version_pin.sh requirements.txt --requested requests=2.31.0
+
+   # Limit to one rule
+   ~/.claude/scripts/version_pin.sh . --rule docker-compose
+   ```
+
+2. **Read the report.** Each entry is classified:
+   - `violation` — loose; shown with the exact pinned+hashed replacement.
+   - `compliant` — already pinned with a hash (left unchanged).
+   - `bypassed` — carries the bypass marker (left byte-for-byte unchanged).
+   - `unresolved` — version/hash could not be resolved (non-fatal warning; file
+     untouched). Common causes: missing native tool, offline, or a mutable
+     `latest` tag with no inferable version (supply `--requested`).
+
+3. **Apply or confirm.** On-demand runs already rewrote the file. If you ran
+   `--check`, re-run without `--check` (or with `--requested` as needed) to apply.
+
+4. **Bypass intentional exceptions.** Add a trailing comment marker to the line:
+
+   ```text
+   somepkg            # version-pin:ignore  (reason: vendored build)
+   ```
+
+## Resolution
+
+By default the script shells out to native tooling (`pip`/`pip-compile`,
+`docker manifest inspect`). To customize resolution (e.g. an internal mirror or
+deterministic CI), set `VERSION_PIN_RESOLVER` to an executable called as
+`RESOLVER <ecosystem> <name> <current> <requested>` that prints
+`<version><TAB><hash>` or exits non-zero when unresolved.
+
+## Automatic hook (warn-only)
+
+The skill is wired as a `PostToolUse` (`Write|Edit`) hook in
+`settings.local.json` via `~/.claude/scripts/version_pin_hook.sh`. On save of a
+recognized file it runs `version_pin.sh --check` (advisory, never blocks, never
+edits) and prints any violations. The wrapper pre-filters by file name so
+unrelated edits stay quiet.
+
+## Guarantees
+
+- **Idempotent**: a second run on an already-pinned file reports no changes.
+- **No silent failures**: unresolvable/unsupported/malformed cases are reported,
+  never swallowed, and never leave a partially-rewritten file.
+- **Security-sensitive**: this is a supply-chain control (Tier 1); changes to the
+  script itself warrant parallel-agent review before merge.

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-modularize-parallel-agent"
+  "feature_directory": "specs/002-new-agent-skills"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,10 @@ The following slash commands are available in Claude Code:
 | `/issue-triage` | Linear issue audit: duplicates, staleness, priority validation | CONDITIONAL (scenario-based) |
 | `/plan-manage` | Plan lifecycle with parallel agent orchestration for create/review | CONDITIONAL |
 | `/browser-test` | AI-powered E2E browser testing via browser-use YAML test prompts | CONDITIONAL |
+| `/version-pin` | Enforce specific, hashed version pins in dependency files (auto-fix on demand, warn-only hook) | ALWAYS (Tier 1) |
+| `/docs-all` | Run docs-readme/docs-diagrams/docs-improve as sub-agents in one pass | NO |
+| `/pr-review` | Review all open PRs and recommend a disposition per PR (analysis-only) | NO |
+| `/branch-clean` | Prune merged/gone/stale branches safely (dry-run by default, local-only) | CONDITIONAL (--apply) |
 | `sync-skills` | Sync .skillshare/skills/ to all home targets (daily skill dev workflow) | NO |
 
 ## Testing Changes
@@ -341,5 +345,5 @@ approaches), review stale plans, or archive/abandon completed work.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at `specs/001-modularize-parallel-agent/plan.md`
+at `specs/002-new-agent-skills/plan.md`
 <!-- SPECKIT END -->

--- a/configs/claude/CLAUDE.md
+++ b/configs/claude/CLAUDE.md
@@ -150,6 +150,10 @@ These integrate with the parallel agent orchestration framework.
 | `/health-check` | Verify CLI tools, auth, config syntax, MCP, symlinks | NO |
 | `/sync-configs` | Detect cross-platform config drift and broken symlinks | NO |
 | `/sync-skills` | Sync .skillshare/skills/ to all home targets (daily skill dev workflow) | NO |
+| `/version-pin` | Enforce specific, hashed version pins in dependency files | ALWAYS (Tier 1) |
+| `/docs-all` | Run docs-readme/docs-diagrams/docs-improve as sub-agents in one pass | NO |
+| `/pr-review` | Review all open PRs, recommend disposition per PR (analysis-only) | NO |
+| `/branch-clean` | Prune merged/gone/stale branches safely (dry-run, local-only) | CONDITIONAL |
 
 ### Command Usage
 
@@ -180,6 +184,14 @@ These integrate with the parallel agent orchestration framework.
 
 # Skill sync (daily dev workflow)
 sync-skills                  # Push .skillshare/skills/ changes to all home targets
+
+# Dependency / repo hygiene
+/version-pin requirements.txt          # Pin to specific version + hash (auto-fix)
+/version-pin requirements.txt --check  # Warn-only (the save-hook mode)
+/docs-all                              # Refresh all docs via sub-agents in one pass
+/pr-review                             # Triage all open PRs (analysis-only)
+/branch-clean                          # Preview prunable branches (dry-run)
+/branch-clean --apply                  # Delete local candidates (with confirmation)
 ```
 
 ### Auto-Triggered Skill

--- a/configs/claude/config/command_config.yml
+++ b/configs/claude/config/command_config.yml
@@ -339,7 +339,16 @@ tool_policies:
     validation_tier: 1
 
 # Version-pinning rule set (consumed by scripts/version_pin.sh).
-# Maps file globs to an ecosystem, its native resolver command, and hash form.
+# Maps file globs to an ecosystem and hash form. Notes on the fields:
+#   ecosystem   - selects the parser AND the native resolver inside the script
+#                 (pip -> pip/pip-compile, docker -> docker manifest inspect).
+#   hash        - ENFORCED: required|digest mean a missing hash/digest makes the
+#                 entry 'unresolved' (file left untouched); optional|none allow a
+#                 version-only pin.
+#   resolve_cmd - ADVISORY only: documents which native tool the ecosystem uses.
+#                 The script maps ecosystem->tool internally; editing resolve_cmd
+#                 does not change behavior (override resolution via
+#                 VERSION_PIN_RESOLVER instead).
 version_pin:
   bypass_marker: "version-pin:ignore"
   rules:

--- a/configs/claude/config/command_config.yml
+++ b/configs/claude/config/command_config.yml
@@ -295,6 +295,91 @@ tool_policies:
     parallel_agents: never
     validation_tier: 2
 
+  version-pin:
+    allowed:
+      - Read
+      - Glob
+      - Grep
+      - Bash   # Invokes native package managers (pip, docker, npm) to resolve versions/hashes
+      - Edit
+      - Write  # Rewrites loose pins in place on explicit (on-demand) invocation
+    parallel_agents: always   # Security-sensitive supply-chain change (Constitution II)
+    validation_tier: 1
+
+  docs-all:
+    allowed:
+      - Read
+      - Glob
+      - Grep
+      - Task   # Dispatches docs-readme / docs-diagrams / docs-improve as sub-agents
+    forbidden:
+      - Bash
+    parallel_agents: conditional
+    validation_tier: 2
+
+  pr-review:
+    allowed:
+      - Read
+      - Glob
+      - Grep
+      - Bash   # Wraps git_ops.sh / gh / glab (read-only enumeration)
+    forbidden:
+      - Write
+      - Edit   # Analysis-only by default (FR-014)
+    parallel_agents: never
+    validation_tier: 2
+
+  branch-clean:
+    allowed:
+      - Read
+      - Glob
+      - Grep
+      - Bash   # git plumbing; branch deletion only on --apply
+    parallel_agents: conditional   # Tier 1 on the destructive --apply path
+    validation_tier: 1
+
+# Version-pinning rule set (consumed by scripts/version_pin.sh).
+# Maps file globs to an ecosystem, its native resolver command, and hash form.
+version_pin:
+  bypass_marker: "version-pin:ignore"
+  rules:
+    - id: pip-requirements
+      match: ["requirements.txt", "requirements*.txt"]
+      ecosystem: pip
+      resolve_cmd: "pip-compile --generate-hashes"
+      hash: required
+    - id: docker-compose
+      match: ["docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"]
+      ecosystem: docker
+      resolve_cmd: "docker manifest inspect"
+      hash: digest
+    - id: dockerfile
+      match: ["Dockerfile", "Dockerfile.*", "*.Dockerfile"]
+      ecosystem: docker
+      resolve_cmd: "docker manifest inspect"
+      hash: digest
+      # Extensible: add a rule above + a matching parser in version_pin.sh to
+      # cover more ecosystems, e.g.:
+      #   - id: npm-package
+      #     match: ["package.json"]
+      #     ecosystem: npm
+      #     resolve_cmd: "npm view"
+      #     hash: optional
+      #   - id: github-actions
+      #     match: [".github/workflows/*.yml"]
+      #     ecosystem: gha
+      #     resolve_cmd: "git ls-remote"
+      #     hash: required   # mutable ref -> full commit SHA
+
+# Branch-cleaner policy (consumed by scripts/branch_clean.sh).
+branch_clean:
+  stale_days: 90
+  protected:
+    - main
+    - master
+    - "release/*"
+    - "hotfix/*"
+
 # Error recovery strategies
 error_recovery:
   timeout_seconds: 120

--- a/configs/claude/config/validation_criteria.yml
+++ b/configs/claude/config/validation_criteria.yml
@@ -254,6 +254,47 @@ command_overrides:
           multi_component: true
           model_tier: flash
 
+  version-pin:
+    # Security-sensitive supply-chain change → full Tier 1 gate (Constitution II)
+    tier1_required: true
+    tier1_checks:
+      - security
+      - error_handling
+      - breaking_changes
+      - cross_verification
+    tier2_required: true
+    tier2_threshold: 0.70
+    consensus_threshold: 0.80
+    parallel_agents: true
+
+  docs-all:
+    tier1_required: false
+    tier2_required: true
+    tier2_checks:
+      - maintainability
+    parallel_agents: false
+
+  pr-review:
+    tier1_required: false
+    tier2_required: true
+    tier2_checks:
+      - maintainability
+    parallel_agents: false
+
+  branch-clean:
+    # Dry-run is advisory; the destructive --apply path requires the Tier 1 gate
+    tier1_required: true
+    tier1_checks:
+      - error_handling
+      - breaking_changes
+    tier2_required: true
+    tier2_checks:
+      - maintainability
+    tier2_threshold: 0.60
+    parallel_agents_condition:
+      type: destructive_flag
+      flag: "--apply"
+
 # Extended tier2 checks for specialized commands
 tier2_extended:
   decision_consistency:

--- a/configs/claude/scripts/branch_clean.sh
+++ b/configs/claude/scripts/branch_clean.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# branch_clean.sh - Identify and (optionally) delete stale git branches
+#
+# Groups deletion candidates by reason — merged into the default branch,
+# tracking a deleted remote ([gone]), or stale beyond a threshold — and deletes
+# them only with --apply + confirmation. Dry-run by default. Local-only by
+# default; remote deletion is opt-in. Protected and current branches are never
+# proposed.
+#
+# Usage: branch_clean.sh [--apply] [--include-remote] [--stale-days N] \
+#                        [--protect GLOB]... [--default BRANCH] [--yes] [--json]
+#
+#   --apply           Perform deletions (otherwise dry-run preview only).
+#   --include-remote  Also delete the matching remote branch (opt-in).
+#   --stale-days N    Staleness threshold (default: config / 90).
+#   --protect GLOB    Extra protected branch glob (repeatable).
+#   --default BRANCH  Override default-branch detection.
+#   --yes             Skip the interactive confirmation prompt (for --apply).
+#   --json            Machine-readable output.
+#
+# Exit codes: 0 = success; 2 = usage / not-a-git-repo error.
+#
+# Compatible with bash 3.2.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="${BRANCH_CLEAN_CONFIG:-${SCRIPT_DIR}/../config/command_config.yml}"
+
+APPLY=false
+INCLUDE_REMOTE=false
+STALE_DAYS=""
+DEFAULT_BRANCH=""
+ASSUME_YES=false
+JSON_OUT=false
+EXTRA_PROTECT=()
+
+err() { echo "branch-clean: $*" >&2; }
+usage_error() { err "$*"; exit 2; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --apply) APPLY=true; shift ;;
+        --include-remote) INCLUDE_REMOTE=true; shift ;;
+        --stale-days) [[ $# -ge 2 ]] || usage_error "--stale-days needs an argument"; STALE_DAYS="$2"; shift 2 ;;
+        --protect) [[ $# -ge 2 ]] || usage_error "--protect needs a glob"; EXTRA_PROTECT+=("$2"); shift 2 ;;
+        --default) [[ $# -ge 2 ]] || usage_error "--default needs a branch"; DEFAULT_BRANCH="$2"; shift 2 ;;
+        --yes) ASSUME_YES=true; shift ;;
+        --json) JSON_OUT=true; shift ;;
+        -*) usage_error "unknown flag: $1" ;;
+        *) usage_error "unexpected argument: $1" ;;
+    esac
+done
+
+git rev-parse --git-dir >/dev/null 2>&1 || usage_error "not a git repository"
+
+# Config defaults (stale_days + protected globs).
+read_config() {
+    [[ -f "$CONFIG" ]] || { echo "90"; return 0; }
+    python3 - "$CONFIG" <<'PY'
+import sys, yaml
+cfg = yaml.safe_load(open(sys.argv[1])) or {}
+bc = cfg.get("branch_clean") or {}
+print(bc.get("stale_days", 90))
+for g in bc.get("protected") or []:
+    print(g)
+PY
+}
+
+CONF="$(read_config)"
+CONF_STALE="$(printf '%s\n' "$CONF" | head -1)"
+[[ -n "$STALE_DAYS" ]] || STALE_DAYS="$CONF_STALE"
+
+PROTECTED=()
+while IFS='' read -r g; do [[ -n "$g" ]] && PROTECTED+=("$g"); done < <(printf '%s\n' "$CONF" | tail -n +2)
+PROTECTED+=(${EXTRA_PROTECT[@]+"${EXTRA_PROTECT[@]}"})
+
+detect_default() {
+    if [[ -n "$DEFAULT_BRANCH" ]]; then echo "$DEFAULT_BRANCH"; return 0; fi
+    local d
+    d="$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+    if [[ -n "$d" ]]; then echo "$d"; return 0; fi
+    for d in main master; do
+        git show-ref --verify --quiet "refs/heads/$d" && { echo "$d"; return 0; }
+    done
+    git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main"
+}
+
+DEFAULT="$(detect_default)"
+CURRENT="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
+
+is_protected() {
+    local b="$1" g
+    [[ "$b" == "$DEFAULT" || "$b" == "$CURRENT" ]] && return 0
+    for g in ${PROTECTED[@]+"${PROTECTED[@]}"}; do
+        # shellcheck disable=SC2053
+        [[ "$b" == $g ]] && return 0
+    done
+    return 1
+}
+
+# Build "branch<TAB>reason" lines (reason priority merged > gone > stale).
+classify() {
+    local now b track ct age merged_list
+    now="$(date +%s)"
+    merged_list=" $(git branch --merged "$DEFAULT" --format '%(refname:short)' 2>/dev/null | tr '\n' ' ') "
+    while IFS='' read -r line; do
+        b="${line%% *}"; track="${line#* }"
+        [[ -n "$b" ]] || continue
+        is_protected "$b" && continue
+        if [[ "$merged_list" == *" $b "* ]]; then
+            printf '%s\t%s\t%s\n' "$b" merged 0; continue
+        fi
+        if [[ "$track" == *"[gone]"* ]]; then
+            printf '%s\t%s\t%s\n' "$b" gone 0; continue
+        fi
+        ct="$(git log -1 --format=%ct "$b" 2>/dev/null || echo "$now")"
+        age=$(( (now - ct) / 86400 ))
+        if [[ "$age" -gt "$STALE_DAYS" ]]; then
+            printf '%s\t%s\t%s\n' "$b" stale "$age"
+        fi
+    done < <(git for-each-ref --format '%(refname:short) %(upstream:track)' refs/heads 2>/dev/null)
+}
+
+delete_local() {
+    # Safe delete (-d): refuses unmerged branches, honoring FR-020.
+    git branch -d "$1" >/dev/null 2>&1
+}
+delete_remote() {
+    git push origin --delete "$1" >/dev/null 2>&1
+}
+
+main() {
+    local candidates; candidates="$(classify)"
+    local n_merged=0 n_gone=0 n_stale=0 total=0
+    local -a names=() reasons=() ages=()
+    while IFS=$'\t' read -r b r a; do
+        [[ -n "$b" ]] || continue
+        names+=("$b"); reasons+=("$r"); ages+=("$a"); total=$((total+1))
+        case "$r" in merged) n_merged=$((n_merged+1));; gone) n_gone=$((n_gone+1));; stale) n_stale=$((n_stale+1));; esac
+    done <<< "$candidates"
+
+    local scope="local"; $INCLUDE_REMOTE && scope="local+remote"
+    local mode="dry-run"; $APPLY && mode="apply"
+
+    if $JSON_OUT; then
+        local i first=true
+        printf '{"mode":"%s","scope":"%s","default":"%s","candidates":[' "$mode" "$scope" "$DEFAULT"
+        for ((i=0; i<total; i++)); do
+            $first || printf ','; first=false
+            printf '{"name":"%s","reason":"%s","age_days":%s}' "${names[$i]}" "${reasons[$i]}" "${ages[$i]}"
+        done
+        printf ']}\n'
+    else
+        echo "branch-clean ($mode) — scope: $scope, default: $DEFAULT"
+        print_group merged "Merged into $DEFAULT" || true
+        print_group gone "Gone upstream" || true
+        print_group stale "Stale > ${STALE_DAYS}d" || true
+        echo "Protected (never deleted): default=$DEFAULT, current=$CURRENT, globs=[${PROTECTED[*]-}]"
+    fi
+
+    [[ "$total" -eq 0 ]] && { $JSON_OUT || echo "Summary: 0 candidates."; return 0; }
+
+    if ! $APPLY; then
+        $JSON_OUT || echo "Summary: $total candidates (merged $n_merged, gone $n_gone, stale $n_stale); dry-run, nothing deleted."
+        return 0
+    fi
+
+    # --apply path: confirm unless --yes.
+    if ! $ASSUME_YES; then
+        printf 'Delete %d local branch(es)%s? [y/N] ' "$total" "$($INCLUDE_REMOTE && echo ' and their remotes' || true)" >&2
+        local ans=""; IFS='' read -r ans < /dev/tty 2>/dev/null || ans=""
+        case "$ans" in y|Y|yes|YES) ;; *) err "aborted"; return 0;; esac
+    fi
+
+    local i deleted=0 failed=0
+    for ((i=0; i<total; i++)); do
+        local b="${names[$i]}" ok=true
+        if delete_local "$b"; then :; else ok=false; fi
+        if $INCLUDE_REMOTE; then delete_remote "$b" || ok=false; fi
+        if $ok; then
+            deleted=$((deleted+1)); $JSON_OUT || echo "  deleted  $b"
+        else
+            failed=$((failed+1)); $JSON_OUT || echo "  FAILED   $b (unmerged or remote error)"
+        fi
+    done
+    $JSON_OUT || echo "Summary: $total candidates; applied: $deleted deleted, $failed failed."
+}
+
+print_group() {
+    local want="$1" title="$2" i shown=false
+    for ((i=0; i<${#names[@]}; i++)); do
+        if [[ "${reasons[$i]}" == "$want" ]]; then
+            $shown || { echo "$title:"; shown=true; }
+            if [[ "$want" == stale ]]; then
+                printf '  - %-30s (stale, %sd) [delete-candidate]\n' "${names[$i]}" "${ages[$i]}"
+            else
+                printf '  - %-30s (%s) [delete-candidate]\n' "${names[$i]}" "$want"
+            fi
+        fi
+    done
+    $shown || return 1
+}
+
+main "$@"

--- a/configs/claude/scripts/branch_clean.sh
+++ b/configs/claude/scripts/branch_clean.sh
@@ -127,6 +127,8 @@ delete_local() {
     git branch -d "$1" >/dev/null 2>&1
 }
 delete_remote() {
+    # Nothing to delete if the remote ref is already absent (not a failure).
+    git ls-remote --exit-code --heads origin "$1" >/dev/null 2>&1 || return 0
     git push origin --delete "$1" >/dev/null 2>&1
 }
 
@@ -176,12 +178,18 @@ main() {
     local i deleted=0 failed=0
     for ((i=0; i<total; i++)); do
         local b="${names[$i]}" ok=true
-        if delete_local "$b"; then :; else ok=false; fi
-        if $INCLUDE_REMOTE; then delete_remote "$b" || ok=false; fi
+        # Gate remote deletion on a successful local safe-delete: if `git branch
+        # -d` refuses (unmerged), never delete the remote (which could still hold
+        # unmerged commits). Local safe-delete is the safety check.
+        if delete_local "$b"; then
+            if $INCLUDE_REMOTE && ! delete_remote "$b"; then ok=false; fi
+        else
+            ok=false
+        fi
         if $ok; then
             deleted=$((deleted+1)); $JSON_OUT || echo "  deleted  $b"
         else
-            failed=$((failed+1)); $JSON_OUT || echo "  FAILED   $b (unmerged or remote error)"
+            failed=$((failed+1)); $JSON_OUT || echo "  FAILED   $b (unmerged locally, or remote error; remote left intact)"
         fi
     done
     $JSON_OUT || echo "Summary: $total candidates; applied: $deleted deleted, $failed failed."

--- a/configs/claude/scripts/pr_review.sh
+++ b/configs/claude/scripts/pr_review.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# pr_review.sh - Triage all open pull/merge requests (analysis-only)
+#
+# Enumerates every open PR on the active platform (GitHub via gh, GitLab via
+# glab), assesses mergeability / checks / staleness / superseded status, and
+# recommends a disposition per PR. Performs NO mutations.
+#
+# Usage: pr_review.sh [--platform github|gitlab] [--stale-days N] [--json]
+#
+# Resolution: by default fetches via the platform CLI. Set PR_REVIEW_FETCH to an
+# executable that prints a normalized JSON array (see fields below) to override
+# fetching (used by tests / custom integrations). Each element:
+#   {number,title,author,updated(ISO8601),mergeable(CLEAN|CONFLICTING|UNKNOWN),
+#    checks(PASS|FAIL|PENDING|NONE),draft(bool),head(str),merged(bool)}
+#
+# Exit codes: 0 = success (incl. empty queue); 2 = usage / platform / auth error.
+#
+# Compatible with bash 3.2.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PLATFORM=""
+STALE_DAYS=30
+JSON_OUT=false
+
+err() { echo "pr-review: $*" >&2; }
+usage_error() { err "$*"; exit 2; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --platform) [[ $# -ge 2 ]] || usage_error "--platform needs an argument"; PLATFORM="$2"; shift 2 ;;
+        --stale-days) [[ $# -ge 2 ]] || usage_error "--stale-days needs an argument"; STALE_DAYS="$2"; shift 2 ;;
+        --json) JSON_OUT=true; shift ;;
+        -*) usage_error "unknown flag: $1" ;;
+        *) usage_error "unexpected argument: $1" ;;
+    esac
+done
+
+detect_platform() {
+    if [[ -n "$PLATFORM" ]]; then echo "$PLATFORM"; return 0; fi
+    if [[ -x "${SCRIPT_DIR}/git_platform.sh" ]]; then
+        "${SCRIPT_DIR}/git_platform.sh" 2>/dev/null || echo "git"
+    else
+        echo "git"
+    fi
+}
+
+# Default fetch: normalize the platform CLI's JSON into our schema.
+default_fetch() {
+    local platform="$1"
+    case "$platform" in
+        github)
+            command -v gh >/dev/null 2>&1 || { err "gh CLI not found"; return 3; }
+            gh pr list --state open --limit 200 \
+               --json number,title,author,updatedAt,mergeable,isDraft,headRefName,statusCheckRollup \
+               2>/dev/null | python3 -c '
+import sys, json
+try:
+    rows = json.load(sys.stdin)
+except Exception:
+    print("[]"); sys.exit(0)
+def checks(r):
+    roll = r.get("statusCheckRollup") or []
+    if not roll: return "NONE"
+    states = [c.get("conclusion") or c.get("state") or "" for c in roll]
+    if any(s in ("FAILURE","ERROR","CANCELLED","TIMED_OUT") for s in states): return "FAIL"
+    if any(s in ("PENDING","IN_PROGRESS","QUEUED","") for s in states): return "PENDING"
+    return "PASS"
+out=[]
+for r in rows:
+    out.append({
+      "number": r.get("number"),
+      "title": r.get("title",""),
+      "author": (r.get("author") or {}).get("login",""),
+      "updated": r.get("updatedAt",""),
+      "mergeable": {"MERGEABLE":"CLEAN","CONFLICTING":"CONFLICTING"}.get(r.get("mergeable",""),"UNKNOWN"),
+      "checks": checks(r),
+      "draft": bool(r.get("isDraft")),
+      "head": r.get("headRefName",""),
+      "merged": False,
+    })
+print(json.dumps(out))
+' || { err "failed to parse gh output"; return 3; }
+            ;;
+        gitlab)
+            command -v glab >/dev/null 2>&1 || { err "glab CLI not found"; return 3; }
+            glab mr list --opened -P 200 -F json 2>/dev/null | python3 -c '
+import sys, json
+try:
+    rows = json.load(sys.stdin)
+except Exception:
+    print("[]"); sys.exit(0)
+out=[]
+for r in rows:
+    out.append({
+      "number": r.get("iid") or r.get("id"),
+      "title": r.get("title",""),
+      "author": (r.get("author") or {}).get("username",""),
+      "updated": r.get("updated_at",""),
+      "mergeable": "CLEAN" if r.get("merge_status")=="can_be_merged" else ("CONFLICTING" if r.get("merge_status")=="cannot_be_merged" else "UNKNOWN"),
+      "checks": "NONE",
+      "draft": bool(r.get("draft") or r.get("work_in_progress")),
+      "head": r.get("source_branch",""),
+      "merged": False,
+    })
+print(json.dumps(out))
+' || { err "failed to parse glab output"; return 3; }
+            ;;
+        *)
+            err "unsupported platform '$platform' (need a GitHub or GitLab remote)"
+            return 2
+            ;;
+    esac
+}
+
+main() {
+    local platform; platform="$(detect_platform)"
+    local data rc
+    if [[ -n "${PR_REVIEW_FETCH:-}" ]]; then
+        data="$("$PR_REVIEW_FETCH" "$platform")" || { err "fetch override failed"; exit 2; }
+    else
+        if ! data="$(default_fetch "$platform")"; then
+            rc=$?
+            [[ $rc -eq 3 ]] && err "cannot enumerate PRs — is the platform CLI installed and authenticated?"
+            exit 2
+        fi
+    fi
+
+    STALE_DAYS="$STALE_DAYS" JSON_OUT="$JSON_OUT" PLATFORM="$platform" \
+    python3 -c '
+import sys, json, os
+from datetime import datetime, timezone
+data = json.loads(sys.stdin.read() or "[]")
+stale = int(os.environ.get("STALE_DAYS","30"))
+json_out = os.environ.get("JSON_OUT")=="true"
+platform = os.environ.get("PLATFORM","git")
+
+def age_days(iso):
+    if not iso: return 0
+    try:
+        s = iso.replace("Z","+00:00")
+        d = datetime.fromisoformat(s)
+        if d.tzinfo is None: d = d.replace(tzinfo=timezone.utc)
+        return (datetime.now(timezone.utc) - d).days
+    except Exception:
+        return 0
+
+# supersession: another open PR shares the same head branch
+heads={}
+for r in data:
+    heads.setdefault(r.get("head",""), []).append(r.get("number"))
+
+results=[]
+for r in data:
+    a = age_days(r.get("updated",""))
+    head = r.get("head","")
+    superseded = head and len(heads.get(head,[]))>1 and r.get("number")!=min(x for x in heads[head] if x is not None)
+    merged = bool(r.get("merged"))
+    mergeable = r.get("mergeable","UNKNOWN")
+    chk = r.get("checks","NONE")
+    draft = bool(r.get("draft"))
+    if merged or superseded:
+        disp, why = "close", ("branch already merged" if merged else "superseded by an earlier open PR on the same branch")
+    elif mergeable=="CONFLICTING" or chk=="FAIL":
+        disp, why = "needs-rebase", ("merge conflicts" if mergeable=="CONFLICTING" else "failing checks")
+    elif mergeable=="CLEAN" and chk in ("PASS","NONE") and not draft:
+        disp, why = "merge", "clean and passing"
+    else:
+        bits=[]
+        if draft: bits.append("draft")
+        if a>=stale: bits.append("stale (%dd)"%a)
+        if chk=="PENDING": bits.append("checks pending")
+        disp, why = "keep", (", ".join(bits) or "active")
+    results.append({**r,"age_days":a,"superseded":bool(superseded),"disposition":disp,"rationale":why})
+
+if json_out:
+    print(json.dumps(results, indent=2)); sys.exit(0)
+
+print("Open PRs on %s: %d" % (platform, len(results)))
+if not results:
+    print("Clean queue — no open PRs."); sys.exit(0)
+counts={"keep":0,"merge":0,"close":0,"needs-rebase":0}
+for r in results:
+    counts[r["disposition"]] = counts.get(r["disposition"],0)+1
+    print("#%-5s %-50.50s %3dd  %-11s/%-7s -> %s" % (
+        r.get("number"), r.get("title",""), r["age_days"],
+        r.get("mergeable",""), r.get("checks",""), r["disposition"]))
+    print("       rationale: %s" % r["rationale"])
+print("Recommended: close %d, merge %d, rebase %d, keep %d" % (
+    counts.get("close",0),counts.get("merge",0),counts.get("needs-rebase",0),counts.get("keep",0)))
+' <<< "$data"
+}
+
+main "$@"

--- a/configs/claude/scripts/pr_review.sh
+++ b/configs/claude/scripts/pr_review.sh
@@ -121,8 +121,11 @@ main() {
     if [[ -n "${PR_REVIEW_FETCH:-}" ]]; then
         data="$("$PR_REVIEW_FETCH" "$platform")" || { err "fetch override failed"; exit 2; }
     else
-        if ! data="$(default_fetch "$platform")"; then
-            rc=$?
+        # Capture the real exit code (a negated `if` would mask it as 0).
+        set +e
+        data="$(default_fetch "$platform")"; rc=$?
+        set -e
+        if [[ $rc -ne 0 ]]; then
             [[ $rc -eq 3 ]] && err "cannot enumerate PRs — is the platform CLI installed and authenticated?"
             exit 2
         fi

--- a/configs/claude/scripts/version_pin.sh
+++ b/configs/claude/scripts/version_pin.sh
@@ -22,6 +22,11 @@
 # "<version><TAB><hash>" (hash may be empty) on stdout, or exit non-zero if the
 # version cannot be resolved.
 #
+# Hash policy: each rule declares a `hash` policy (required | digest | optional |
+# none). When a hash/digest is required (required/digest) but cannot be obtained,
+# the entry is reported `unresolved` and the file is left untouched — never
+# rewritten into a still-mutable / unhashed reference.
+#
 # Exit codes: 0 = clean (or all fixed on-demand); 1 = violations remain (--check);
 #             2 = usage/config error.
 #
@@ -36,6 +41,7 @@ CHECK_ONLY=false
 RULE_FILTER=""
 PATHS=()
 REQUESTED_KV=()   # entries of the form "name=version"
+FIND_GLOBS=()     # basename globs harvested from the rule set (config-driven)
 
 # Counters
 N_FILES=0 N_VIOLATION=0 N_FIXED=0 N_COMPLIANT=0 N_BYPASSED=0 N_UNRESOLVED=0
@@ -96,6 +102,11 @@ print((cfg.get("version_pin") or {}).get("bypass_marker", "version-pin:ignore"))
 PY
 }
 
+# True when the rule's hash policy means a missing hash/digest is unacceptable.
+hash_is_required() {
+    case "$1" in required|digest) return 0 ;; *) return 1 ;; esac
+}
+
 # Match a basename against a rule's comma-separated globs.
 file_matches_globs() {
     local base="$1" globs="$2" g arr
@@ -105,6 +116,15 @@ file_matches_globs() {
         [[ "$base" == $g ]] && return 0
     done
     return 1
+}
+
+# Compute a sha256, preferring sha256sum (Linux) then shasum (macOS).
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" 2>/dev/null | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+    fi
 }
 
 # Resolve "<version><TAB><hash>" for a dependency; return 1 if unresolved.
@@ -136,7 +156,7 @@ resolve_pip() {
     tmp="$(mktemp -d)"
     if "$pip" download --no-deps --quiet --dest "$tmp" "${name}==${ver}" >/dev/null 2>&1; then
         f="$(find "$tmp" -maxdepth 1 -type f | head -1)"
-        [[ -n "$f" ]] && hash="$(shasum -a 256 "$f" 2>/dev/null | awk '{print $1}')"
+        [[ -n "$f" ]] && hash="$(sha256_of "$f")"
     fi
     rm -rf "$tmp"
     printf '%s\t%s\n' "$ver" "$hash"
@@ -147,13 +167,16 @@ resolve_docker() {
     command -v docker >/dev/null 2>&1 || return 1
     if [[ -n "$requested" ]]; then
         tag="$requested"
-    elif [[ -n "$current" && "$current" != "latest" ]]; then
-        tag="$current"   # concrete tag already present; only the digest is missing
+    elif [[ -n "$current" ]]; then
+        tag="$current"      # pin the digest of the current tag (incl. 'latest')
     else
-        return 1         # cannot infer a specific version from 'latest'/empty
+        tag="latest"
     fi
+    # Pin by digest even for a mutable tag like 'latest' — the digest is what
+    # makes the reference reproducible; the tag label is preserved.
     digest="$(docker manifest inspect "${name}:${tag}" 2>/dev/null \
              | python3 -c 'import sys,json; print(json.load(sys.stdin).get("config",{}).get("digest",""))' 2>/dev/null || true)"
+    [[ -n "$digest" ]] || return 1
     printf '%s\t%s\n' "$tag" "$digest"
 }
 
@@ -185,8 +208,8 @@ report() {
 # ---- per-ecosystem processors -------------------------------------------------
 
 process_pip() {
-    local marker="$1" changed=false
-    local line trimmed name ver hash resolved fixed req
+    local marker="$1" hashpol="$2" changed=false
+    local line trimmed name name_extras env_marker ver hash resolved fixed req
     OUT_LINES=(); CHANGED=false
     [[ ${#FILE_LINES[@]} -gt 0 ]] || return 0
     for line in "${FILE_LINES[@]}"; do
@@ -197,7 +220,18 @@ process_pip() {
         if [[ "$line" == *"$marker"* ]]; then
             OUT_LINES+=("$line"); N_BYPASSED=$((N_BYPASSED+1)); report bypassed "$trimmed"; continue
         fi
-        name="$(printf '%s' "$trimmed" | sed -E 's/[[:space:]]*([A-Za-z0-9._-]+).*/\1/')"
+        # Bare package name (no extras) for resolution.
+        name="$(printf '%s' "$trimmed" | sed -E 's/^([A-Za-z0-9._-]+).*/\1/')"
+        # Name plus any extras, e.g. "requests[socks]" — preserved on rewrite.
+        name_extras="$(printf '%s' "$trimmed" | sed -E 's/^([A-Za-z0-9._-]+(\[[^]]*\])?).*/\1/')"
+        # Environment marker (everything after a ';'), comment-stripped & trimmed.
+        env_marker=""
+        case "$trimmed" in
+            *\;*)
+                env_marker="${trimmed#*;}"; env_marker="${env_marker%%#*}"
+                env_marker="$(printf '%s' "$env_marker" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+                ;;
+        esac
         if [[ "$trimmed" == *"=="* && "$trimmed" == *"--hash="* ]]; then
             OUT_LINES+=("$line"); N_COMPLIANT=$((N_COMPLIANT+1)); continue
         fi
@@ -205,7 +239,13 @@ process_pip() {
         req="$(requested_for "$name")"
         if resolved="$(resolve pip "$name" "" "$req")"; then
             ver="${resolved%%	*}"; hash="${resolved#*	}"
-            fixed="${name}==${ver}"
+            if [[ -z "$hash" ]] && hash_is_required "$hashpol"; then
+                OUT_LINES+=("$line"); N_UNRESOLVED=$((N_UNRESOLVED+1))
+                report unresolved "$name (no integrity hash; policy '$hashpol' requires one)"
+                continue
+            fi
+            fixed="${name_extras}==${ver}"
+            [[ -n "$env_marker" ]] && fixed="${fixed}; ${env_marker}"
             [[ -n "$hash" ]] && fixed="${fixed} --hash=sha256:${hash}"
             report violation "$trimmed -> $fixed"
             if $CHECK_ONLY; then OUT_LINES+=("$line")
@@ -217,63 +257,107 @@ process_pip() {
     CHANGED="$changed"
 }
 
+# Split a docker image reference into name + tag, honoring registry ports.
+# The tag is the part after the LAST ':' only when that ':' is in the final
+# path component (otherwise the ':' belongs to a registry host:port).
+docker_split_ref() {
+    local ref="$1" after_slash
+    after_slash="${ref##*/}"
+    if [[ "$after_slash" == *:* ]]; then
+        DK_NAME="${ref%:*}"; DK_TAG="${ref##*:}"
+    else
+        DK_NAME="$ref"; DK_TAG="latest"
+    fi
+}
+
 process_docker() {
-    local marker="$1" kind="$2" changed=false
-    local line key ref name tag rest resolved ver digest newref re req
+    local marker="$1" hashpol="$2" kind="$3" changed=false
+    local line key ref rest resolved ver digest newref re req
     OUT_LINES=(); CHANGED=false
-    if [[ "$kind" == "compose" ]]; then re='^([[:space:]]*image:[[:space:]]*)([^[:space:]#]+)(.*)$'
-    else re='^([[:space:]]*FROM[[:space:]]+)([^[:space:]#]+)(.*)$'; fi
+    if [[ "$kind" == "compose" ]]; then
+        re='^([[:space:]]*image:[[:space:]]*)([^[:space:]#]+)(.*)$'
+    else
+        # Allow optional FROM flags (e.g. --platform=linux/amd64) before the ref.
+        re='^([[:space:]]*FROM[[:space:]]+(--[A-Za-z-]+=[^[:space:]]+[[:space:]]+)*)([^[:space:]#]+)(.*)$'
+    fi
     [[ ${#FILE_LINES[@]} -gt 0 ]] || return 0
     for line in "${FILE_LINES[@]}"; do
         if [[ ! "$line" =~ $re ]]; then OUT_LINES+=("$line"); continue; fi
-        key="${BASH_REMATCH[1]}"; ref="${BASH_REMATCH[2]}"; rest="${BASH_REMATCH[3]}"
+        if [[ "$kind" == "compose" ]]; then
+            key="${BASH_REMATCH[1]}"; ref="${BASH_REMATCH[2]}"; rest="${BASH_REMATCH[3]}"
+        else
+            key="${BASH_REMATCH[1]}"; ref="${BASH_REMATCH[3]}"; rest="${BASH_REMATCH[4]}"
+        fi
         if [[ "$line" == *"$marker"* ]]; then
             OUT_LINES+=("$line"); N_BYPASSED=$((N_BYPASSED+1)); report bypassed "$ref"; continue
         fi
         if [[ "$ref" == *"@sha256:"* ]]; then OUT_LINES+=("$line"); N_COMPLIANT=$((N_COMPLIANT+1)); continue; fi
-        if [[ "$ref" == *:* ]]; then name="${ref%%:*}"; tag="${ref##*:}"; else name="$ref"; tag="latest"; fi
+        docker_split_ref "$ref"   # sets DK_NAME / DK_TAG
         N_VIOLATION=$((N_VIOLATION+1))
-        req="$(requested_for "$name")"
-        if resolved="$(resolve docker "$name" "$tag" "$req")"; then
+        req="$(requested_for "$DK_NAME")"
+        if resolved="$(resolve docker "$DK_NAME" "$DK_TAG" "$req")"; then
             ver="${resolved%%	*}"; digest="${resolved#*	}"
-            newref="${name}:${ver}"
+            if [[ -z "$digest" ]] && hash_is_required "$hashpol"; then
+                OUT_LINES+=("$line"); N_UNRESOLVED=$((N_UNRESOLVED+1))
+                report unresolved "$DK_NAME (no digest; policy '$hashpol' requires one)"
+                continue
+            fi
+            newref="${DK_NAME}:${ver}"
             [[ -n "$digest" ]] && newref="${newref}@${digest}"
             report violation "$ref -> $newref"
             if $CHECK_ONLY; then OUT_LINES+=("$line")
             else OUT_LINES+=("${key}${newref}${rest}"); changed=true; N_FIXED=$((N_FIXED+1)); fi
         else
-            OUT_LINES+=("$line"); N_UNRESOLVED=$((N_UNRESOLVED+1)); report unresolved "$name (cannot infer specific version from '$tag')"
+            OUT_LINES+=("$line"); N_UNRESOLVED=$((N_UNRESOLVED+1)); report unresolved "$DK_NAME (cannot resolve digest for '$DK_TAG')"
         fi
     done
     CHANGED="$changed"
 }
 
 process_file() {
-    local file="$1" eco="$2" rule_id="$3" marker
+    local file="$1" eco="$2" rule_id="$3" hashpol="$4" marker
     marker="$(bypass_marker)"
     N_FILES=$((N_FILES+1))
     echo "version-pin: ${file}"
     read_file "$file"
     case "$eco" in
-        pip) process_pip "$marker"; write_back "$file" "$CHANGED" ;;
+        pip) process_pip "$marker" "$hashpol"; write_back "$file" "$CHANGED" ;;
         docker)
             case "$rule_id" in
-                dockerfile) process_docker "$marker" dockerfile ;;
-                *) process_docker "$marker" compose ;;
+                dockerfile) process_docker "$marker" "$hashpol" dockerfile ;;
+                *) process_docker "$marker" "$hashpol" compose ;;
             esac
             write_back "$file" "$CHANGED" ;;
         *) report unresolved "ecosystem '$eco' has no parser (skipped)"; N_UNRESOLVED=$((N_UNRESOLVED+1)) ;;
     esac
 }
 
+# Harvest basename globs from the rule set so directory scans are config-driven.
+build_find_globs() {
+    local rules="$1" id eco hash globs g arr
+    FIND_GLOBS=()
+    while IFS=$'\t' read -r id eco hash globs; do
+        [[ -z "$id" ]] && continue
+        [[ -n "$RULE_FILTER" && "$RULE_FILTER" != "$id" ]] && continue
+        IFS=',' read -ra arr <<< "$globs"
+        for g in "${arr[@]}"; do
+            [[ -n "$g" ]] && FIND_GLOBS+=("${g##*/}")   # basename portion only
+        done
+    done <<< "$rules"
+}
+
 collect_files() {
-    local p
+    local p g args first
     for p in "${PATHS[@]}"; do
-        if [[ -f "$p" ]]; then echo "$p"
+        if [[ -f "$p" ]]; then
+            echo "$p"
         elif [[ -d "$p" ]]; then
-            find "$p" -type f \( -name 'requirements*.txt' -o -name 'docker-compose.y*ml' \
-                 -o -name 'compose.y*ml' -o -name 'Dockerfile' -o -name 'Dockerfile.*' \
-                 -o -name '*.Dockerfile' \) 2>/dev/null
+            args=(); first=true
+            for g in ${FIND_GLOBS[@]+"${FIND_GLOBS[@]}"}; do
+                if $first; then args+=( -name "$g" ); first=false
+                else args+=( -o -name "$g" ); fi
+            done
+            [[ ${#args[@]} -gt 0 ]] && find "$p" -type f \( "${args[@]}" \) 2>/dev/null
         else
             err "path not found: $p"
         fi
@@ -284,6 +368,7 @@ main() {
     parse_args "$@"
     local rules; rules="$(load_rules)"
     [[ -n "$rules" ]] || usage_error "no version_pin rules in $CONFIG"
+    build_find_globs "$rules"
 
     local explicit_unmatched=true
     [[ -d "${PATHS[0]}" ]] && explicit_unmatched=false
@@ -297,7 +382,7 @@ main() {
             [[ -z "$id" ]] && continue
             [[ -n "$RULE_FILTER" && "$RULE_FILTER" != "$id" ]] && continue
             if file_matches_globs "$base" "$globs"; then
-                process_file "$file" "$eco" "$id"; matched=true; break
+                process_file "$file" "$eco" "$id" "$hash"; matched=true; break
             fi
         done <<< "$rules"
         if [[ "$matched" == false && -f "$file" ]] && $explicit_unmatched; then
@@ -305,8 +390,11 @@ main() {
         fi
     done < <(collect_files)
 
-    local mode="fixed"; $CHECK_ONLY && mode="reported"
-    echo "Summary: ${N_FILES} files, ${N_VIOLATION} violations ${mode}, ${N_COMPLIANT} compliant, ${N_BYPASSED} bypassed, ${N_UNRESOLVED} unresolved"
+    if $CHECK_ONLY; then
+        echo "Summary: ${N_FILES} files, ${N_VIOLATION} violations reported, ${N_COMPLIANT} compliant, ${N_BYPASSED} bypassed, ${N_UNRESOLVED} unresolved"
+    else
+        echo "Summary: ${N_FILES} files, ${N_VIOLATION} violations (${N_FIXED} fixed, ${N_UNRESOLVED} unresolved), ${N_COMPLIANT} compliant, ${N_BYPASSED} bypassed"
+    fi
     if $CHECK_ONLY && [[ $N_VIOLATION -gt 0 ]]; then return 1; fi
     return 0
 }

--- a/configs/claude/scripts/version_pin.sh
+++ b/configs/claude/scripts/version_pin.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# version_pin.sh - Enforce specific, hashed version pins in dependency files
+#
+# Detects loose dependency references (latest / missing version / unbounded
+# range / missing integrity hash) in recognized files, resolves a specific
+# version + integrity hash via native package-manager tooling, and either
+# rewrites the file in place (on-demand) or reports the fix (--check / hook).
+#
+# Usage: version_pin.sh [<path>...] [--check] [--requested NAME=VERSION]... \
+#                       [--rule ID] [--config FILE]
+#
+#   <path>...            Files/dirs to scan (default: current directory tree).
+#   --check              Warn-only: report violations + fixes, make NO edits
+#                        (this is the save-hook mode).
+#   --requested NAME=VER Pin NAME to an exact requested version (repeatable).
+#   --rule ID            Limit to one rule-set entry from the config.
+#   --config FILE        Override config (default: ../config/command_config.yml).
+#
+# Resolution: by default the script shells out to native tooling (pip / docker).
+# Set VERSION_PIN_RESOLVER to an executable to override resolution; it is called
+# as: RESOLVER <ecosystem> <name> <current> <requested>  and must print
+# "<version><TAB><hash>" (hash may be empty) on stdout, or exit non-zero if the
+# version cannot be resolved.
+#
+# Exit codes: 0 = clean (or all fixed on-demand); 1 = violations remain (--check);
+#             2 = usage/config error.
+#
+# Compatible with bash 3.2 (no associative arrays / mapfile).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="${VERSION_PIN_CONFIG:-${SCRIPT_DIR}/../config/command_config.yml}"
+
+CHECK_ONLY=false
+RULE_FILTER=""
+PATHS=()
+REQUESTED_KV=()   # entries of the form "name=version"
+
+# Counters
+N_FILES=0 N_VIOLATION=0 N_FIXED=0 N_COMPLIANT=0 N_BYPASSED=0 N_UNRESOLVED=0
+
+# Per-file working buffers (reset by read_file / process_*)
+FILE_LINES=()
+OUT_LINES=()
+CHANGED=false   # set by process_* to signal the file needs rewriting
+
+err() { echo "version-pin: $*" >&2; }
+usage_error() { err "$*"; exit 2; }
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --check) CHECK_ONLY=true; shift ;;
+            --rule) [[ $# -ge 2 ]] || usage_error "--rule needs an argument"; RULE_FILTER="$2"; shift 2 ;;
+            --config) [[ $# -ge 2 ]] || usage_error "--config needs an argument"; CONFIG="$2"; shift 2 ;;
+            --requested)
+                [[ $# -ge 2 ]] || usage_error "--requested needs NAME=VERSION"
+                [[ "$2" == *=* ]] || usage_error "--requested must be NAME=VERSION"
+                REQUESTED_KV+=("$2"); shift 2 ;;
+            --) shift; while [[ $# -gt 0 ]]; do PATHS+=("$1"); shift; done ;;
+            -*) usage_error "unknown flag: $1" ;;
+            *) PATHS+=("$1"); shift ;;
+        esac
+    done
+    [[ ${#PATHS[@]} -gt 0 ]] || PATHS=(".")
+}
+
+requested_for() {
+    local name="$1" kv
+    for kv in ${REQUESTED_KV[@]+"${REQUESTED_KV[@]}"}; do
+        if [[ "$kv" == "${name}="* ]]; then echo "${kv#*=}"; return 0; fi
+    done
+    return 0
+}
+
+# Emit rules as TSV: id<TAB>ecosystem<TAB>hash<TAB>glob,glob,...
+load_rules() {
+    [[ -f "$CONFIG" ]] || usage_error "config not found: $CONFIG"
+    python3 - "$CONFIG" <<'PY'
+import sys, yaml
+cfg = yaml.safe_load(open(sys.argv[1])) or {}
+vp = cfg.get("version_pin") or {}
+for r in vp.get("rules") or []:
+    globs = ",".join(r.get("match") or [])
+    print("\t".join([str(r.get("id","")), str(r.get("ecosystem","")),
+                     str(r.get("hash","none")), globs]))
+PY
+}
+
+bypass_marker() {
+    python3 - "$CONFIG" <<'PY'
+import sys, yaml
+cfg = yaml.safe_load(open(sys.argv[1])) or {}
+print((cfg.get("version_pin") or {}).get("bypass_marker", "version-pin:ignore"))
+PY
+}
+
+# Match a basename against a rule's comma-separated globs.
+file_matches_globs() {
+    local base="$1" globs="$2" g arr
+    IFS=',' read -ra arr <<< "$globs"
+    for g in "${arr[@]}"; do
+        # shellcheck disable=SC2053
+        [[ "$base" == $g ]] && return 0
+    done
+    return 1
+}
+
+# Resolve "<version><TAB><hash>" for a dependency; return 1 if unresolved.
+resolve() {
+    local eco="$1" name="$2" current="$3" requested="${4:-}"
+    if [[ -n "${VERSION_PIN_RESOLVER:-}" ]]; then
+        "$VERSION_PIN_RESOLVER" "$eco" "$name" "$current" "$requested" || return 1
+        return 0
+    fi
+    case "$eco" in
+        pip)    resolve_pip "$name" "$requested" ;;
+        docker) resolve_docker "$name" "$current" "$requested" ;;
+        *)      return 1 ;;
+    esac
+}
+
+resolve_pip() {
+    local name="$1" requested="${2:-}" ver hash pip tmp f
+    pip="$(command -v pip || command -v pip3 || true)"
+    [[ -n "$pip" ]] || return 1
+    if [[ -n "$requested" ]]; then
+        ver="$requested"
+    else
+        ver="$("$pip" index versions "$name" 2>/dev/null \
+              | sed -n 's/.*LATEST:[[:space:]]*\([^[:space:]]*\).*/\1/p' | head -1)"
+    fi
+    [[ -n "$ver" ]] || return 1
+    hash=""
+    tmp="$(mktemp -d)"
+    if "$pip" download --no-deps --quiet --dest "$tmp" "${name}==${ver}" >/dev/null 2>&1; then
+        f="$(find "$tmp" -maxdepth 1 -type f | head -1)"
+        [[ -n "$f" ]] && hash="$(shasum -a 256 "$f" 2>/dev/null | awk '{print $1}')"
+    fi
+    rm -rf "$tmp"
+    printf '%s\t%s\n' "$ver" "$hash"
+}
+
+resolve_docker() {
+    local name="$1" current="$2" requested="${3:-}" tag digest
+    command -v docker >/dev/null 2>&1 || return 1
+    if [[ -n "$requested" ]]; then
+        tag="$requested"
+    elif [[ -n "$current" && "$current" != "latest" ]]; then
+        tag="$current"   # concrete tag already present; only the digest is missing
+    else
+        return 1         # cannot infer a specific version from 'latest'/empty
+    fi
+    digest="$(docker manifest inspect "${name}:${tag}" 2>/dev/null \
+             | python3 -c 'import sys,json; print(json.load(sys.stdin).get("config",{}).get("digest",""))' 2>/dev/null || true)"
+    printf '%s\t%s\n' "$tag" "$digest"
+}
+
+read_file() {
+    local file="$1" line
+    FILE_LINES=()
+    while IFS='' read -r line || [[ -n "$line" ]]; do
+        FILE_LINES+=("$line")
+    done < "$file"
+}
+
+write_back() {
+    local file="$1" changed="$2"
+    $CHECK_ONLY && return 0
+    [[ "$changed" == true ]] || return 0
+    [[ ${#OUT_LINES[@]} -gt 0 ]] || return 0
+    printf '%s\n' "${OUT_LINES[@]}" > "$file"
+}
+
+report() {
+    local state="$1" detail="$2" sym
+    case "$state" in
+        violation) sym="x" ;; compliant) sym="ok" ;;
+        bypassed) sym="--" ;; unresolved) sym="!" ;; *) sym="-" ;;
+    esac
+    printf '  %-2s %-10s %s\n' "$sym" "$state" "$detail"
+}
+
+# ---- per-ecosystem processors -------------------------------------------------
+
+process_pip() {
+    local marker="$1" changed=false
+    local line trimmed name ver hash resolved fixed req
+    OUT_LINES=(); CHANGED=false
+    [[ ${#FILE_LINES[@]} -gt 0 ]] || return 0
+    for line in "${FILE_LINES[@]}"; do
+        trimmed="${line#"${line%%[![:space:]]*}"}"
+        if [[ -z "$trimmed" || "$trimmed" == \#* || "$trimmed" == -* ]]; then
+            OUT_LINES+=("$line"); continue
+        fi
+        if [[ "$line" == *"$marker"* ]]; then
+            OUT_LINES+=("$line"); N_BYPASSED=$((N_BYPASSED+1)); report bypassed "$trimmed"; continue
+        fi
+        name="$(printf '%s' "$trimmed" | sed -E 's/[[:space:]]*([A-Za-z0-9._-]+).*/\1/')"
+        if [[ "$trimmed" == *"=="* && "$trimmed" == *"--hash="* ]]; then
+            OUT_LINES+=("$line"); N_COMPLIANT=$((N_COMPLIANT+1)); continue
+        fi
+        N_VIOLATION=$((N_VIOLATION+1))
+        req="$(requested_for "$name")"
+        if resolved="$(resolve pip "$name" "" "$req")"; then
+            ver="${resolved%%	*}"; hash="${resolved#*	}"
+            fixed="${name}==${ver}"
+            [[ -n "$hash" ]] && fixed="${fixed} --hash=sha256:${hash}"
+            report violation "$trimmed -> $fixed"
+            if $CHECK_ONLY; then OUT_LINES+=("$line")
+            else OUT_LINES+=("$fixed"); changed=true; N_FIXED=$((N_FIXED+1)); fi
+        else
+            OUT_LINES+=("$line"); N_UNRESOLVED=$((N_UNRESOLVED+1)); report unresolved "$name (no version/tool)"
+        fi
+    done
+    CHANGED="$changed"
+}
+
+process_docker() {
+    local marker="$1" kind="$2" changed=false
+    local line key ref name tag rest resolved ver digest newref re req
+    OUT_LINES=(); CHANGED=false
+    if [[ "$kind" == "compose" ]]; then re='^([[:space:]]*image:[[:space:]]*)([^[:space:]#]+)(.*)$'
+    else re='^([[:space:]]*FROM[[:space:]]+)([^[:space:]#]+)(.*)$'; fi
+    [[ ${#FILE_LINES[@]} -gt 0 ]] || return 0
+    for line in "${FILE_LINES[@]}"; do
+        if [[ ! "$line" =~ $re ]]; then OUT_LINES+=("$line"); continue; fi
+        key="${BASH_REMATCH[1]}"; ref="${BASH_REMATCH[2]}"; rest="${BASH_REMATCH[3]}"
+        if [[ "$line" == *"$marker"* ]]; then
+            OUT_LINES+=("$line"); N_BYPASSED=$((N_BYPASSED+1)); report bypassed "$ref"; continue
+        fi
+        if [[ "$ref" == *"@sha256:"* ]]; then OUT_LINES+=("$line"); N_COMPLIANT=$((N_COMPLIANT+1)); continue; fi
+        if [[ "$ref" == *:* ]]; then name="${ref%%:*}"; tag="${ref##*:}"; else name="$ref"; tag="latest"; fi
+        N_VIOLATION=$((N_VIOLATION+1))
+        req="$(requested_for "$name")"
+        if resolved="$(resolve docker "$name" "$tag" "$req")"; then
+            ver="${resolved%%	*}"; digest="${resolved#*	}"
+            newref="${name}:${ver}"
+            [[ -n "$digest" ]] && newref="${newref}@${digest}"
+            report violation "$ref -> $newref"
+            if $CHECK_ONLY; then OUT_LINES+=("$line")
+            else OUT_LINES+=("${key}${newref}${rest}"); changed=true; N_FIXED=$((N_FIXED+1)); fi
+        else
+            OUT_LINES+=("$line"); N_UNRESOLVED=$((N_UNRESOLVED+1)); report unresolved "$name (cannot infer specific version from '$tag')"
+        fi
+    done
+    CHANGED="$changed"
+}
+
+process_file() {
+    local file="$1" eco="$2" rule_id="$3" marker
+    marker="$(bypass_marker)"
+    N_FILES=$((N_FILES+1))
+    echo "version-pin: ${file}"
+    read_file "$file"
+    case "$eco" in
+        pip) process_pip "$marker"; write_back "$file" "$CHANGED" ;;
+        docker)
+            case "$rule_id" in
+                dockerfile) process_docker "$marker" dockerfile ;;
+                *) process_docker "$marker" compose ;;
+            esac
+            write_back "$file" "$CHANGED" ;;
+        *) report unresolved "ecosystem '$eco' has no parser (skipped)"; N_UNRESOLVED=$((N_UNRESOLVED+1)) ;;
+    esac
+}
+
+collect_files() {
+    local p
+    for p in "${PATHS[@]}"; do
+        if [[ -f "$p" ]]; then echo "$p"
+        elif [[ -d "$p" ]]; then
+            find "$p" -type f \( -name 'requirements*.txt' -o -name 'docker-compose.y*ml' \
+                 -o -name 'compose.y*ml' -o -name 'Dockerfile' -o -name 'Dockerfile.*' \
+                 -o -name '*.Dockerfile' \) 2>/dev/null
+        else
+            err "path not found: $p"
+        fi
+    done
+}
+
+main() {
+    parse_args "$@"
+    local rules; rules="$(load_rules)"
+    [[ -n "$rules" ]] || usage_error "no version_pin rules in $CONFIG"
+
+    local explicit_unmatched=true
+    [[ -d "${PATHS[0]}" ]] && explicit_unmatched=false
+
+    local file base matched id eco hash globs
+    while IFS='' read -r file; do
+        [[ -n "$file" ]] || continue
+        base="$(basename "$file")"
+        matched=false
+        while IFS=$'\t' read -r id eco hash globs; do
+            [[ -z "$id" ]] && continue
+            [[ -n "$RULE_FILTER" && "$RULE_FILTER" != "$id" ]] && continue
+            if file_matches_globs "$base" "$globs"; then
+                process_file "$file" "$eco" "$id"; matched=true; break
+            fi
+        done <<< "$rules"
+        if [[ "$matched" == false && -f "$file" ]] && $explicit_unmatched; then
+            echo "version-pin: ${file}"; report unresolved "no applicable rules"
+        fi
+    done < <(collect_files)
+
+    local mode="fixed"; $CHECK_ONLY && mode="reported"
+    echo "Summary: ${N_FILES} files, ${N_VIOLATION} violations ${mode}, ${N_COMPLIANT} compliant, ${N_BYPASSED} bypassed, ${N_UNRESOLVED} unresolved"
+    if $CHECK_ONLY && [[ $N_VIOLATION -gt 0 ]]; then return 1; fi
+    return 0
+}
+
+main "$@"

--- a/configs/claude/scripts/version_pin_hook.sh
+++ b/configs/claude/scripts/version_pin_hook.sh
@@ -15,13 +15,17 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Extract tool_input.file_path from the PostToolUse payload (empty if absent).
+# Extract the edited file path from the PostToolUse payload (empty if absent).
+# Prefer .tool_input.file_path, fall back to a top-level .file_path — payload
+# shape varies across Claude Code versions / tools (mirrors ai-hooks-integration:
+# `.tool_input.file_path // .file_path`).
 file="$(python3 -c 'import json,sys
 try:
     d = json.load(sys.stdin)
 except Exception:
     print(""); sys.exit(0)
-print((d.get("tool_input") or {}).get("file_path","") or "")' 2>/dev/null || true)"
+ti = d.get("tool_input") or {}
+print(ti.get("file_path") or d.get("file_path") or "")' 2>/dev/null || true)"
 
 [[ -n "$file" && -f "$file" ]] || exit 0
 

--- a/configs/claude/scripts/version_pin_hook.sh
+++ b/configs/claude/scripts/version_pin_hook.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# version_pin_hook.sh - PostToolUse adapter for version_pin.sh (warn-only)
+#
+# Reads the Claude Code PostToolUse JSON payload on stdin, extracts the edited
+# file path, and — only for recognized version-pinned file names — runs
+# version_pin.sh in warn-only mode. Advisory only: always exits 0 so it never
+# blocks an edit; the pinning report (if any) is written to stderr.
+#
+# Wire via settings.local.json:
+#   "hooks": { "PostToolUse": [ { "matcher": "Write|Edit",
+#     "hooks": [ { "type": "command",
+#       "command": "~/.claude/scripts/version_pin_hook.sh" } ] } ] }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Extract tool_input.file_path from the PostToolUse payload (empty if absent).
+file="$(python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(""); sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path","") or "")' 2>/dev/null || true)"
+
+[[ -n "$file" && -f "$file" ]] || exit 0
+
+# Only act on recognized, version-pinnable file names (keeps unrelated edits quiet).
+case "$(basename "$file")" in
+    requirements.txt|requirements*.txt|docker-compose.yml|docker-compose.yaml|\
+    compose.yml|compose.yaml|Dockerfile|Dockerfile.*|*.Dockerfile)
+        "${SCRIPT_DIR}/version_pin.sh" --check "$file" >&2 || true
+        ;;
+esac
+
+exit 0

--- a/configs/claude/settings.local.json
+++ b/configs/claude/settings.local.json
@@ -5,6 +5,10 @@
       "Bash(~/.claude/scripts/git_ops.sh:*)",
       "Bash(~/.claude/scripts/label_sync.sh:*)",
       "Bash(~/.claude/scripts/linear_ops.sh:*)",
+      "Bash(~/.claude/scripts/version_pin.sh:*)",
+      "Bash(~/.claude/scripts/version_pin_hook.sh:*)",
+      "Bash(~/.claude/scripts/pr_review.sh:*)",
+      "Bash(~/.claude/scripts/branch_clean.sh:*)",
       "Bash(shellcheck:*)",
       "Bash(python3:*)",
       "Bash(pip3 install:*)",
@@ -24,6 +28,19 @@
       "WebFetch(domain:github.com)",
       "WebFetch(domain:gist.github.com)",
       "WebFetch(domain:docs.github.com)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/version_pin_hook.sh"
+          }
+        ]
+      }
     ]
   },
   "mcpServers": {

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -41,6 +41,10 @@ Manifest ships with 13 slash commands, 1 CLI tool, and 14 skills (1 auto-trigger
 | `/checkpoint` | Create compact checkpoint summary when context is high | NO |
 | `/health-check` | Verify CLI tools, auth, config syntax, MCP, symlinks | NO |
 | `/sync-configs` | Detect cross-platform config drift and broken symlinks | NO |
+| `/version-pin` | Enforce specific, hashed version pins in dependency files (auto-fix on demand; warn-only save hook) | ALWAYS (Tier 1) |
+| `/docs-all` | Run docs-readme/docs-diagrams/docs-improve as sub-agents in one pass | NO |
+| `/pr-review` | Review all open PRs and recommend a disposition per PR (analysis-only) | NO |
+| `/branch-clean` | Prune merged/gone/stale branches safely (dry-run by default, local-only) | CONDITIONAL (--apply) |
 
 **CLI tool** (installed to `~/.local/bin/`):
 

--- a/specs/002-new-agent-skills/checklists/requirements.md
+++ b/specs/002-new-agent-skills/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: New Agent Skills (Version Pinning, Docs Orchestration, PR Review, Branch Cleanup)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All three high-impact scope decisions were resolved with the user before writing the spec:
+  1. PR Reviewer and Branch Cleaner → **two separate skills**.
+  2. Version-pinning enforcement → **auto-fix in place with an explicit bypass**.
+  3. Docs orchestration order → **decided per run** with a documented default precedence as fallback.
+- The spec names a few repo-internal artifacts (`.skillshare/skills/`, `git_ops.sh`, `command_config.yml`) in the Requirements/Assumptions. These are intentional: this feature's "users" are repo maintainers and the deliverables are skills within this configuration repo, so these are scope boundaries rather than premature implementation choices. The plan phase will detail the how.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/002-new-agent-skills/contracts/branch-clean.md
+++ b/specs/002-new-agent-skills/contracts/branch-clean.md
@@ -1,0 +1,43 @@
+# Contract: `branch-clean`
+
+**Type**: Claude Code skill (`/branch-clean`) + helper `configs/claude/scripts/branch_clean.sh`.
+
+## Invocation
+
+```
+/branch-clean [--apply] [--include-remote] [--stale-days N] [--protect <glob>...]
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| (none) | dry-run | Preview candidates only; delete nothing (FR-018). |
+| `--apply` | off | Perform deletions after confirmation. |
+| `--include-remote` | off | Opt-in to remote-branch deletion; otherwise local-only (FR-016a). |
+| `--stale-days` | config / 90 | Threshold for the `stale` category. |
+| `--protect <glob>` | config defaults | Additional protected patterns. |
+
+## Behavior contract
+
+- **MUST** classify candidates by reason `merged` / `gone` / `stale` (FR-016, data-model §4).
+- **MUST** default to local scope; remote deletion only under `--include-remote` (FR-016a).
+- **MUST** never propose default/protected/current-HEAD branches (FR-017), and never enter the `merged` category for unmerged branches (FR-020).
+- **MUST** default to dry-run; delete only with `--apply` + confirmation (FR-018).
+- **MUST** report each deletion outcome incl. failures (FR-019).
+
+## Output schema
+
+```
+branch-clean (dry-run | apply) — scope: local[+remote]
+Merged into <default>:
+  - feature/x        (merged)        [delete-candidate]
+Gone upstream:
+  - feature/y        (gone)          [delete-candidate]
+Stale > Nd:
+  - spike/z          (stale, 120d)   [delete-candidate]
+Protected (skipped): main, release/*, <current>
+Summary: K candidates; [dry-run: nothing deleted | applied: D deleted, F failed]
+```
+
+## Acceptance mapping
+
+US4 scenarios 1–5 → this contract. Tier 1 on `--apply` (destructive), Tier 2 dry-run.

--- a/specs/002-new-agent-skills/contracts/docs-all.md
+++ b/specs/002-new-agent-skills/contracts/docs-all.md
@@ -1,0 +1,35 @@
+# Contract: `docs-all`
+
+**Type**: Claude Code skill (`/docs-all`). Pure sub-agent orchestration — no helper script.
+
+## Invocation
+
+```
+/docs-all [<path>] [--order readme,diagrams,improve]
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `<path>` | repo root | Scope passed through to sub-skills. |
+| `--order` | auto (per-run) | Override the chosen order explicitly. |
+
+## Behavior contract
+
+- **MUST** dispatch `docs-readme`, `docs-diagrams`, `docs-improve` each as an independent sub-agent (Agent tool) (FR-008).
+- **MUST** choose order per run from changed-file signals, falling back to documented default `readme → diagrams → improve`, and **MUST** keep `docs-improve` after the other two (FR-009, R7).
+- **MUST** continue remaining sub-agents if one fails and surface the failure (FR-011).
+- **MUST** emit one consolidated report (data-model §5) stating order, rationale, and per-sub-skill outcome (FR-010).
+
+## Output schema
+
+```
+docs-all report
+Order: readme → diagrams → improve   (reason: <signal | default fallback>)
+- docs-readme    : success  — <1-line summary>
+- docs-diagrams  : success  — <1-line summary>
+- docs-improve   : failed   — <error>
+```
+
+## Acceptance mapping
+
+US2 scenarios 1–4 → this contract. Tier 2 validation.

--- a/specs/002-new-agent-skills/contracts/pr-review.md
+++ b/specs/002-new-agent-skills/contracts/pr-review.md
@@ -1,0 +1,38 @@
+# Contract: `pr-review`
+
+**Type**: Claude Code skill (`/pr-review`) + helper `configs/claude/scripts/pr_review.sh` (wraps `git_ops.sh` / `git_platform.sh`).
+
+## Invocation
+
+```
+/pr-review [--platform github|gitlab] [--stale-days N] [--json]
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--platform` | auto-detect | Override `git_platform.sh` detection. |
+| `--stale-days` | config / 30 | Activity threshold for staleness signal. |
+| `--json` | off | Emit machine-readable records. |
+
+## Behavior contract
+
+- **MUST** enumerate ALL open PRs via `git_ops.sh pr-list` and enrich each via `pr-view`/`pr-diff`/`pr-checks` (FR-012, R5).
+- **MUST** produce per-PR: status, mergeability, staleness, superseded/merged flags, disposition + rationale (FR-013, data-model §3).
+- **MUST** be analysis-only: zero mutations without an explicit action (FR-014). (Acting on a recommendation is a separate, confirmed step — out of scope for this skill's default run.)
+- **MUST** report empty queue cleanly and unauthenticated/no-API distinctly (not as "clean") (FR-015).
+
+## Output schema
+
+```
+Open PRs on <platform>: N
+#<id>  <title>            <age>  <mergeable>/<checks>  → <disposition>
+       rationale: <one line>
+...
+Recommended: close C, merge M, rebase R, keep K
+```
+
+`--json`: array of PR Assessment records (data-model §3).
+
+## Acceptance mapping
+
+US3 scenarios 1–4 → this contract. Tier 2 validation.

--- a/specs/002-new-agent-skills/contracts/version-pin.md
+++ b/specs/002-new-agent-skills/contracts/version-pin.md
@@ -19,6 +19,11 @@
 
 - **MUST** classify each parsed reference as `compliant` / `violation` / `bypassed` / `unresolved` (data-model §1).
 - On-demand (no `--check`): **MUST** rewrite `violation` entries in place to specific version + hash where the rule's `hash` ≠ `none` (FR-003a).
+- **Hash policy is enforced**: when the rule's `hash` is `required`/`digest` and a hash/digest cannot be obtained, the entry is `unresolved` and the file is left untouched — never rewritten into an unhashed/mutable reference.
+- **Docker mutable tags**: a mutable tag (`latest` or no tag) is pinned **by digest** with the tag label preserved (e.g. `postgres:latest@sha256:…`) — the digest is what makes it reproducible. Supply `--requested name=VERSION` to also pin a specific version label (e.g. `postgres:16.2@sha256:…`).
+- **Edits preserve the rest of the line**: pip extras and environment markers (`requests[socks]==X; python_version<"3.12"`) and Dockerfile `FROM` flags / `AS` stage names are retained; only the version/hash is tightened.
+- **Registry ports** (`registry.host:5000/team/app:1.2`) are not mistaken for tags.
+- Recognized files (for directory scans and the hook) are derived from the config rule globs — adding a rule extends coverage with no script change.
 - `--check` (hook): **MUST NOT** edit any file; **MUST** print each violation with its exact proposed pinned line; exit non-zero if any violation found (FR-005).
 - **MUST** leave `compliant` and `bypassed` entries byte-for-byte unchanged (FR-004/FR-006); re-run is a no-op (SC-002).
 - **MUST** treat missing native tool / offline / yanked / malformed file as `unresolved` warning — no partial rewrite (FR-007).

--- a/specs/002-new-agent-skills/contracts/version-pin.md
+++ b/specs/002-new-agent-skills/contracts/version-pin.md
@@ -1,0 +1,41 @@
+# Contract: `version-pin`
+
+**Type**: Claude Code skill (`/version-pin`) + helper `configs/claude/scripts/version_pin.sh` + warn-only hook.
+
+## Invocation
+
+```
+/version-pin [<path>] [--check] [--requested <pkg>=<version>] [--rule <id>]
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `<path>` | working tree | File or directory to scan; unspecified ⇒ all recognized files in the tree. |
+| `--check` | off | Warn-only: report violations + fixes, make NO edits (this is the hook mode). |
+| `--requested pkg=ver` | latest stable | Pin the named dep to an exact requested version instead of latest stable. |
+| `--rule <id>` | all matching | Limit to one rule-set entry. |
+
+## Behavior contract
+
+- **MUST** classify each parsed reference as `compliant` / `violation` / `bypassed` / `unresolved` (data-model §1).
+- On-demand (no `--check`): **MUST** rewrite `violation` entries in place to specific version + hash where the rule's `hash` ≠ `none` (FR-003a).
+- `--check` (hook): **MUST NOT** edit any file; **MUST** print each violation with its exact proposed pinned line; exit non-zero if any violation found (FR-005).
+- **MUST** leave `compliant` and `bypassed` entries byte-for-byte unchanged (FR-004/FR-006); re-run is a no-op (SC-002).
+- **MUST** treat missing native tool / offline / yanked / malformed file as `unresolved` warning — no partial rewrite (FR-007).
+
+## Output schema (stdout, human + `--check` summary)
+
+```
+version-pin: <file>
+  ✔ compliant   <name> <version> (<hash-prefix>)
+  ✖ violation   <name> <current> → <resolved>==<version> --hash=sha256:<...>
+  ⤼ bypassed    <name>            (reason: <text>)
+  ⚠ unresolved  <name>            (<why>)
+Summary: F files, V violations [fixed|reported], B bypassed, U unresolved
+```
+
+Exit codes: `0` = no violations (or all fixed on-demand); `1` = violations remain (`--check`); `2` = usage/config error.
+
+## Acceptance mapping
+
+US1 scenarios 1–6 → this contract. Tier 1 validation (security/supply-chain).

--- a/specs/002-new-agent-skills/data-model.md
+++ b/specs/002-new-agent-skills/data-model.md
@@ -1,0 +1,139 @@
+# Phase 1 Data Model: New Agent Skills
+
+**Feature**: 002-new-agent-skills | **Date**: 2026-06-01
+
+These skills have no persistent datastore. The "data model" is the set of in-memory /
+on-the-wire structures the helper scripts and SKILL.md workflows produce and consume,
+plus the YAML config schema that parameterizes them. Structures are described
+language-agnostically; shell scripts emit them as line records or JSON.
+
+---
+
+## 1. Dependency Reference (`version-pin`)
+
+A single pinnable item parsed from a recognized file.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `file` | path | Source file (relative to repo root in reports). |
+| `line_no` | int | 1-based line for reporting. |
+| `ecosystem` | enum | `pip` \| `docker` \| `npm` \| `gha` \| ... (from rule set). |
+| `name` | string | Dependency / image / action identifier. |
+| `current_expr` | string | Raw current version expression (`latest`, `^1.2`, empty, ...). |
+| `resolved_version` | string \| null | Specific version from native tool; null if unresolved. |
+| `hash` | string \| null | Integrity hash/digest; null when ecosystem has none or unresolved. |
+| `state` | enum | `compliant` \| `violation` \| `bypassed` \| `unresolved`. |
+| `bypass_reason` | string \| null | Populated when `state == bypassed`. |
+
+**Validation / rules**:
+- `violation` ⇔ loose per FR-001 (no specific version, mutable tag, or missing hash where supported).
+- `compliant` entries are emitted unchanged (FR-006); a second run reclassifies any prior fix as `compliant` (idempotency, SC-002).
+- `unresolved` ⇒ non-fatal warning (FR-007); file untouched for that entry.
+- `bypassed` ⇒ inline marker present (R3); line left byte-for-byte unchanged.
+
+**Lifecycle**: `parsed → classified(state) → [on-demand] rewritten | [hook] reported`.
+
+---
+
+## 2. Pinning Rule Set (`version-pin`, config)
+
+Schema for the `version_pin` block in `command_config.yml`. Data, not code (R4).
+
+```yaml
+version_pin:
+  rules:
+    - id: pip-requirements
+      match: ["requirements*.txt"]          # glob(s)
+      ecosystem: pip
+      resolve_cmd: "pip-compile --generate-hashes"  # native tool (R1)
+      hash: required                         # required | optional | none
+    - id: docker-compose
+      match: ["docker-compose.yml", "docker-compose.yaml", "compose.yaml"]
+      ecosystem: docker
+      resolve_cmd: "docker manifest inspect"
+      hash: digest
+    # ... Dockerfile, package.json, github-actions
+  protected_bypass_marker: "version-pin:ignore"
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `rules[].id` | string | Unique rule key. |
+| `rules[].match` | glob[] | File names/patterns the hook + on-demand run apply to. |
+| `rules[].ecosystem` | enum | Drives parser + hash form. |
+| `rules[].resolve_cmd` | string | Native tool invocation (R1); absence ⇒ warning. |
+| `rules[].hash` | enum | `required` \| `optional` \| `digest` \| `none`. |
+
+---
+
+## 3. PR Assessment (`pr-review`)
+
+One record per open PR.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string | PR/MR number. |
+| `title` | string | |
+| `author` | string | |
+| `age_days` | int | Days since last activity. |
+| `mergeable` | enum | `clean` \| `conflicting` \| `unknown`. |
+| `checks` | enum | `passing` \| `failing` \| `pending` \| `none`. |
+| `branch_merged` | bool | Head already merged into base. |
+| `superseded_by` | string \| null | Another open PR covering the same branch/scope. |
+| `draft` | bool | |
+| `disposition` | enum | `keep` \| `merge` \| `close` \| `needs-rebase`. |
+| `rationale` | string | One-line justification (FR-013). |
+
+**Disposition heuristic** (R5): `branch_merged \|\| superseded_by` → `close`;
+`conflicting \|\| checks==failing` → `needs-rebase`; `mergeable==clean && checks==passing && !draft` → `merge`; else `keep`.
+
+**Invariant**: produced read-only; no field mutates a PR (FR-014).
+
+---
+
+## 4. Branch Candidate (`branch-clean`)
+
+One record per local branch (and remote when `--include-remote`).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Branch short name. |
+| `scope` | enum | `local` \| `remote`. |
+| `reason` | enum | `merged` \| `gone` \| `stale` \| `none`. |
+| `last_activity_days` | int | For `stale` classification. |
+| `protected` | bool | Default/release/current-HEAD ⇒ true (FR-017). |
+| `is_current` | bool | Checked-out branch. |
+| `proposed_action` | enum | `delete-candidate` \| `skip-protected` \| `skip-unmerged`. |
+| `delete_result` | enum \| null | `deleted` \| `failed` \| null (dry-run). |
+
+**Rules**:
+- `protected \|\| is_current` ⇒ `proposed_action = skip-protected`, never a candidate (FR-017).
+- Unmerged branch ⇒ never `reason == merged`; default path never force-deletes (FR-020).
+- `delete_result` populated only on `--apply`; failures reported, not swallowed (FR-019).
+
+---
+
+## 5. Docs Run Report (`docs-all`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `order` | string[] | Ordered sub-skill names actually invoked. |
+| `precedence_reason` | string | Why this order (changed-file signal or "default fallback"). |
+| `results[]` | record[] | Per sub-skill: `{ skill, status: success\|failed\|skipped, summary }`. |
+
+**Rules**: every dispatched sub-skill appears in `results` (FR-010); a `failed` entry does
+not abort remaining sub-agents (FR-011); `docs-improve` ordered after the others (R7).
+
+---
+
+## Cross-cutting: Skill Registration (config, all four)
+
+Per skill, two config additions (FR-021/FR-022):
+
+- `command_config.yml → tool_policies.<skill>`: `allowed[]`, `forbidden[]`,
+  `parallel_agents`, `validation_tier`, optional `mcp_servers[]`.
+- `validation_criteria.yml → command_overrides.<skill>`: `tier1_required`,
+  `tier2_required`, `tier2_checks[]`, `parallel_agents` / `_condition`.
+
+Tier assignment (R8): `version-pin` Tier 1; `branch-clean` Tier 1 on `--apply`;
+`docs-all` and `pr-review` Tier 2.

--- a/specs/002-new-agent-skills/plan.md
+++ b/specs/002-new-agent-skills/plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: New Agent Skills (Version Pinning, Docs Orchestration, PR Review, Branch Cleanup)
+
+**Branch**: `002-new-agent-skills` | **Date**: 2026-06-01 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/002-new-agent-skills/spec.md`
+
+## Summary
+
+Add four discrete, independently-invocable Claude Code skills to the Manifest
+configuration repository, each authored as a `SKILL.md` under
+`.skillshare/skills/<name>/` (source of truth), registered in
+`command_config.yml` tool policies and `validation_criteria.yml` overrides, and
+documented in the repo's command listings:
+
+1. **`version-pin`** — detect loose dependency references (`latest`, missing version,
+   unbounded range, missing hash) in recognized files; resolve specific versions + integrity
+   hashes via **native package-manager tooling**; auto-fix in place on explicit invocation,
+   **warn-only** when fired from the save-triggered hook; explicit per-entry bypass.
+2. **`docs-all`** — orchestrate the existing `docs-readme` / `docs-diagrams` / `docs-improve`
+   skills as sub-agents, choosing order per run with a documented default precedence fallback,
+   aggregating one consolidated report.
+3. **`pr-review`** — enumerate all open PRs via the existing `git_ops.sh` abstraction, recommend a
+   disposition per PR, analysis-only by default.
+4. **`branch-clean`** — identify merged / `[gone]` / stale branch candidates, dry-run by default,
+   **local-only** deletion by default with remote deletion behind an explicit flag, never touching
+   protected/current branches.
+
+Technical approach: skills are Markdown instruction documents (prompt-as-program), not compiled
+code. `version-pin`, `pr-review`, and `branch-clean` are backed by new shell helper scripts under
+`configs/claude/scripts/` (consistent with `git_ops.sh`, `label_sync.sh`); `docs-all` is pure
+orchestration via the Agent/sub-agent mechanism with no new script. The `version-pin` hook is wired
+through the existing `ai-hooks-integration` skill / `settings` hooks mechanism, not a new framework.
+
+## Technical Context
+
+**Language/Version**: Bash (POSIX-leaning, shellcheck-clean) for helper scripts; Markdown for SKILL.md instruction bodies; Python 3 only where a YAML/parse helper is unavoidable (mirrors existing repo scripts).
+
+**Primary Dependencies**: Existing repo scripts (`git_ops.sh`, `git_platform.sh`); platform CLIs `gh` / `glab`; native package managers invoked on demand (`pip`/`pip-compile`, `docker` manifest/buildx, `npm`) — all degrade to reported warnings when absent.
+
+**Storage**: Files only — target dependency files in the working tree, plus repo config YAML (`command_config.yml`, `validation_criteria.yml`). No database.
+
+**Testing**: `bats tests/bats/` for shell helpers; `pytest tests/python/` for any Python helper; `shellcheck` + `yamllint` lint gates per the constitution.
+
+**Target Platform**: Developer macOS/Linux workstations running Claude Code (and the Cursor/Gemini/Codex/Antigravity deploy targets via symlink).
+
+**Project Type**: Agent-configuration repository — skills + supporting shell scripts (single project).
+
+**Performance Goals**: Not throughput-bound; interactive CLI skills. `version-pin` resolution latency is dominated by package-manager/registry calls and is bounded only by being non-blocking on the hook path (warn-only).
+
+**Constraints**: Idempotent (`version-pin` second run = no-op; SC-002); no silent failures (constitution Tier 1); analysis-only / dry-run defaults for destructive operations; `configs/claude/skills` must remain a symlink.
+
+**Scale/Scope**: 4 new skills, ~3 new shell helper scripts, 2 config-file edits, doc updates, and a hook registration recipe. Tens-to-hundreds of dependency lines / PRs / branches per run.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Configuration-as-Code | ✅ PASS | All four skills + scripts live in `configs/`/`.skillshare/`, deployed via `bootstrap.sh`. No manual edits to deployed `~/.claude`. |
+| II. Parallel Agent Orchestration | ✅ PASS | `version-pin` is security-sensitive (supply chain) → flagged for parallel-agent review at PR time. `docs-all` itself *is* a multi-sub-agent orchestrator. |
+| III. Consensus-Driven Decisions | ✅ PASS | New skills inherit the standard consensus thresholds; `version-pin` set to Tier 1. |
+| IV. Skill-First Extensibility | ✅ PASS | Each capability is a discrete `SKILL.md`; no expansion of `parallel_agent.py`. Helper scripts are siblings of existing `git_ops.sh`, not core-engine changes. |
+| V. Bootstrap Reproducibility | ✅ PASS | Skills are files copied by existing `deploy_home_skills`; no new install step. Hook registration is idempotent (guarded). |
+
+**Result**: PASS — no violations. Complexity Tracking table not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-new-agent-skills/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output — CLI command schemas per skill
+│   ├── version-pin.md
+│   ├── docs-all.md
+│   ├── pr-review.md
+│   └── branch-clean.md
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+.skillshare/skills/                  # Source of truth for skills
+├── version-pin/SKILL.md             # NEW — pinning skill instruction body
+├── docs-all/SKILL.md                # NEW — docs orchestration
+├── pr-review/SKILL.md               # NEW — open-PR triage
+└── branch-clean/SKILL.md            # NEW — branch cleanup
+# (configs/claude/skills is a symlink → .skillshare/skills; not modified directly)
+
+configs/claude/scripts/
+├── version_pin.sh                   # NEW — detect/resolve/rewrite pinning logic
+├── pr_review.sh                     # NEW — enumerate + assess open PRs (wraps git_ops.sh)
+├── branch_clean.sh                  # NEW — identify + (confirm) delete branch candidates
+├── git_ops.sh                       # EXISTING — reused by pr_review.sh / branch_clean.sh
+└── git_platform.sh                  # EXISTING — reused for platform detection
+
+configs/claude/config/
+├── command_config.yml               # EDIT — add tool_policies for 4 skills + pinning rule set
+└── validation_criteria.yml          # EDIT — add command_overrides for 4 skills
+
+configs/claude/hooks/ (or settings)  # EDIT — register version-pin warn-only hook recipe
+                                     #        via ai-hooks-integration conventions
+
+tests/
+├── bats/
+│   ├── version_pin.bats             # NEW — pin detection/rewrite/idempotency/bypass
+│   ├── pr_review.bats               # NEW — enumeration + disposition + analysis-only
+│   └── branch_clean.bats            # NEW — candidate grouping + protected/dry-run safety
+└── python/                          # (only if a Python parse helper is introduced)
+
+docs/COMMANDS.md                     # EDIT — list the 4 new skills
+CLAUDE.md / configs/claude/CLAUDE.md # EDIT — add skills to command tables
+```
+
+**Structure Decision**: Single-project layout matching the existing repo. Skills are
+instruction Markdown in `.skillshare/skills/`; their non-trivial logic lives in
+companion shell scripts under `configs/claude/scripts/` (the established pattern set by
+`git_ops.sh` and `label_sync.sh`), keeping SKILL.md bodies focused on workflow and the
+scripts independently testable via `bats`. `docs-all` needs no script — it is pure
+sub-agent orchestration.
+
+## Complexity Tracking
+
+> No constitution violations. Section intentionally empty.

--- a/specs/002-new-agent-skills/quickstart.md
+++ b/specs/002-new-agent-skills/quickstart.md
@@ -1,0 +1,99 @@
+# Quickstart: New Agent Skills
+
+**Feature**: 002-new-agent-skills | **Date**: 2026-06-01
+
+How a maintainer uses the four new skills once implemented and deployed
+(`./bootstrap.sh` copies them to `~/.claude/skills`).
+
+---
+
+## version-pin
+
+```bash
+# Audit + auto-fix every recognized file in the working tree
+/version-pin
+
+# Audit one file, warn-only (no edits) — same mode the save hook uses
+/version-pin requirements.txt --check
+
+# Pin a specific requested version instead of latest stable
+/version-pin requirements.txt --requested requests=2.31.0
+```
+
+Register the warn-only save hook (idempotent) via the `ai-hooks-integration` skill so
+`requirements.txt`, `docker-compose.yaml`, Dockerfiles, etc. are checked on write.
+
+**Expected**: loose entries reported with the exact pinned+hashed replacement; already-pinned
+and `# version-pin:ignore`-marked entries untouched; a clean second run reports no changes.
+
+## docs-all
+
+```bash
+# Refresh all documentation in one command
+/docs-all
+
+# Force an explicit order
+/docs-all --order readme,diagrams,improve
+```
+
+**Expected**: one consolidated report listing the order chosen, why, and each sub-skill's
+outcome; a single sub-skill failure does not abort the others.
+
+**Verification scenario** (manual — `docs-all` is orchestration, no script/bats):
+
+1. Run `/docs-all` on the repo. Confirm the report lists all three sub-skills
+   (`docs-readme`, `docs-diagrams`, `docs-improve`), each dispatched as a sub-agent.
+2. Confirm the report states the **order** and a **reason** line, and that
+   `docs-improve` appears **last**.
+3. Make a change touching only architecture/imports, run again, and confirm the
+   order adapts (diagrams prioritized) while the report still explains the precedence.
+4. Temporarily make one sub-skill fail (e.g. point it at a missing path); confirm
+   its failure is surfaced in the report and the other two still run.
+
+## pr-review
+
+```bash
+# Triage every open PR (read-only)
+/pr-review
+
+# Machine-readable, custom staleness window
+/pr-review --json --stale-days 14
+```
+
+**Expected**: one row per open PR with mergeability/checks/staleness and a recommended
+disposition (keep/merge/close/needs-rebase) + rationale. No PRs are modified.
+
+## branch-clean
+
+```bash
+# Preview deletable branches (default: dry-run, local only)
+/branch-clean
+
+# Actually delete, after confirmation
+/branch-clean --apply
+
+# Include remote branches (opt-in)
+/branch-clean --apply --include-remote
+```
+
+**Expected**: candidates grouped by reason (merged / gone / stale); protected and current
+branches never listed for deletion; nothing deleted without `--apply` + confirmation.
+
+---
+
+## Verifying the implementation
+
+```bash
+# Shell helper tests
+bats tests/bats/version_pin.bats tests/bats/pr_review.bats tests/bats/branch_clean.bats
+
+# Lint
+shellcheck configs/claude/scripts/version_pin.sh configs/claude/scripts/pr_review.sh configs/claude/scripts/branch_clean.sh
+yamllint configs/claude/config/command_config.yml configs/claude/config/validation_criteria.yml
+
+# Config parses
+python3 -c "import yaml; yaml.safe_load(open('configs/claude/config/command_config.yml'))"
+
+# Skills discoverable after deploy
+./bootstrap.sh && ls ~/.claude/skills | grep -E 'version-pin|docs-all|pr-review|branch-clean'
+```

--- a/specs/002-new-agent-skills/research.md
+++ b/specs/002-new-agent-skills/research.md
@@ -1,0 +1,168 @@
+# Phase 0 Research: New Agent Skills
+
+**Feature**: 002-new-agent-skills | **Date**: 2026-06-01
+
+All spec-level `NEEDS CLARIFICATION` items were resolved during `/speckit-clarify`
+(see spec §Clarifications). This document records the design decisions that flow from
+those clarifications plus integration/best-practice research for each skill.
+
+---
+
+## R1. Version resolution + integrity hashing per ecosystem (`version-pin`)
+
+**Decision**: Resolve specific versions and integrity hashes by shelling out to each
+ecosystem's native tooling, never by guessing. Per-ecosystem mapping:
+
+| File / type | Detect loose | Resolve version | Hash form | Native tool |
+|-------------|-------------|-----------------|-----------|-------------|
+| `requirements.txt` | no `==`, range only, no `--hash` | `pip index versions` / `pip-compile --generate-hashes` | `--hash=sha256:...` | `pip` / `pip-compile` |
+| `docker-compose.{yml,yaml}` | `image: x:latest` or no digest | `docker manifest inspect` | `@sha256:...` digest | `docker` |
+| `Dockerfile` | `FROM x:latest` / no digest | `docker manifest inspect` | `@sha256:` digest | `docker` |
+| `package.json` / npm | `^`/`~`/`latest` | `npm view <pkg> version` | integrity from `package-lock.json` | `npm` |
+| GitHub Actions `uses: org/action@vN` | mutable tag/branch ref | resolve tag → commit SHA | full 40-char commit SHA | `git ls-remote` / `gh api` |
+
+**Rationale**: Native tools produce the same versions/hashes the build will actually use,
+avoiding the correctness and maintenance burden of bespoke registry clients. Matches the
+user's clarification (native package managers).
+
+**Alternatives considered**:
+- Direct registry HTTP APIs (PyPI JSON, Docker Registry v2) — rejected: more per-ecosystem
+  bespoke code and divergence risk from what the package manager resolves.
+- Lockfile-only — rejected as primary: lockfiles don't always exist for every target file
+  (e.g. a hand-written `requirements.txt` without `pip-compile`); used opportunistically.
+
+**Failure mode**: When the native tool is absent or offline, emit a reported warning
+(FR-002 / FR-007) and leave the entry unchanged — never a silent skip or partial rewrite.
+
+---
+
+## R2. On-demand auto-fix vs. hook warn-only split (`version-pin`)
+
+**Decision**: Two execution modes from one skill/script:
+- **On-demand** (`/version-pin [path]`): resolve + rewrite in place (FR-003a).
+- **Hook path** (save of a tracked file): `--check`/warn-only — print violations and the
+  exact pinned+hashed replacement line, exit non-zero to surface, but make **no edits**
+  (FR-005, spec Clarifications).
+
+**Rationale**: Auto-editing a file mid-edit fights the editor and surprises the user; a
+non-mutating advisory is the correct hook posture. The user explicitly chose warn-only on
+the hook.
+
+**Hook wiring**: Use the existing `ai-hooks-integration` skill conventions (PostToolUse /
+on-write matcher scoped to the recognized file globs) rather than introducing a new hook
+framework. Registration must be idempotent (guarded existence check) per Constitution V.
+
+---
+
+## R3. Bypass mechanism (`version-pin`)
+
+**Decision**: Inline trailing comment marker on the entry, ecosystem-comment-aware, e.g.
+`requests  # version-pin:ignore reason="vendored build"`. The skill skips the line,
+leaves it byte-for-byte unchanged, and lists it under a "Bypassed" group in the summary
+(FR-004).
+
+**Rationale**: Inline markers are self-documenting, travel with the line in diffs/blame,
+and need no side-car config file. Mirrors widely understood `# noqa` / `# nosec` idioms.
+
+**Alternatives considered**: central allowlist file — rejected for v1 (extra indirection,
+drift risk); may be added later as an extension.
+
+---
+
+## R4. Recognized-file rule set is data, not code (`version-pin`)
+
+**Decision**: Express the file→rule mapping as a `version_pin` block in
+`command_config.yml` (globs, loose-pattern regexes, resolver command, hash form). The
+script reads this block so new file types are added by config, not code (FR-005
+"documented, extensible list").
+
+**Rationale**: Consistent with how the repo centralizes policy in YAML
+(`labels.yml`, `command_config.yml`); keeps the skill extensible without script edits.
+
+---
+
+## R5. Reuse existing platform abstraction (`pr-review`, `branch-clean`)
+
+**Decision**: `pr-review` enumerates PRs via `git_ops.sh pr-list` / `pr-view` / `pr-diff`
+/ `pr-checks` (already implemented for github + gitlab) and `git_platform.sh` for
+detection. `branch-clean` uses `git` plumbing directly (`git branch --merged`,
+`git for-each-ref ... [gone]`, `git log -1 --format=%cr`) and `git_platform.sh` only when
+the explicit remote-deletion flag is set.
+
+**Rationale**: Avoids duplicating platform logic; respects Constitution IV (no core-script
+bloat — these are sibling scripts). Note the *existing* `git_ops.sh pr-review` subcommand
+submits a review to one PR — distinct from the new `pr-review` skill which triages *all*
+open PRs read-only; naming overlap is acceptable since they live at different layers.
+
+**Best practice — "is it needed?" signals** (FR-013): per PR collect → mergeable state,
+CI/checks status, age since last activity, branch already merged into base, title/branch
+duplication of another open PR, draft flag. Disposition heuristic: merged-or-superseded →
+*close candidate*; failing/conflicting → *needs-rebase*; clean + approved → *merge*; else
+*keep*.
+
+---
+
+## R6. Branch-clean safety model (`branch-clean`)
+
+**Decision**: Candidate categories: (a) merged into default branch (`git branch --merged
+<default>`), (b) `[gone]` upstream (`git for-each-ref --format '%(refname:short) %(upstream:track)'`),
+(c) stale > threshold (last commit date). Default scope **local only**; remote deletion
+behind `--include-remote` (spec Clarifications, FR-016a). Always exclude default,
+configured protected branches, and current `HEAD` (FR-017). Dry-run preview is the default;
+deletion requires `--apply` + confirmation (FR-018). Unmerged branches never enter the
+"merged" category and are never force-deleted by the default path (FR-020).
+
+**Rationale**: Deletion is destructive and remote deletion affects shared state; safest
+defaults with explicit opt-in. Overlaps conceptually with the `commit-commands:clean_gone`
+plugin command but is platform-aware, grouped-by-reason, and dry-run-first.
+
+**Protected-branch source**: read from a `branch_clean.protected` list in
+`command_config.yml`, defaulting to the detected default branch + common release globs
+(`release/*`, `main`, `master`).
+
+---
+
+## R7. Docs orchestration ordering (`docs-all`)
+
+**Decision**: Dispatch `docs-readme`, `docs-diagrams`, `docs-improve` as independent
+sub-agents (Agent tool / parallel where safe). Choose order per run from changed-file
+signals; documented **default precedence** fallback: `docs-readme` → `docs-diagrams` →
+`docs-improve` (establish facts → visualize structure → quality-pass the whole set last).
+Hard dependency honored: `docs-improve` runs after `docs-readme`/`docs-diagrams` so its
+Diataxis audit sees their output. One consolidated report states order + rationale +
+per-sub-agent outcome; a failing sub-agent is surfaced, others continue (FR-008–011).
+
+**Rationale**: Matches the user's "decide per run with documented default" choice.
+Improve-last maximizes the surface the quality pass evaluates.
+
+**Alternatives considered**: fixed static order — rejected per clarification; fully
+parallel with no ordering — rejected because `docs-improve` depends on prior outputs.
+
+---
+
+## R8. Skill authoring + deployment conventions (all four)
+
+**Decision**: Each skill is `.skillshare/skills/<name>/SKILL.md` with `name` +
+`description` frontmatter (Constitution IV). Tool policies added to
+`command_config.yml.tool_policies`; validation overrides to
+`validation_criteria.yml.command_overrides`. Deployment relies on existing
+`deploy_home_skills` in `bootstrap.sh` — no new install step. `configs/claude/skills`
+stays a symlink.
+
+**Tool-policy decisions**:
+- `version-pin`: `Read, Glob, Grep, Bash, Edit/Write` (must rewrite files); Tier 1 (security/supply-chain).
+- `docs-all`: `Read, Glob, Grep, Agent` (orchestration); Tier 2.
+- `pr-review`: `Read, Glob, Grep, Bash` (gh/glab read-only); Tier 2; mcp: none required.
+- `branch-clean`: `Read, Glob, Grep, Bash`; Tier 1 for the destructive `--apply` path (breaking-changes/error-handling gates), Tier 2 for dry-run.
+
+**Rationale**: Aligns with existing entries (e.g. `refactor-shell` allows Bash for tooling).
+`version-pin` is the only skill granted Edit/Write because it is the only one that mutates
+non-config files; the others are read-only or gated.
+
+---
+
+## Open items deferred to planning/tasks (non-blocking)
+
+- Exact `bats` fixtures per ecosystem (Phase 1 / tasks).
+- Whether a tiny Python YAML helper is needed for `docker-compose` parsing vs. pure-shell
+  (decide during implementation; prefer shell, fall back to Python per repo convention).

--- a/specs/002-new-agent-skills/spec.md
+++ b/specs/002-new-agent-skills/spec.md
@@ -1,0 +1,181 @@
+# Feature Specification: New Agent Skills (Version Pinning, Docs Orchestration, PR Review, Branch Cleanup)
+
+**Feature Branch**: `002-new-agent-skills`
+
+**Created**: 2026-06-01
+
+**Status**: Draft
+
+**Input**: User description: "Add new skills to do the following: Skill: Enforce version pinning — specific version (avoid latest, recommended latest stable, or request version); ensure version pin also includes hash if supported; force it on specific file types / name as a hook (e.g. requirements.txt, docker-compose.yaml, common files that support version pinning). Skill: Create an all-in-one docs command that runs our existing DOCS in sub-agents in the appropriate order to support any order of precedency. Skill: GitHub PR Reviewer (review all open PRs, identify if they are needed...); GitHub/Git Branch Cleaner."
+
+## Clarifications
+
+### Session 2026-06-01
+
+- Q: On the automatic hook path (tracked file saved), should version-pin auto-rewrite or warn-only? → A: Warn-only on the hook (report violations + exact fix, no silent rewrite mid-edit); on-demand invocation still auto-fixes.
+- Q: How should version-pin resolve the latest-stable version and integrity hash? → A: Shell out to native package managers (pip/pip-compile, docker manifest/buildx, npm, etc.); degrade to a reported warning when the tool is absent.
+- Q: What deletion scope should branch-clean operate on? → A: Local branches only by default; remote-branch deletion is opt-in behind a separate explicit flag.
+
+## User Scenarios & Testing *(mandatory)*
+
+This feature adds **four** independent skills to the Manifest agent-configuration repository. Each is a standalone slice of value and can be developed, tested, and demonstrated on its own.
+
+### User Story 1 - Enforce Version Pinning (Priority: P1)
+
+A contributor edits a dependency-bearing file (e.g. `requirements.txt`, `docker-compose.yaml`, a Dockerfile, or a GitHub Actions workflow) that references a dependency loosely — `latest`, an unbounded range, or a pin with no integrity hash. The version-pinning skill detects the loose reference, resolves the latest stable specific version (and a supported integrity hash where the ecosystem provides one), and rewrites the reference in place to a fully pinned form. The skill can also run on demand against a path or the working tree, and can be wired as an automatic hook scoped to recognized file types/names so the check fires whenever those files are written.
+
+**Why this priority**: Loose version references are the highest-risk item — they cause non-reproducible builds and are a supply-chain attack vector. Pinning with hashes is a Tier-1 security concern in this repo's validation criteria.
+
+**Independent Test**: Point the skill at a fixture `requirements.txt` containing `requests` (unpinned) and a `docker-compose.yaml` using `image: postgres:latest`. Confirm the skill rewrites them to a specific version plus hash where supported, leaves already-correctly-pinned entries untouched, and honors an explicit bypass marker.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `requirements.txt` line `requests` (no version), **When** the skill runs, **Then** it is rewritten to a specific latest-stable version with the ecosystem-supported integrity hash (e.g. `requests==X.Y.Z --hash=sha256:...`).
+2. **Given** a `docker-compose.yaml` service using `image: postgres:latest`, **When** the skill runs, **Then** the tag is replaced with a specific version and a digest (`postgres:X.Y@sha256:...`) where the registry supports it.
+3. **Given** an entry already pinned to a specific version with a hash, **When** the skill runs, **Then** the entry is left unchanged and reported as compliant.
+4. **Given** a line carrying an explicit bypass marker (an allowed exception), **When** the skill runs, **Then** that line is skipped, left unmodified, and the bypass is recorded in the run summary.
+5. **Given** the skill is registered as a hook for tracked file types, **When** one of those files is written/saved, **Then** the pinning check fires automatically against just that file in **warn-only** mode — it reports violations and the exact pinned+hashed fix but does not rewrite the file mid-edit (the user applies the fix via on-demand invocation or confirmation).
+6. **Given** a requested version is supplied for a dependency, **When** the skill runs, **Then** it pins to that exact requested version (plus hash) rather than latest stable.
+
+---
+
+### User Story 2 - All-in-One Documentation Refresh (Priority: P2)
+
+A maintainer wants to refresh all project documentation in a single command rather than running `docs-readme`, `docs-diagrams`, and `docs-improve` by hand. They invoke the all-in-one docs skill, which dispatches the existing docs skills as sub-agents, choosing the execution order per run based on what changed (with a documented default precedence as fallback), respecting dependencies between them, and returns one consolidated report.
+
+**Why this priority**: High convenience and consistency value, but it composes existing, already-working skills rather than introducing new capability, so it ranks below the security-critical pinning skill.
+
+**Independent Test**: Run the all-in-one docs skill on the repo and confirm it invokes all three existing docs skills as sub-agents, produces a single merged summary identifying which ran, in what order, and why, and that the order adapts when only (say) diagrams-relevant files changed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the three docs skills exist, **When** the all-in-one skill runs, **Then** each is dispatched as an independent sub-agent and all results are aggregated into one report.
+2. **Given** recent changes touch only architecture/structure, **When** the skill chooses an order, **Then** it prioritizes the diagram-relevant skill while still documenting the precedence it applied.
+3. **Given** no special context, **When** the skill runs, **Then** it falls back to a documented default precedence and states this in the report.
+4. **Given** one sub-agent fails, **When** the run completes, **Then** the failure is surfaced in the report without silently dropping the other results.
+
+---
+
+### User Story 3 - Review All Open Pull Requests (Priority: P2)
+
+A maintainer wants to understand the state of every open PR on the active platform (GitHub primarily, with the repo's existing GitLab abstraction respected where present). The PR-review skill enumerates all open PRs, assesses each for whether it is still needed, mergeable, stale, superseded, or in conflict, and returns a prioritized, actionable summary with a recommended disposition per PR. The skill is analysis-only by default and does not merge, close, or modify PRs without explicit confirmation.
+
+**Why this priority**: Strong workflow value for keeping the PR queue healthy, and it builds on the repo's existing `git_ops.sh` / platform-detection scripts, so it is well-scoped but not security-critical.
+
+**Independent Test**: Run the skill against a repo with multiple open PRs and confirm it lists each with a recommended disposition (keep/merge/close/needs-rebase/superseded) and a one-line rationale, performing no mutations.
+
+**Acceptance Scenarios**:
+
+1. **Given** several open PRs, **When** the skill runs, **Then** it returns one row per PR with status, mergeability, staleness, and a recommended disposition with rationale.
+2. **Given** a PR whose branch is already merged or whose changes are superseded, **When** the skill runs, **Then** it flags the PR as a candidate to close.
+3. **Given** the skill is invoked without an explicit action flag, **When** it completes, **Then** it makes no changes to any PR (analysis-only).
+4. **Given** no open PRs exist, **When** the skill runs, **Then** it reports a clean queue without error.
+
+---
+
+### User Story 4 - Clean Up Stale Branches (Priority: P3)
+
+A maintainer wants to prune branches that are no longer useful — branches already merged into the default branch, branches whose remote was deleted (`[gone]`), and branches with no activity past a staleness threshold. The branch-cleaner skill identifies these candidates, presents them grouped by reason, and deletes them only after explicit confirmation (with a dry-run preview by default). By default it operates on **local branches only**; remote-branch deletion is opt-in behind a separate explicit flag. Protected branches (default branch, release branches) are never proposed for deletion.
+
+**Why this priority**: Useful housekeeping that reduces clutter, but lowest risk-reduction value and most easily deferred; deletion is destructive so safety gating matters most here.
+
+**Independent Test**: Run the skill in a repo with a merged branch, a `[gone]` branch, and a protected branch; confirm it lists the first two as deletion candidates (grouped by reason), never lists the protected branch, and deletes nothing without confirmation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a local branch fully merged into the default branch, **When** the skill runs, **Then** it is listed as a safe-to-delete candidate.
+2. **Given** a local branch tracking a deleted remote (`[gone]`), **When** the skill runs, **Then** it is listed as a candidate with that reason.
+3. **Given** the default branch and any protected branches, **When** the skill runs, **Then** they are never proposed for deletion.
+4. **Given** no confirmation/`--apply` flag, **When** the skill runs, **Then** it only previews (dry-run) and deletes nothing.
+5. **Given** confirmation is provided, **When** the skill applies, **Then** it deletes the confirmed branches and reports each deletion outcome (including failures).
+
+---
+
+### Edge Cases
+
+- **Pinning — unresolvable version**: A dependency whose latest stable version cannot be resolved (offline, private registry, yanked release) must be reported as a non-fatal warning, not silently skipped or left in a broken state.
+- **Pinning — no hash support**: For ecosystems/files where integrity hashes are not supported, the skill pins the specific version and notes that no hash was applicable, without failing.
+- **Pinning — file-type coverage boundary**: A file type not in the recognized set is ignored by the hook; on-demand runs against an unrecognized file report "no applicable rules" rather than erroring.
+- **Pinning — malformed file**: A syntactically broken target file is reported as a parse error and left untouched (no partial rewrites).
+- **Docs orchestration — missing sub-skill**: If one of the three docs skills is unavailable, the all-in-one skill runs the remaining ones and reports the gap.
+- **PR review — platform without API access / unauthenticated**: The skill reports that it cannot enumerate PRs and how to authenticate, rather than returning an empty "clean" result.
+- **Branch cleanup — unmerged work**: A branch with unmerged commits is never proposed under the "merged" category and requires an explicit force path the skill does not take by default.
+- **Branch cleanup — current branch**: The currently checked-out branch is never proposed for deletion.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Version-Pinning skill (`version-pin`)**
+
+- **FR-001**: The skill MUST detect loose dependency references — `latest`, missing version, unbounded/open-ended ranges, and pins lacking an integrity hash — in recognized dependency files.
+- **FR-002**: The skill MUST resolve target versions by shelling out to the ecosystem's native package-manager tooling (e.g. pip / pip-compile, `docker manifest`/buildx, npm), defaulting to the latest stable release or to an explicitly requested version when one is provided; when the required native tool is absent it MUST degrade to a reported warning rather than guessing.
+- **FR-003**: The skill MUST include an integrity hash/digest in the pin wherever the target ecosystem's tooling supplies one (e.g. pip `--hash`, container image `@sha256:` digest, lockfile digests), and MUST note when hashing is not applicable.
+- **FR-003a**: On explicit on-demand invocation, the skill MUST rewrite loose references in place to the resolved specific version (plus hash where supported).
+- **FR-004**: The skill MUST support an explicit per-entry bypass mechanism so an intentional exception is left unmodified and recorded in the run summary.
+- **FR-005**: The skill MUST be invokable on demand (against a path or the working tree) and MUST be registrable as an automatic hook scoped to a recognized set of file types/names (initial set MUST include at least `requirements.txt`, `docker-compose.yaml`/`docker-compose.yml`, Dockerfiles, and a documented, extensible list of other commonly version-pinned files). On the automatic hook path the skill MUST operate in **warn-only** mode — reporting violations and the exact pinned+hashed fix without rewriting the file mid-edit.
+- **FR-006**: The skill MUST leave already-compliant entries unchanged and report them as compliant.
+- **FR-007**: The skill MUST treat unresolvable versions, unsupported hashes, and unrecognized/malformed files as non-fatal, reported outcomes — never silent failures or partial corruption.
+
+**All-in-one docs skill (`docs-all`)**
+
+- **FR-008**: The skill MUST dispatch the existing `docs-readme`, `docs-diagrams`, and `docs-improve` skills as sub-agents.
+- **FR-009**: The skill MUST choose execution order per run based on changed context, with a documented default precedence used as a fallback, and MUST honor any required ordering dependencies between the docs skills.
+- **FR-010**: The skill MUST aggregate the sub-agent results into a single consolidated report that states which skills ran, in what order, and why.
+- **FR-011**: The skill MUST surface a sub-agent failure in the report and continue running the remaining sub-agents rather than aborting the whole run.
+
+**PR-review skill (`pr-review`)**
+
+- **FR-012**: The skill MUST enumerate all open pull requests on the active platform, reusing the repo's existing platform-detection / git-ops abstraction.
+- **FR-013**: For each open PR, the skill MUST assess and report status, mergeability, staleness, whether it appears superseded/already-merged, and a recommended disposition (e.g. keep, merge, close, needs-rebase) with a brief rationale.
+- **FR-014**: The skill MUST be analysis-only by default and MUST NOT merge, close, or otherwise mutate any PR without explicit user confirmation.
+- **FR-015**: The skill MUST handle the empty-queue and unauthenticated/no-API cases with clear messaging rather than a misleading "clean" result.
+
+**Branch-cleaner skill (`branch-clean`)**
+
+- **FR-016**: The skill MUST identify branch-deletion candidates grouped by reason: merged into the default branch, tracking a deleted remote (`[gone]`), and stale beyond a configurable threshold.
+- **FR-016a**: The skill MUST operate on **local branches only by default**; deletion of remote branches MUST be opt-in behind a separate explicit flag and MUST NOT occur as part of the default local cleanup.
+- **FR-017**: The skill MUST never propose protected branches (default branch, configured release/protected branches) or the currently checked-out branch for deletion.
+- **FR-018**: The skill MUST default to a dry-run preview and MUST delete branches only after explicit confirmation/flag.
+- **FR-019**: The skill MUST report the outcome of each attempted deletion, including failures, without silently swallowing errors.
+- **FR-020**: The skill MUST never delete branches with unmerged commits via the default (safe) path.
+
+**Cross-cutting (all four skills)**
+
+- **FR-021**: Each skill MUST follow the repo's skill-authoring conventions: a `SKILL.md` with `name` and `description` frontmatter under `.skillshare/skills/<skill-name>/` (the source of truth), reachable via the `configs/claude/skills` compat symlink.
+- **FR-022**: Each skill MUST register appropriate tool policies in `configs/claude/config/command_config.yml`, and add validation overrides in `configs/claude/config/validation_criteria.yml` where its default verdict criteria differ.
+- **FR-023**: Each new skill MUST be documented in the repo's command/skill listings (CLAUDE.md and docs/COMMANDS.md as applicable) consistent with how existing skills are listed.
+
+### Key Entities *(include if feature involves data)*
+
+- **Dependency reference**: A single pinnable item in a target file — its name, current version expression, resolved specific version, and integrity hash/digest (where supported), plus a compliant/violation/bypassed state.
+- **Pinning rule set**: The mapping of recognized file types/names to how their dependency references are parsed and what hash form (if any) applies.
+- **PR assessment**: Per-PR record — identifier, title, author, age, mergeability, staleness, superseded/merged flags, recommended disposition, and rationale.
+- **Branch candidate**: Per-branch record — name, local/remote, merged status, `[gone]` status, last-activity age, protected flag, and proposed action.
+- **Docs run report**: The consolidated result of the orchestrated docs run — ordered list of sub-skills invoked, the precedence reasoning, and each sub-skill's outcome.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Running the version-pinning skill on a file with N loose references produces a fully pinned file (specific version + hash wherever supported) with zero remaining loose references, except entries explicitly bypassed.
+- **SC-002**: 100% of already-compliant entries are left byte-for-byte unchanged across repeat runs (the skill is idempotent — a second run reports no changes).
+- **SC-003**: The version-pinning hook fires automatically on save/write for every file in the recognized set and for none outside it.
+- **SC-004**: The all-in-one docs skill completes a full documentation refresh in a single invocation and produces one report covering all three docs skills, with the applied order and rationale stated.
+- **SC-005**: The PR-review skill returns a disposition recommendation with rationale for 100% of open PRs and performs zero mutations when run without an explicit action.
+- **SC-006**: The branch-cleaner skill proposes zero protected or current branches for deletion across all runs, and deletes nothing without explicit confirmation.
+- **SC-007**: A maintainer can go from "no open-PR/branch overview" to a prioritized, actionable list in a single command for each of the PR-review and branch-clean skills.
+
+## Assumptions
+
+- The four capabilities are delivered as **four separate skills** (`version-pin`, `docs-all`, `pr-review`, `branch-clean`), per the user's choice, matching the repo's single-purpose skill convention.
+- The version-pinning skill **auto-fixes in place on explicit on-demand invocation** (resolves and rewrites) with an **explicit bypass** mechanism for intentional exceptions; the **automatic hook path is warn-only** (reports the fix without mutating the file mid-edit), per the user's clarification.
+- Version/hash resolution shells out to **native package-manager tooling** rather than bespoke registry calls, degrading to a warning when the tool is unavailable, per the user's clarification.
+- The branch-cleaner skill operates on **local branches only by default**, with remote deletion gated behind a separate explicit flag, per the user's clarification.
+- The docs skill **decides ordering per run** with a documented default precedence as fallback, per the user's choice.
+- Skills live in `.skillshare/skills/` (source of truth) and are deployed to home targets by `bootstrap.sh`; `configs/claude/skills` is a compat symlink and must not be replaced with a real directory.
+- "Latest stable" excludes pre-releases/release-candidates unless a pre-release is explicitly requested.
+- The PR-review and branch-clean skills reuse the existing platform abstraction (`git_platform.sh` / `git_ops.sh`), defaulting to GitHub while respecting GitLab where detected; Linear is out of scope for these two.
+- The version-pinning hook integration uses the repo's existing hook mechanism (the `ai-hooks-integration` skill) rather than introducing a new hook framework.
+- Staleness and protected-branch definitions are configurable, defaulting to values consistent with existing repo config conventions.
+- Network/registry access is available when resolving latest-stable versions and hashes; offline runs degrade to reported warnings rather than failures.

--- a/specs/002-new-agent-skills/tasks.md
+++ b/specs/002-new-agent-skills/tasks.md
@@ -1,0 +1,176 @@
+---
+description: "Task list for 002-new-agent-skills implementation"
+---
+
+# Tasks: New Agent Skills (Version Pinning, Docs Orchestration, PR Review, Branch Cleanup)
+
+**Input**: Design documents from `/specs/002-new-agent-skills/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the Manifest constitution mandates `bats tests/bats/` for shell changes and `shellcheck`/`yamllint` lint gates, so shell-helper test tasks are first-class here.
+
+**Organization**: Tasks are grouped by user story. US1 (version-pin, P1) is the MVP. US2–US4 are independent of each other once Phase 2 completes.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1=version-pin, US2=docs-all, US3=pr-review, US4=branch-clean
+- All paths are repo-relative from the worktree root.
+
+## Path Conventions
+
+Agent-configuration repo (single project): skills in `.skillshare/skills/<name>/SKILL.md`
+(source of truth; `configs/claude/skills` is a symlink), helper scripts in
+`configs/claude/scripts/`, config in `configs/claude/config/`, tests in `tests/bats/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the skill directories and confirm the deploy/test harness covers them.
+
+- [x] T001 [P] Create skill directories with placeholder SKILL.md frontmatter in `.skillshare/skills/version-pin/SKILL.md`, `.skillshare/skills/docs-all/SKILL.md`, `.skillshare/skills/pr-review/SKILL.md`, `.skillshare/skills/branch-clean/SKILL.md`
+- [x] T002 [P] Verify `bootstrap.sh` `deploy_home_skills` globs the new directories (symlink-safe) and that `configs/claude/skills` remains a symlink — record finding in `specs/002-new-agent-skills/quickstart.md` if any change is needed
+
+**Checkpoint**: Four discoverable (empty) skills exist and deploy without breaking the symlink.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Register all four skills in the shared config + doc files in one pass so the
+per-story phases (which create different files) can proceed in parallel without contending
+on these shared files.
+
+- [x] T003 Add `tool_policies` entries for all four skills to `configs/claude/config/command_config.yml` per research §R8 (version-pin: Read/Glob/Grep/Bash/Edit/Write, Tier 1; docs-all: Read/Glob/Grep/Agent, Tier 2; pr-review: Read/Glob/Grep/Bash, Tier 2; branch-clean: Read/Glob/Grep/Bash, Tier 1 on apply), AND add the `version_pin` rule-set block (globs, ecosystem, resolve_cmd, hash, bypass marker) per data-model §2
+- [x] T004 Add `command_overrides` entries for all four skills to `configs/claude/config/validation_criteria.yml` (version-pin Tier 1; branch-clean Tier 1 destructive path; docs-all + pr-review Tier 2 maintainability) — mirrors existing override blocks
+- [x] T005 [P] Add the four skills to the command/skill tables in `CLAUDE.md`, `configs/claude/CLAUDE.md`, and `docs/COMMANDS.md` consistent with existing entries (FR-023)
+- [x] T006 Validate config parses after edits: `python3 -c "import yaml; yaml.safe_load(open('configs/claude/config/command_config.yml'))"` and the same for `validation_criteria.yml`, plus `yamllint` both files
+
+**Checkpoint**: All four skills are registered and config still parses + lints. Stories can now proceed independently.
+
+---
+
+## Phase 3: User Story 1 — Enforce Version Pinning (Priority: P1) 🎯 MVP
+
+**Goal**: Detect loose dependency references, resolve specific versions + integrity hashes
+via native tooling, auto-fix on demand, warn-only on the save hook, with explicit bypass.
+
+**Independent Test**: Run against a fixture `requirements.txt` (`requests` unpinned) and
+`docker-compose.yaml` (`postgres:latest`); confirm on-demand run rewrites to specific
+version + hash, `--check` reports without editing, compliant/bypassed lines untouched, and
+a second run is a no-op.
+
+- [x] T007 [P] [US1] Write `tests/bats/version_pin.bats` covering: loose-detection per ecosystem, on-demand rewrite to version+hash, `--check` makes no edits + non-zero exit, compliant left unchanged, `# version-pin:ignore` bypass preserved, unresolved/offline → warning + untouched, idempotent second run, AND hook-scoping — a recognized file (e.g. `requirements.txt`) IS processed while an unrelated file (e.g. `README.md`) is NOT (the negative case of SC-003) (SC-001/SC-002/SC-003, contract `version-pin.md`)
+- [x] T008 [US1] Implement `configs/claude/scripts/version_pin.sh`: read `version_pin` rule set from `command_config.yml`; parse Dependency References (data-model §1); classify compliant/violation/bypassed/unresolved; resolve via native tools (pip/pip-compile, `docker manifest`, npm, `git ls-remote` for GHA) per research §R1; on-demand rewrite vs `--check` warn-only per §R2; emit the contract output schema + exit codes
+- [x] T009 [US1] Author `.skillshare/skills/version-pin/SKILL.md` (name/description frontmatter; workflow: invoke `version_pin.sh`, present results, apply/confirm; document flags from contract; document non-fatal failure handling FR-007)
+- [x] T010 [US1] Register the warn-only save-hook as a `PostToolUse` entry (matcher `Write|Edit`) in `configs/claude/settings.local.json` that calls `version_pin.sh --check "$file_path"`; the script — not the matcher — enforces the recognized-glob scoping (so non-tracked files no-op, per T007). Make the insertion idempotent (skip if an equivalent entry already exists) per Constitution V, and mirror the cross-tool wiring via `ai-hooks-integration` conventions. Document the recipe in the SKILL.md and `specs/002-new-agent-skills/quickstart.md`
+- [x] T011 [US1] Run `shellcheck configs/claude/scripts/version_pin.sh` and `bats tests/bats/version_pin.bats`; fix to green
+
+**Checkpoint**: `/version-pin` is a complete, independently shippable MVP.
+
+---
+
+## Phase 4: User Story 2 — All-in-One Documentation Refresh (Priority: P2)
+
+**Goal**: Orchestrate `docs-readme` / `docs-diagrams` / `docs-improve` as sub-agents,
+choosing order per run with a documented default fallback, into one consolidated report.
+
+**Independent Test**: Run `/docs-all`; confirm all three sub-skills dispatch as sub-agents,
+the report states the order + rationale + per-sub-skill outcome, and a forced sub-skill
+failure does not abort the others.
+
+- [x] T012 [US2] Author `.skillshare/skills/docs-all/SKILL.md`: dispatch the three docs skills via the Agent tool; per-run ordering from changed-file signals with default precedence `readme → diagrams → improve` and `docs-improve` always last (research §R7); continue-on-failure; emit the consolidated Docs Run Report (data-model §5, contract `docs-all.md`)
+- [x] T013 [US2] Add a manual verification scenario to `specs/002-new-agent-skills/quickstart.md` confirming order/rationale/failure-surfacing behavior (no script ⇒ no bats; orchestration is exercised manually)
+
+**Checkpoint**: `/docs-all` delivers a one-command docs refresh.
+
+---
+
+## Phase 5: User Story 3 — Review All Open Pull Requests (Priority: P2)
+
+**Goal**: Enumerate all open PRs via the existing platform abstraction and recommend a
+disposition per PR, analysis-only by default.
+
+**Independent Test**: Run `/pr-review` against a repo with multiple open PRs; confirm one
+row per PR with mergeability/checks/staleness + disposition + rationale, zero mutations,
+and clean empty-queue / unauthenticated handling.
+
+- [x] T014 [P] [US3] Write `tests/bats/pr_review.bats` covering: enumeration via mocked `git_ops.sh pr-list`, disposition heuristic (merged/superseded→close, conflicting/failing→needs-rebase, clean+passing→merge, else keep), empty-queue clean output, unauthenticated distinct message, analysis-only (no mutating calls) (contract `pr-review.md`, data-model §3)
+- [x] T015 [US3] Implement `configs/claude/scripts/pr_review.sh`: detect platform via `git_platform.sh`; enumerate via `git_ops.sh pr-list` and enrich with `pr-view`/`pr-diff`/`pr-checks`; compute PR Assessment fields + disposition; support `--stale-days`, `--platform`, `--json`; never call mutating subcommands (research §R5)
+- [x] T016 [US3] Author `.skillshare/skills/pr-review/SKILL.md` (frontmatter; invoke `pr_review.sh`; present prioritized table; explicit analysis-only contract FR-014)
+- [x] T017 [US3] Run `shellcheck configs/claude/scripts/pr_review.sh` and `bats tests/bats/pr_review.bats`; fix to green
+
+**Checkpoint**: `/pr-review` triages the open-PR queue read-only.
+
+---
+
+## Phase 6: User Story 4 — Clean Up Stale Branches (Priority: P3)
+
+**Goal**: Identify merged / `[gone]` / stale branch candidates, dry-run by default,
+local-only deletion with remote opt-in, never touching protected/current branches.
+
+**Independent Test**: In a repo with a merged branch, a `[gone]` branch, and a protected
+branch, confirm the first two are listed (grouped by reason), the protected/current are
+never listed, dry-run deletes nothing, and `--apply` deletes only confirmed branches.
+
+- [x] T018 [P] [US4] Write `tests/bats/branch_clean.bats` covering: candidate grouping (merged/gone/stale), protected + current-HEAD exclusion, unmerged never in `merged` category, dry-run default deletes nothing, `--apply` deletes + reports outcomes incl. failures, local-only default vs `--include-remote` (contract `branch-clean.md`, data-model §4)
+- [x] T019 [US4] Implement `configs/claude/scripts/branch_clean.sh`: classify via `git branch --merged`, `git for-each-ref ... upstream:track [gone]`, last-commit-date staleness; read protected globs + `--stale-days` from `command_config.yml` `branch_clean` block; dry-run default, `--apply` + confirmation, `--include-remote` opt-in via `git_platform.sh`; report each outcome (research §R6)
+- [x] T020 [US4] Add the `branch_clean` config block (protected globs, default stale-days) to `configs/claude/config/command_config.yml`
+- [x] T021 [US4] Author `.skillshare/skills/branch-clean/SKILL.md` (frontmatter; invoke `branch_clean.sh`; present grouped candidates; safety/confirmation contract FR-017/FR-018/FR-020)
+- [x] T022 [US4] Run `shellcheck configs/claude/scripts/branch_clean.sh` and `bats tests/bats/branch_clean.bats`; fix to green
+
+**Checkpoint**: `/branch-clean` prunes branches safely.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Repo-wide gates and final consistency.
+
+- [x] T023 [P] Run full lint sweep: `shellcheck configs/claude/scripts/version_pin.sh configs/claude/scripts/pr_review.sh configs/claude/scripts/branch_clean.sh` and `yamllint configs/claude/config/*.yml`
+- [x] T024 [P] Run full test suite: `bats tests/bats/` (all new + existing) to confirm no regressions
+- [ ] T025 [P] Deploy check: `./bootstrap.sh` then confirm `ls ~/.claude/skills | grep -E 'version-pin|docs-all|pr-review|branch-clean'` lists all four (Constitution V idempotency: re-run is a no-op)
+- [x] T026 Final docs consistency pass: ensure CLAUDE.md / configs/claude/CLAUDE.md / docs/COMMANDS.md tables, `Available Commands`, and `Adding New Skills` references are consistent across all four skills
+- [ ] T027 [P] Constitution Principle II gate — cross-verify the security-sensitive shell helpers with parallel agents before merge: `~/.claude/scripts/parallel_agent.py --json --timeout 600 --review <abs-path>/configs/claude/scripts/version_pin.sh` and the same for `branch_clean.sh` (its destructive `--apply` path). Resolve any ≥HIGH consensus findings; record the consensus verdict in the PR description
+
+---
+
+## Dependencies & Execution Order
+
+```text
+Phase 1 (Setup: T001–T002)
+        ↓
+Phase 2 (Foundational: T003 → T004 → T006; T005 [P]) ── blocks all stories (shared config/docs)
+        ↓
+   ┌────────────┬────────────┬────────────┐
+Phase 3 US1   Phase 4 US2   Phase 5 US3   Phase 6 US4   ← independent, can run in parallel
+(T007–T011)   (T012–T013)   (T014–T017)   (T018–T022)
+   └────────────┴────────────┴────────────┘
+        ↓
+Phase 7 (Polish: T023–T027)
+```
+
+- **Within a story**: the `.bats` test [P] is authored alongside; the helper script depends on the rule-set/config from Phase 2; SKILL.md can be written in parallel with its script (different files); the per-story lint+test task runs last.
+- **US4 note**: T020 edits the shared `command_config.yml` again — run it without `[P]` against other Phase-2/other-story config edits to avoid a write conflict.
+- **Cross-story parallelism**: US1–US4 touch disjoint scripts, skill dirs, and bats files, so the four story phases are mutually parallelizable after Phase 2.
+
+## Parallel Execution Examples
+
+- **Phase 1**: T001 and T002 together.
+- **After Phase 2**: launch one agent per story — `T007/T009/T010` (US1), `T012` (US2), `T014/T016` (US3), `T018/T021` (US4) can start in parallel; each story's script + lint task follows its own test.
+- **Phase 7**: T023, T024, T025, T027 together (read-only / independent gates); T026 (docs consistency) after the others.
+
+## Implementation Strategy
+
+- **MVP = User Story 1 (`version-pin`)** — the P1, security-critical, supply-chain skill. Ship it first and independently; it delivers value alone.
+- **Incremental delivery**: After the MVP, US2/US3/US4 can be delivered in any order (all P2/P3, all independent). Recommended order matches priority: docs-all → pr-review → branch-clean.
+- **Each story is independently testable** via its checkpoint criteria before moving on.
+
+## Task Summary
+
+- **Total tasks**: 27
+- **By story**: Setup 2 · Foundational 4 · US1 5 · US2 2 · US3 4 · US4 5 · Polish 5
+- **Parallel opportunities**: Phase 1 (2), the four story phases run concurrently after Phase 2, Phase 7 gates (T023/T024/T025/T027); plus per-story test/skill authoring.
+- **Suggested MVP scope**: Phases 1–2 + Phase 3 (US1 `version-pin`).

--- a/tests/bats/branch_clean.bats
+++ b/tests/bats/branch_clean.bats
@@ -97,6 +97,25 @@ teardown() {
     assert_output --partial "stale-spike"
 }
 
+@test "remote deletion is gated on a successful local safe-delete" {
+    # A stale branch with a remote ref, then a further local-only commit so it is
+    # unmerged vs its upstream -> `git branch -d` refuses it. With --include-remote
+    # the failed local safe-delete must leave the remote branch intact.
+    GIT_AUTHOR_DATE="2020-01-01T00:00:00" GIT_COMMITTER_DATE="2020-01-01T00:00:00" \
+        git checkout -q -b stale-remote
+    GIT_AUTHOR_DATE="2020-01-01T00:00:00" GIT_COMMITTER_DATE="2020-01-01T00:00:00" \
+        git commit -q --allow-empty -m "pushed work"
+    git push -q -u origin stale-remote
+    GIT_AUTHOR_DATE="2020-01-02T00:00:00" GIT_COMMITTER_DATE="2020-01-02T00:00:00" \
+        git commit -q --allow-empty -m "local-only ahead"
+    git checkout -q main
+    run "$SCRIPT" --default main --protect 'release/*' --stale-days 90 --apply --yes --include-remote
+    assert_success
+    assert_output --partial "FAILED   stale-remote"
+    run git ls-remote --heads origin stale-remote
+    assert_output --partial "stale-remote"
+}
+
 @test "--json emits candidates with reasons" {
     run "$SCRIPT" --default main --protect 'release/*' --json
     assert_success

--- a/tests/bats/branch_clean.bats
+++ b/tests/bats/branch_clean.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Tests for configs/claude/scripts/branch_clean.sh
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SCRIPT="$REPO_ROOT/configs/claude/scripts/branch_clean.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    SANDBOX=$(mktemp -d "$BATS_TMPDIR/branch_clean.XXXXXX")
+    export BRANCH_CLEAN_CONFIG="$REPO_ROOT/configs/claude/config/command_config.yml"
+    export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+    REMOTE=$(mktemp -d "$BATS_TMPDIR/branch_clean_remote.XXXXXX")
+    git init -q --bare "$REMOTE/origin.git"
+    cd "$SANDBOX"
+    git init -q -b main .
+    git commit -q --allow-empty -m init
+    git remote add origin "$REMOTE/origin.git"
+    git push -q -u origin main
+    # merged branch (no extra commits -> fully merged into main)
+    git branch merged-feature
+    # protected branch
+    git branch release/keepme
+    # stale branch: a merged-state branch with an old commit date is still 'merged';
+    # create a stale, unmerged-but-old branch instead
+    GIT_AUTHOR_DATE="2020-01-01T00:00:00" GIT_COMMITTER_DATE="2020-01-01T00:00:00" \
+        git checkout -q -b stale-spike
+    GIT_AUTHOR_DATE="2020-01-01T00:00:00" GIT_COMMITTER_DATE="2020-01-01T00:00:00" \
+        git commit -q --allow-empty -m "old spike"
+    git checkout -q main
+}
+
+teardown() {
+    cd /
+    [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+    [[ -n "$REMOTE" && -d "$REMOTE" ]] && rm -rf "$REMOTE"
+}
+
+@test "merged branch is listed as a delete candidate" {
+    run "$SCRIPT" --default main --protect 'release/*'
+    assert_success
+    assert_output --partial "merged-feature"
+    assert_output --partial "Merged into main"
+}
+
+@test "stale branch beyond threshold is listed" {
+    run "$SCRIPT" --default main --protect 'release/*' --stale-days 90
+    assert_success
+    assert_output --partial "stale-spike"
+    assert_output --partial "stale"
+}
+
+@test "protected and current branches are never proposed" {
+    run "$SCRIPT" --default main --protect 'release/*'
+    assert_success
+    refute_output --partial "- release/keepme"
+    refute_output --partial "- main "
+}
+
+@test "dry-run is the default and deletes nothing" {
+    run "$SCRIPT" --default main --protect 'release/*'
+    assert_success
+    assert_output --partial "dry-run, nothing deleted"
+    run git branch --list merged-feature
+    assert_output --partial "merged-feature"
+}
+
+@test "--apply --yes deletes a merged branch" {
+    run "$SCRIPT" --default main --protect 'release/*' --apply --yes
+    assert_success
+    assert_output --partial "deleted  merged-feature"
+    run git branch --list merged-feature
+    assert_output ""
+}
+
+@test "[gone] branch (with unique commit) is classified as gone" {
+    git checkout -q -b gone-feature
+    git commit -q --allow-empty -m "unique work"   # not merged into main
+    git push -q -u origin gone-feature
+    git push -q origin --delete gone-feature
+    git fetch -q -p
+    git checkout -q main
+    run "$SCRIPT" --default main --protect 'release/*'
+    assert_success
+    assert_output --partial "gone-feature"
+    assert_output --partial "Gone upstream"
+}
+
+@test "safe delete refuses an unmerged branch and reports failure (FR-020)" {
+    # stale-spike has an unmerged commit; --apply must not force-delete it.
+    run "$SCRIPT" --default main --protect 'release/*' --stale-days 90 --apply --yes
+    assert_success
+    assert_output --partial "FAILED   stale-spike"
+    run git branch --list stale-spike
+    assert_output --partial "stale-spike"
+}
+
+@test "--json emits candidates with reasons" {
+    run "$SCRIPT" --default main --protect 'release/*' --json
+    assert_success
+    echo "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert any(c["reason"]=="merged" for c in d["candidates"]); assert d["scope"]=="local"'
+}

--- a/tests/bats/pr_review.bats
+++ b/tests/bats/pr_review.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# Tests for configs/claude/scripts/pr_review.sh
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SCRIPT="$REPO_ROOT/configs/claude/scripts/pr_review.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    SANDBOX=$(mktemp -d "$BATS_TMPDIR/pr_review.XXXXXX")
+    cat > "$SANDBOX/fetch.sh" <<'EOF'
+#!/usr/bin/env bash
+cat <<'JSON'
+[
+ {"number":1,"title":"Clean feature","author":"a","updated":"2026-05-30T00:00:00Z","mergeable":"CLEAN","checks":"PASS","draft":false,"head":"feat","merged":false},
+ {"number":2,"title":"Conflicts","author":"b","updated":"2026-01-01T00:00:00Z","mergeable":"CONFLICTING","checks":"NONE","draft":false,"head":"old","merged":false},
+ {"number":3,"title":"Merged","author":"c","updated":"2026-05-29T00:00:00Z","mergeable":"UNKNOWN","checks":"NONE","draft":false,"head":"done","merged":true},
+ {"number":4,"title":"Draft","author":"d","updated":"2026-05-31T00:00:00Z","mergeable":"CLEAN","checks":"PENDING","draft":true,"head":"wip","merged":false}
+]
+JSON
+EOF
+    chmod +x "$SANDBOX/fetch.sh"
+    export PR_REVIEW_FETCH="$SANDBOX/fetch.sh"
+}
+
+teardown() {
+    [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+@test "enumerates all open PRs" {
+    run "$SCRIPT" --platform github
+    assert_success
+    assert_output --partial "Open PRs on github: 4"
+}
+
+@test "clean + passing PR is recommended for merge" {
+    run "$SCRIPT" --platform github --json
+    assert_success
+    echo "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert next(r for r in d if r["number"]==1)["disposition"]=="merge"'
+}
+
+@test "merged branch is recommended for close" {
+    run "$SCRIPT" --platform github --json
+    assert_success
+    echo "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert next(r for r in d if r["number"]==3)["disposition"]=="close"'
+}
+
+@test "conflicting PR is recommended for rebase" {
+    run "$SCRIPT" --platform github --json
+    assert_success
+    echo "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert next(r for r in d if r["number"]==2)["disposition"]=="needs-rebase"'
+}
+
+@test "draft PR is kept" {
+    run "$SCRIPT" --platform github --json
+    assert_success
+    echo "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert next(r for r in d if r["number"]==4)["disposition"]=="keep"'
+}
+
+@test "empty queue reports clean without error" {
+    cat > "$SANDBOX/empty.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "[]"
+EOF
+    chmod +x "$SANDBOX/empty.sh"
+    export PR_REVIEW_FETCH="$SANDBOX/empty.sh"
+    run "$SCRIPT" --platform github
+    assert_success
+    assert_output --partial "Clean queue"
+}
+
+@test "superseded PR (shared head branch) is recommended for close" {
+    cat > "$SANDBOX/dup.sh" <<'EOF'
+#!/usr/bin/env bash
+cat <<'JSON'
+[
+ {"number":10,"title":"first","author":"a","updated":"2026-05-30T00:00:00Z","mergeable":"CLEAN","checks":"PASS","draft":false,"head":"shared","merged":false},
+ {"number":11,"title":"dup","author":"a","updated":"2026-05-31T00:00:00Z","mergeable":"CLEAN","checks":"PASS","draft":false,"head":"shared","merged":false}
+]
+JSON
+EOF
+    chmod +x "$SANDBOX/dup.sh"
+    export PR_REVIEW_FETCH="$SANDBOX/dup.sh"
+    run "$SCRIPT" --platform github --json
+    assert_success
+    echo "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert next(r for r in d if r["number"]==11)["disposition"]=="close"'
+}
+
+@test "unsupported platform errors with exit 2" {
+    unset PR_REVIEW_FETCH
+    run "$SCRIPT" --platform bitbucket
+    assert_failure
+    assert_equal "$status" 2
+}

--- a/tests/bats/pr_review.bats
+++ b/tests/bats/pr_review.bats
@@ -94,3 +94,11 @@ EOF
     assert_failure
     assert_equal "$status" 2
 }
+
+@test "missing platform CLI reports an enumeration error (not a clean queue)" {
+    unset PR_REVIEW_FETCH
+    # PATH without gh/glab: default_fetch should fail and surface the auth/CLI hint.
+    run env PATH="/usr/bin:/bin" "$SCRIPT" --platform github
+    assert_failure
+    assert_output --partial "cannot enumerate PRs"
+}

--- a/tests/bats/version_pin.bats
+++ b/tests/bats/version_pin.bats
@@ -142,3 +142,66 @@ EOF
     assert_output --partial "no applicable rules"
     refute_output --partial " -> "
 }
+
+@test "pip: extras and environment markers are preserved on rewrite" {
+    printf 'requests[socks]>=2 ; python_version < "3.12"\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt"
+    assert_success
+    run cat "$SANDBOX/requirements.txt"
+    assert_output 'requests[socks]==2.31.0; python_version < "3.12" --hash=sha256:abc123'
+}
+
+@test "pip: hash required but unobtainable -> unresolved, file untouched" {
+    cat > "$SANDBOX/nohash.sh" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == pip ]] && printf '%s\t\n' "2.31.0" || exit 1
+EOF
+    chmod +x "$SANDBOX/nohash.sh"
+    export VERSION_PIN_RESOLVER="$SANDBOX/nohash.sh"
+    printf 'flask\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt"
+    assert_success
+    assert_output --partial "unresolved"
+    assert_output --partial "requires one"
+    run cat "$SANDBOX/requirements.txt"
+    assert_output "flask"
+}
+
+@test "dockerfile: FROM --platform flag and AS stage are preserved" {
+    printf 'FROM --platform=linux/amd64 node:20 AS build\n' > "$SANDBOX/Dockerfile"
+    run "$SCRIPT" "$SANDBOX/Dockerfile"
+    assert_success
+    run cat "$SANDBOX/Dockerfile"
+    assert_output "FROM --platform=linux/amd64 node:20@sha256:dead AS build"
+}
+
+@test "docker: registry host:port is not mistaken for a tag" {
+    printf 'services:\n  app:\n    image: registry.internal:5000/team/app:1.2\n' > "$SANDBOX/docker-compose.yaml"
+    run "$SCRIPT" "$SANDBOX/docker-compose.yaml"
+    assert_success
+    run cat "$SANDBOX/docker-compose.yaml"
+    assert_output --partial "image: registry.internal:5000/team/app:1.2@sha256:dead"
+}
+
+@test "docker: digest required but empty -> unresolved, file untouched" {
+    cat > "$SANDBOX/nodigest.sh" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == docker ]] && printf '%s\t\n' "1.0" || exit 1
+EOF
+    chmod +x "$SANDBOX/nodigest.sh"
+    export VERSION_PIN_RESOLVER="$SANDBOX/nodigest.sh"
+    printf 'services:\n  app:\n    image: redis:7\n' > "$SANDBOX/docker-compose.yaml"
+    run "$SCRIPT" "$SANDBOX/docker-compose.yaml"
+    assert_success
+    assert_output --partial "unresolved"
+    run cat "$SANDBOX/docker-compose.yaml"
+    assert_output --partial "image: redis:7"
+}
+
+@test "directory scan is config-driven (finds recognized files in a tree)" {
+    mkdir -p "$SANDBOX/sub"
+    printf 'requests\n' > "$SANDBOX/sub/requirements.txt"
+    run "$SCRIPT" "$SANDBOX" --check
+    assert_failure
+    assert_output --partial "sub/requirements.txt"
+}

--- a/tests/bats/version_pin.bats
+++ b/tests/bats/version_pin.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# Tests for configs/claude/scripts/version_pin.sh
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SCRIPT="$REPO_ROOT/configs/claude/scripts/version_pin.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    SANDBOX=$(mktemp -d "$BATS_TMPDIR/version_pin.XXXXXX")
+    export VERSION_PIN_CONFIG="$REPO_ROOT/configs/claude/config/command_config.yml"
+
+    # Deterministic, offline stub resolver.
+    cat > "$SANDBOX/resolver.sh" <<'EOF'
+#!/usr/bin/env bash
+eco="$1"; name="$2"; current="$3"; requested="$4"
+case "$eco" in
+  pip) printf '%s\t%s\n' "${requested:-2.31.0}" "abc123" ;;
+  docker)
+    if [[ -n "$requested" ]]; then printf '%s\t%s\n' "$requested" "sha256:dead"
+    elif [[ -n "$current" && "$current" != latest ]]; then printf '%s\t%s\n' "$current" "sha256:dead"
+    else printf '%s\t%s\n' "16.2" "sha256:cafe"; fi ;;
+  *) exit 1 ;;
+esac
+EOF
+    chmod +x "$SANDBOX/resolver.sh"
+    export VERSION_PIN_RESOLVER="$SANDBOX/resolver.sh"
+}
+
+teardown() {
+    [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+@test "pip: unpinned requirement is rewritten to version + hash (on-demand)" {
+    printf 'requests\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt"
+    assert_success
+    run cat "$SANDBOX/requirements.txt"
+    assert_output "requests==2.31.0 --hash=sha256:abc123"
+}
+
+@test "pip: pin without hash is upgraded to include a hash" {
+    printf 'flask==2.0.0\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt"
+    assert_success
+    run cat "$SANDBOX/requirements.txt"
+    assert_output "flask==2.31.0 --hash=sha256:abc123"
+}
+
+@test "pip: --requested pins the exact requested version" {
+    printf 'requests\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt" --requested requests=9.9.9
+    assert_success
+    run cat "$SANDBOX/requirements.txt"
+    assert_output "requests==9.9.9 --hash=sha256:abc123"
+}
+
+@test "--check is warn-only: reports violations, exits 1, makes no edits" {
+    printf 'requests\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt" --check
+    assert_failure
+    assert_output --partial "violation"
+    run cat "$SANDBOX/requirements.txt"
+    assert_output "requests"
+}
+
+@test "compliant entry is left unchanged and counted compliant" {
+    printf 'good==1.0 --hash=sha256:zzz\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt"
+    assert_success
+    assert_output --partial "1 compliant"
+    run cat "$SANDBOX/requirements.txt"
+    assert_output "good==1.0 --hash=sha256:zzz"
+}
+
+@test "bypass marker preserves the line byte-for-byte" {
+    printf 'legacy  # version-pin:ignore\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt"
+    assert_success
+    assert_output --partial "bypassed"
+    run cat "$SANDBOX/requirements.txt"
+    assert_output "legacy  # version-pin:ignore"
+}
+
+@test "second run is idempotent (no further changes)" {
+    printf 'requests\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt"
+    assert_success
+    first=$(cat "$SANDBOX/requirements.txt")
+    run "$SCRIPT" "$SANDBOX/requirements.txt"
+    assert_success
+    assert_output --partial "0 violations"
+    second=$(cat "$SANDBOX/requirements.txt")
+    [ "$first" = "$second" ]
+}
+
+@test "unresolved (resolver fails) is a non-fatal warning, file untouched" {
+    cat > "$SANDBOX/fail.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$SANDBOX/fail.sh"
+    export VERSION_PIN_RESOLVER="$SANDBOX/fail.sh"
+    printf 'requests\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt"
+    assert_success
+    assert_output --partial "unresolved"
+    run cat "$SANDBOX/requirements.txt"
+    assert_output "requests"
+}
+
+@test "docker-compose: latest tag becomes specific version + digest" {
+    printf 'services:\n  db:\n    image: postgres:latest\n' > "$SANDBOX/docker-compose.yaml"
+    run "$SCRIPT" "$SANDBOX/docker-compose.yaml"
+    assert_success
+    run cat "$SANDBOX/docker-compose.yaml"
+    assert_output --partial "image: postgres:16.2@sha256:cafe"
+}
+
+@test "docker-compose: already-digested image is left unchanged" {
+    printf 'services:\n  x:\n    image: nginx:1.0@sha256:abc\n' > "$SANDBOX/docker-compose.yaml"
+    run "$SCRIPT" "$SANDBOX/docker-compose.yaml"
+    assert_success
+    assert_output --partial "1 compliant"
+    run cat "$SANDBOX/docker-compose.yaml"
+    assert_output --partial "image: nginx:1.0@sha256:abc"
+}
+
+@test "hook-scoping: a recognized file IS processed (SC-003 positive)" {
+    printf 'requests\n' > "$SANDBOX/requirements.txt"
+    run "$SCRIPT" "$SANDBOX/requirements.txt" --check
+    assert_failure
+    assert_output --partial "requirements.txt"
+}
+
+@test "hook-scoping: an unrelated file is NOT processed (SC-003 negative)" {
+    printf 'just some prose\n' > "$SANDBOX/README.md"
+    run "$SCRIPT" "$SANDBOX/README.md" --check
+    assert_success
+    assert_output --partial "no applicable rules"
+    refute_output --partial " -> "
+}


### PR DESCRIPTION
## Summary

Adds four discrete, independently-invocable Claude Code skills (spec `002-new-agent-skills`), each authored via the full spec-kit pipeline (specify → clarify → plan → tasks → analyze → implement).

| Skill | What it does | Tier |
|-------|--------------|------|
| `/version-pin` | Detect loose dependency refs (`latest`, no version, unbounded range, missing hash) in `requirements.txt` / `docker-compose` / `Dockerfile`; resolve a specific version + integrity hash via native package managers; **auto-fix on demand**, **warn-only on the save hook**; explicit per-entry bypass | 1 |
| `/docs-all` | Orchestrate `docs-readme` / `docs-diagrams` / `docs-improve` as sub-agents with per-run ordering (`docs-improve` last) into one consolidated report | 2 |
| `/pr-review` | Enumerate all open PRs via `git_ops.sh` / `git_platform.sh` and recommend a disposition (keep / merge / close / needs-rebase) per PR — **analysis-only** | 2 |
| `/branch-clean` | Group merged / `[gone]` / stale branch candidates; **dry-run + local-only by default**; never touches protected/current; never force-deletes unmerged | 1 (`--apply`) |

## Design notes

- Skills live in `.skillshare/skills/` (source of truth); non-trivial logic is in bash-3.2-compatible helper scripts under `configs/claude/scripts/`, mirroring `git_ops.sh` / `label_sync.sh`.
- Helper scripts expose dependency-injection seams (`VERSION_PIN_RESOLVER`, `PR_REVIEW_FETCH`) so deterministic logic is unit-tested without network/live PRs — the default path still shells out to real tooling (verified: `pip` resolved `requests==2.34.2` with a genuine sha256).
- Recognized version-pin file types are a config-driven, extensible rule set in `command_config.yml`.
- Warn-only `PostToolUse` (`Write|Edit`) hook wired via `settings.local.json` + `version_pin_hook.sh` (advisory, never blocks/edits; the script enforces glob scoping).

## Constitution compliance

All 5 principles hold — config-as-code, skill-first (no core-script bloat), consensus thresholds inherited, idempotent (`version-pin` re-run is a no-op; hook insertion guarded), no silent failures (unresolved/unmerged cases reported, never swallowed).

## Testing

- **28 new bats tests** across the three scripted skills; **151/151 full suite green** (zero regressions).
- `shellcheck` clean on all four scripts; `yamllint` clean on both config files; `settings.local.json` valid JSON.

## Follow-ups (not in this PR)

- Run `./bootstrap.sh` to deploy the skills + enable the save-hook on your machine (outward-facing; left to the maintainer).
- Per Constitution II, run `parallel_agent.py --review` on `version_pin.sh` / `branch_clean.sh` as the pre-merge cross-verification gate (tracked as task T027).

🤖 Generated with [Claude Code](https://claude.com/claude-code)