### PR TITLE
fix(bootstrap): preserve user runtime state on "Backup and replace"

### DIFF
--- a/bootstrap/lib/deploy.sh
+++ b/bootstrap/lib/deploy.sh
@@ -25,6 +25,13 @@ restore_runtime_state() {
         excludes+=("--exclude=/$(basename "$entry")")
     done
 
+    # .agent_outputs is recreated below as a symlink into $MANIFEST_OUTPUT_DIR
+    # (under ~/.manifest, outside ~/.claude and therefore never part of the
+    # backup). Restoring it here is wasted work — create_symlink rm -rf's it
+    # moments later — and would be slow if the backup holds a large legacy
+    # outputs directory. The authoritative outputs were never moved, so skip it.
+    excludes+=("--exclude=/.agent_outputs")
+
     print_step "Restoring runtime state (plugins, sessions, settings.json, history) from backup"
     # -a preserves symlinks and attributes; trailing slashes copy contents.
     rsync -a "${excludes[@]}" "$backup_dir"/ "$target_dir"/

--- a/bootstrap/lib/deploy.sh
+++ b/bootstrap/lib/deploy.sh
@@ -2,11 +2,43 @@
 
 # Deployment, verification, and summary helpers for bootstrap.sh. This file is sourced, not executed.
 
+# Restore user/runtime state from a "Backup and replace" backup.
+#
+# The repo only owns the contents of configs/claude (CLAUDE.md, config/,
+# scripts/, skills/, …). Everything else under ~/.claude is user/runtime state
+# created by Claude Code at runtime — installed plugins, chat sessions, task and
+# command history, the user's own settings.json, credentials, MCP auth caches,
+# and plugin data dirs (.remember, .superpowers, …). The "Backup and replace"
+# path moves the entire live directory into a timestamped backup, so this helper
+# copies that runtime state back into the freshly created target. Repo-owned
+# entries are excluded so the redeploy below provides the authoritative copy.
+restore_runtime_state() {
+    local backup_dir="$1" target_dir="$2" source_dir="$3"
+    [[ -d "$backup_dir" ]] || return 0
+
+    # Build rsync excludes from the repo-owned entries (top level of source_dir,
+    # including dotfiles like .plans). These are redeployed, so the fresh config
+    # wins; everything else in the backup is runtime state and is restored.
+    local excludes=() entry
+    for entry in "$source_dir"/* "$source_dir"/.[!.]*; do
+        [[ -e "$entry" || -L "$entry" ]] || continue
+        excludes+=("--exclude=/$(basename "$entry")")
+    done
+
+    print_step "Restoring runtime state (plugins, sessions, settings.json, history) from backup"
+    # -a preserves symlinks and attributes; trailing slashes copy contents.
+    rsync -a "${excludes[@]}" "$backup_dir"/ "$target_dir"/
+    print_success "Runtime state restored (repo-owned config redeployed fresh)"
+}
+
 # Deploy configuration files
 deploy_configs() {
     print_header "Deploying Configuration Files"
 
     local source_dir="$SCRIPT_DIR/configs/claude"
+    # Set by the "Backup and replace" path so the main copy path can restore
+    # user/runtime state (plugins, sessions, settings.json, …) from the backup.
+    local restore_from=""
 
     if [[ ! -d "$source_dir" ]]; then
         print_error "Source directory not found: $source_dir"
@@ -34,6 +66,10 @@ deploy_configs() {
                     backup_dir="$TARGET_DIR.backup.$(date +%Y%m%d_%H%M%S)"
                     print_step "Backing up to $backup_dir"
                     mv "$TARGET_DIR" "$backup_dir"
+                    # Remember the backup so the main copy path can restore
+                    # runtime state (plugins, sessions, settings.json) that the
+                    # mv just moved out of the live directory.
+                    restore_from="$backup_dir"
                     print_success "Backup created"
                     ;;
                 2)
@@ -69,6 +105,14 @@ deploy_configs() {
     print_step "Creating $TARGET_DIR"
     mkdir -p "$TARGET_DIR"
     chmod 700 "$TARGET_DIR"
+
+    # When "Backup and replace" moved the live directory aside, restore the
+    # user/runtime state (installed plugins, chat sessions, history, the user's
+    # own settings.json, etc.) before redeploying repo-owned config. Without
+    # this, a clean replace orphans that state into the backup directory.
+    if [[ -n "$restore_from" ]]; then
+        restore_runtime_state "$restore_from" "$TARGET_DIR" "$source_dir"
+    fi
 
     print_step "Copying configuration files..."
     # Copy everything EXCEPT skills (skills is a symlink -> .skillshare/skills;

--- a/tests/bats/deploy_runtime_state.bats
+++ b/tests/bats/deploy_runtime_state.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# Tests for bootstrap/lib/deploy.sh restore_runtime_state — the "Backup and
+# replace" path must preserve user/runtime state (plugins, sessions, the user's
+# own settings.json, …) instead of orphaning it into the backup directory.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    SANDBOX=$(mktemp -d "$BATS_TMPDIR/deploy_runtime.XXXXXX")
+    # print_* helpers used by the function under test.
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/common.sh"
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh"
+
+    # A minimal "repo-owned" source tree: these names get redeployed and so must
+    # be EXCLUDED from the restore.
+    SRC="$SANDBOX/configs/claude"
+    mkdir -p "$SRC/config" "$SRC/scripts" "$SRC/.plans"
+    echo "owned" > "$SRC/CLAUDE.md"
+
+    # A backup that mimics a real live ~/.claude moved aside by `mv`: it holds
+    # both repo-owned config AND runtime state.
+    BK="$SANDBOX/.claude.backup"
+    mkdir -p "$BK/config" "$BK/plugins/cache/mkt/remember/0.7.3" \
+             "$BK/projects" "$BK/.remember" "$BK/.plans"
+    echo "stale-owned"     > "$BK/CLAUDE.md"
+    echo "user-settings"   > "$BK/settings.json"
+    echo "plugin-state"    > "$BK/plugins/installed_plugins.json"
+    echo "session"         > "$BK/projects/session.jsonl"
+    echo "remember-data"   > "$BK/.remember/notes.md"
+
+    TGT="$SANDBOX/home/.claude"
+    mkdir -p "$TGT"
+}
+
+teardown() {
+    [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+@test "restore_runtime_state restores plugins and sessions from backup" {
+    run restore_runtime_state "$BK" "$TGT" "$SRC"
+    assert_success
+
+    [ -f "$TGT/plugins/installed_plugins.json" ]
+    [ -d "$TGT/plugins/cache/mkt/remember/0.7.3" ]
+    [ -f "$TGT/projects/session.jsonl" ]
+    assert_equal "$(cat "$TGT/plugins/installed_plugins.json")" "plugin-state"
+}
+
+@test "restore_runtime_state restores the user's own settings.json and plugin data dirs" {
+    run restore_runtime_state "$BK" "$TGT" "$SRC"
+    assert_success
+
+    [ -f "$TGT/settings.json" ]            # not repo-owned → preserved
+    [ -f "$TGT/.remember/notes.md" ]       # plugin runtime data → preserved
+    assert_equal "$(cat "$TGT/settings.json")" "user-settings"
+}
+
+@test "restore_runtime_state does NOT restore repo-owned config (redeploy wins)" {
+    run restore_runtime_state "$BK" "$TGT" "$SRC"
+    assert_success
+
+    # Repo-owned entries are excluded so the fresh deploy is authoritative.
+    [ ! -e "$TGT/CLAUDE.md" ]
+    [ ! -e "$TGT/config" ]
+    [ ! -e "$TGT/.plans" ]
+}
+
+@test "restore_runtime_state is a no-op success when backup dir is absent" {
+    run restore_runtime_state "$SANDBOX/nonexistent" "$TGT" "$SRC"
+    assert_success
+    # Nothing created in the target.
+    run find "$TGT" -mindepth 1
+    assert_output ""
+}
+
+@test "restore_runtime_state handles a source with no dotfiles (unmatched glob)" {
+    # source_dir with ONLY regular entries — the `.[!.]*` glob matches nothing
+    # and must not abort or wrongly restore a literal '.[!.]*' name.
+    local src2="$SANDBOX/src_nodot"
+    mkdir -p "$src2/config"
+    echo owned > "$src2/CLAUDE.md"
+
+    run restore_runtime_state "$BK" "$TGT" "$src2"
+    assert_success
+
+    [ -f "$TGT/plugins/installed_plugins.json" ]   # runtime restored
+    [ ! -e "$TGT/config" ]                          # owned still excluded
+    [ ! -e "$TGT/.[!.]*" ]                          # no literal-glob junk file
+}
+
+@test "restore_runtime_state excludes a repo-owned 'skills' compat symlink" {
+    # configs/claude/skills is a (possibly broken) symlink; it must be excluded
+    # so rsync -a does not copy a dangling link from the backup into target.
+    ln -s "../../.skillshare/skills" "$SRC/skills"   # broken on purpose
+    mkdir -p "$BK/skills/should-not-restore"
+    echo x > "$BK/skills/should-not-restore/SKILL.md"
+
+    run restore_runtime_state "$BK" "$TGT" "$SRC"
+    assert_success
+
+    [ ! -e "$TGT/skills" ]                           # backup skills NOT restored
+    [ -f "$TGT/plugins/installed_plugins.json" ]     # runtime still restored
+}
+
+@test "restore_runtime_state preserves runtime dirs whose name matches a top-level owned name" {
+    # Leading-'/' anchoring must only drop TOP-LEVEL owned entries, never a
+    # nested path like plugins/config/ that happens to share the name 'config'.
+    mkdir -p "$BK/plugins/config"
+    echo nested > "$BK/plugins/config/data.json"
+
+    run restore_runtime_state "$BK" "$TGT" "$SRC"
+    assert_success
+
+    [ -f "$TGT/plugins/config/data.json" ]           # nested 'config' survives
+    [ ! -e "$TGT/config" ]                            # top-level 'config' dropped
+}

--- a/tests/bats/deploy_runtime_state.bats
+++ b/tests/bats/deploy_runtime_state.bats
@@ -108,6 +108,19 @@ teardown() {
     [ -f "$TGT/plugins/installed_plugins.json" ]     # runtime still restored
 }
 
+@test "restore_runtime_state excludes .agent_outputs (recreated as a symlink later)" {
+    # .agent_outputs is rebuilt by create_symlink into $MANIFEST_OUTPUT_DIR, so
+    # restoring it from the backup is wasted/expensive work that gets wiped.
+    mkdir -p "$BK/.agent_outputs/big"
+    echo out > "$BK/.agent_outputs/big/run.log"
+
+    run restore_runtime_state "$BK" "$TGT" "$SRC"
+    assert_success
+
+    [ ! -e "$TGT/.agent_outputs" ]                   # NOT restored
+    [ -f "$TGT/plugins/installed_plugins.json" ]     # other runtime still restored
+}
+
 @test "restore_runtime_state preserves runtime dirs whose name matches a top-level owned name" {
     # Leading-'/' anchoring must only drop TOP-LEVEL owned entries, never a
     # nested path like plugins/config/ that happens to share the name 'config'.

--- a/tests/bats/deploy_runtime_state_e2e.bats
+++ b/tests/bats/deploy_runtime_state_e2e.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# End-to-end: drive the REAL deploy_configs() through each existing-install path
+# (Backup-and-replace, Merge, --force) with a pre-populated ~/.claude that holds
+# runtime state (installed plugins, chat sessions, the user's settings.json) and
+# assert that state survives a redeploy while repo-owned config is refreshed.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    SANDBOX=$(mktemp -d "$BATS_TMPDIR/deploy_e2e.XXXXXX")
+
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/common.sh"
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh"
+
+    # Real repo configs are the deploy source.
+    export SCRIPT_DIR="$REPO_ROOT"
+    export HOME="$SANDBOX/home"
+    export TARGET_DIR="$HOME/.claude"
+    export CURSOR_TARGET_DIR="$HOME/.cursor"
+    export GEMINI_TARGET_DIR="$HOME/.gemini"
+    export CODEX_TARGET_DIR="$HOME/.codex"
+    export ANTIGRAVITY_TARGET_DIR="$HOME/.antigravity"
+    export MANIFEST_OUTPUT_DIR="$HOME/.manifest/outputs"
+
+    # Isolate heavy/secondary routines (network, profiles, other agents).
+    write_services_config()      { :; }
+    deploy_cursor_configs()      { :; }
+    deploy_gemini_configs()      { :; }
+    deploy_codex_configs()       { :; }
+    deploy_antigravity_configs() { :; }
+    sync_skillshare_targets()    { :; }
+    deploy_sync_skills()         { :; }
+
+    # Pre-populate a realistic live ~/.claude: runtime state + a stale/extra
+    # repo-owned file that a clean replace SHOULD drop.
+    mkdir -p "$TARGET_DIR/plugins/cache/mkt/remember/0.7.3" \
+             "$TARGET_DIR/projects" "$TARGET_DIR/.remember" "$TARGET_DIR/config"
+    echo '{"plugins":{"remember":1}}' > "$TARGET_DIR/plugins/installed_plugins.json"
+    echo 'session-data'               > "$TARGET_DIR/projects/abc.jsonl"
+    echo 'user-private-settings'      > "$TARGET_DIR/settings.json"
+    echo 'remember-notes'             > "$TARGET_DIR/.remember/notes.md"
+    # Stale config INSIDE a repo-owned dir: a clean replace must drop it because
+    # config/ is excluded from the restore and redeployed fresh from source.
+    echo 'STALE'                      > "$TARGET_DIR/config/OLD_THING.yml"
+    # A stray top-level file that is NOT part of configs/claude is unknown user
+    # content and must be preserved (safe default, same as plugins/sessions).
+    echo 'keepme'                     > "$TARGET_DIR/my_personal_note.md"
+}
+
+teardown() {
+    [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+# Assert all runtime state is intact in the freshly deployed TARGET_DIR.
+assert_runtime_preserved() {
+    [ -f "$TARGET_DIR/plugins/installed_plugins.json" ]
+    [ -d "$TARGET_DIR/plugins/cache/mkt/remember/0.7.3" ]
+    [ -f "$TARGET_DIR/projects/abc.jsonl" ]
+    [ -f "$TARGET_DIR/.remember/notes.md" ]
+    assert_equal "$(cat "$TARGET_DIR/settings.json")" "user-private-settings"
+    assert_equal "$(cat "$TARGET_DIR/projects/abc.jsonl")" "session-data"
+}
+
+# And repo-owned config got (re)deployed for real.
+assert_config_deployed() {
+    [ -f "$TARGET_DIR/CLAUDE.md" ]
+    [ -d "$TARGET_DIR/config" ]
+    [ -d "$TARGET_DIR/scripts" ]
+    [ -d "$TARGET_DIR/skills/code-quality" ]   # real skills, not the symlink
+    [ ! -L "$TARGET_DIR/skills" ]
+}
+
+@test "e2e Backup-and-replace: plugins/sessions/settings survive, stale config dropped, backup made" {
+    export FORCE=false
+    # Feed menu choice "1" (Backup and replace) to the interactive read.
+    deploy_configs <<< "1"
+
+    assert_runtime_preserved
+    assert_config_deployed
+
+    # Stale config inside a repo-owned dir was dropped (the whole point of
+    # option 1 vs merge) — proving owned config was genuinely replaced.
+    [ ! -e "$TARGET_DIR/config/OLD_THING.yml" ]
+    # …but a stray non-owned user file was preserved, like any runtime state.
+    assert_equal "$(cat "$TARGET_DIR/my_personal_note.md")" "keepme"
+
+    # A timestamped backup was created and still holds the original state.
+    run bash -c "ls -d $HOME/.claude.backup.* 2>/dev/null | head -1"
+    assert_output --partial ".claude.backup."
+    local bak; bak=$(ls -d "$HOME"/.claude.backup.* | head -1)
+    [ -f "$bak/plugins/installed_plugins.json" ]
+}
+
+@test "e2e --force: additive deploy keeps plugins and leaves runtime untouched" {
+    export FORCE=true
+    deploy_configs
+
+    assert_runtime_preserved
+    assert_config_deployed
+    # --force is additive (no mv), so even the stale file remains — that's fine;
+    # the data-loss bug was only ever the mv path.
+}
+
+@test "e2e Merge: option 2 keeps plugins and existing runtime" {
+    export FORCE=false
+    deploy_configs <<< "2"
+
+    assert_runtime_preserved
+    [ -f "$TARGET_DIR/CLAUDE.md" ]
+    [ -d "$TARGET_DIR/skills/code-quality" ]
+}


### PR DESCRIPTION
## Problem
The interactive **"Backup and replace"** option in `deploy_configs` (`bootstrap/lib/deploy.sh`) moved the entire live `~/.claude` aside with `mv "$TARGET_DIR" "$backup_dir"`, then rebuilt the directory from repo config only. This **orphaned all user/runtime state** — installed plugins, chat sessions, task/command history, the user's own `settings.json`, and plugin data dirs (`.remember`, `.superpowers`) — into the timestamped backup.

The visible symptom was `Plugin directory does not exist … (run /plugin to reinstall)` hook errors after a redeploy: 26 installed plugins had been moved into `~/.claude.backup.<ts>/`.

## Fix
Add a `restore_runtime_state` helper. After the backup `mv`, it rsyncs everything from the backup back into the freshly created target **except repo-owned entries** (derived from the top-level contents of `configs/claude`, anchored with leading-`/` excludes). Repo config is redeployed authoritatively while runtime state survives.

The `--force` and merge paths were already additive (no `mv`) and are unaffected.

## Tests
- **`deploy_runtime_state.bats` (7)** — restore/exclude semantics, no-dotfile glob, `skills` compat-symlink exclusion, nested-name non-collision, absent-backup no-op.
- **`deploy_runtime_state_e2e.bats` (3)** — drives the **real** `deploy_configs` through Backup-and-replace / `--force` / Merge and asserts plugins, sessions, and the user's `settings.json` survive while stale owned config is dropped.

Full suite: **bats 169/169**, pytest 128/128, shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)