### PR TITLE
fix(bootstrap): deploy all 5 Antigravity symlinks, not just skills

### DIFF
--- a/.skillshare/skills/health-check/SKILL.md
+++ b/.skillshare/skills/health-check/SKILL.md
@@ -95,7 +95,15 @@ Verify all cross-platform symlinks are intact:
 .codex/prompts   → ../.claude/prompts
 .codex/skills    → ../.claude/skills
 .codex/.plans    → ../.claude/.plans
+.antigravity/scripts → ../.claude/scripts
+.antigravity/config  → ../.claude/config
+.antigravity/prompts → ../.claude/prompts
+.antigravity/skills  → ../.claude/skills
+.antigravity/.plans  → ../.claude/.plans
 ```
+
+Only check symlinks for services marked `enabled: true` in
+`.claude/config/services.yml` (e.g. skip `.cursor`/`.codex` when disabled).
 
 For each: check if symlink exists and target is valid.
 

--- a/bootstrap/lib/deploy.sh
+++ b/bootstrap/lib/deploy.sh
@@ -269,12 +269,14 @@ deploy_codex_configs() {
     print_success "Codex configuration deployed to $CODEX_TARGET_DIR"
 }
 
-# Deploy Antigravity configuration (skills symlink only — Antigravity reads
-# ~/.antigravity/skills; it shares the single source of truth via symlink).
+# Deploy Antigravity configuration (mirrors .claude with symlinks, matching
+# Cursor/Gemini/Codex). Antigravity shares the single source of truth in
+# ~/.claude via symlinks for scripts, config, prompts, skills, and .plans.
 deploy_antigravity_configs() {
     print_step "Deploying Antigravity configuration..."
     mkdir -p "$ANTIGRAVITY_TARGET_DIR"
-    create_symlink "$ANTIGRAVITY_TARGET_DIR/skills" "$TARGET_DIR/skills" "Antigravity skills"
+    # Link shared assets from ~/.claude to avoid duplicate copies, including shared skills.
+    link_shared_assets "$ANTIGRAVITY_TARGET_DIR" "Antigravity" "true"
     print_success "Antigravity configuration deployed to $ANTIGRAVITY_TARGET_DIR"
 }
 

--- a/tests/bats/deploy_skills.bats
+++ b/tests/bats/deploy_skills.bats
@@ -100,10 +100,11 @@ teardown() {
     assert_output ""
 }
 
-@test "deploy_antigravity_configs symlinks ~/.antigravity/skills to claude skills" {
+@test "deploy_antigravity_configs symlinks all 5 shared assets to claude" {
     export TARGET_DIR="$SANDBOX/home/.claude"
     export ANTIGRAVITY_TARGET_DIR="$SANDBOX/home/.antigravity"
-    mkdir -p "$TARGET_DIR/skills/demo"
+    mkdir -p "$TARGET_DIR/skills/demo" "$TARGET_DIR/scripts" \
+        "$TARGET_DIR/config" "$TARGET_DIR/prompts" "$TARGET_DIR/.plans"
 
     # shellcheck disable=SC1090
     source "$REPO_ROOT/bootstrap/lib/deploy.sh"
@@ -111,14 +112,18 @@ teardown() {
     run deploy_antigravity_configs
     assert_success
 
-    [ -L "$ANTIGRAVITY_TARGET_DIR/skills" ]
+    # All five shared assets are symlinked (mirrors Cursor/Gemini/Codex).
+    for link in skills scripts config prompts .plans; do
+        [ -L "$ANTIGRAVITY_TARGET_DIR/$link" ]
+    done
     [ -d "$ANTIGRAVITY_TARGET_DIR/skills/demo" ]
 }
 
-@test "deploy_antigravity_configs is idempotent — second run leaves symlink intact" {
+@test "deploy_antigravity_configs is idempotent — second run leaves symlinks intact" {
     export TARGET_DIR="$SANDBOX/home/.claude"
     export ANTIGRAVITY_TARGET_DIR="$SANDBOX/home/.antigravity"
-    mkdir -p "$TARGET_DIR/skills/demo"
+    mkdir -p "$TARGET_DIR/skills/demo" "$TARGET_DIR/scripts" \
+        "$TARGET_DIR/config" "$TARGET_DIR/prompts" "$TARGET_DIR/.plans"
 
     # shellcheck disable=SC1090
     source "$REPO_ROOT/bootstrap/lib/deploy.sh"
@@ -127,7 +132,9 @@ teardown() {
     run deploy_antigravity_configs      # second run — must not fail
     assert_success
 
-    [ -L "$ANTIGRAVITY_TARGET_DIR/skills" ]
+    for link in skills scripts config prompts .plans; do
+        [ -L "$ANTIGRAVITY_TARGET_DIR/$link" ]
+    done
     [ -d "$ANTIGRAVITY_TARGET_DIR/skills/demo" ]
 }
 


### PR DESCRIPTION
## Problem

`deploy_antigravity_configs()` in `bootstrap/lib/deploy.sh` only created the `skills` symlink, but the source `configs/antigravity/` and the `CLAUDE.md` manual-deployment docs both define **5** symlinks (`scripts`, `config`, `prompts`, `skills`, `.plans`).

This three-way drift meant every `./bootstrap.sh` run left an **enabled** Antigravity install missing `scripts`, `config`, `prompts`, and `.plans` — unlike Cursor/Gemini/Codex, which all get the full set.

Found while auditing the deployed `~/.claude` environment after bootstrap.

## Fix

- **`bootstrap/lib/deploy.sh`** — `deploy_antigravity_configs()` now calls `link_shared_assets ... "true"`, the same helper Cursor/Gemini/Codex use. Antigravity now gets all 5 symlinks and stays automatically in sync if the shared-asset set changes.
- **`tests/bats/deploy_skills.bats`** — expanded the two Antigravity tests to assert all 5 symlinks (previously skills-only).
- **`.skillshare/skills/health-check/SKILL.md`** — added `.antigravity` to the symlink-integrity check (a prior blind spot — the skill only checked `.cursor`/`.gemini`/`.codex`), plus a note to only check symlinks for services marked `enabled: true`.

## Verification

- `bats tests/bats/deploy_skills.bats` → 15/15 pass
- `bats tests/bats/deploy_antigravity.bats` → 2/2 pass
- `bats tests/bats/deploy_runtime_state_e2e.bats` → 3/3 pass
- `shellcheck bootstrap/lib/deploy.sh` → no new findings (2 pre-existing infos, outside the edit)
- Backfilled the live `~/.antigravity` symlinks; all 5 now resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)