### PR TITLE
🎨 Palette: Add transient=True to rich UIs to clear terminal spam

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,3 +3,10 @@
 ## 2026-02-06 - Initial Setup
 **Learning:** UX improvements in CLI tools are just as critical as web UIs.
 **Action:** When working on CLI scripts, prioritize readability (colors, spacing) and explicit user guidance (defaults, help text).
+
+## 2024-06-07 - Transient UI Components
+**Learning:** Persistent CLI loading spinners or live displays can
+leave a trail of cluttered state after completion, frustrating users
+tracking progress.
+**Action:** Add `transient=True` to `rich` Progress and Live components
+so they smoothly clear themselves upon completion.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -141,6 +141,7 @@ class Orchestrator:
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
             console=self.console,
+            transient=True,
         ) as progress:
             _task = progress.add_task(
                 f"Running {len(self.agents)} agents...", total=None
@@ -186,6 +187,7 @@ class Orchestrator:
                 self._build_streaming_layout(agent_panels),
                 refresh_per_second=self.config.get("streaming.refresh_rate", 4),
                 console=self.console,
+                transient=True,
             ) as live:
                 # Run agents in parallel
                 results = await asyncio.gather(


### PR DESCRIPTION
💡 What: Added `transient=True` to `rich.progress.Progress` and `rich.live.Live` in the parallel agent orchestrator.
🎯 Why: Persistent terminal UI displays remain on the screen as clutter after execution finishes. Clearing them on exit leaves a cleaner execution log for the user.
📸 Before/After: Terminal scrollback is no longer cluttered with old completed loading spinners.
♿ Accessibility: Reduces visual noise and screen reader noise for CLI users.

---
*PR created automatically by Jules for task [16133383985880183012](https://jules.google.com/task/16133383985880183012) started by @RB-chrismandich*