### PR TITLE
🛡️ Forge: Fix unsafe eval parsing in issue-triage skill

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,0 +1,3 @@
+## 2026-06-07 - issue-triage
+**Learning:** Python scripts often format output as shell variable assignments intended to be sourced. Executing this output dynamically via `eval` introduces command injection risks in bash scripts if the python code or input files are altered.
+**Action:** Configure automated checks to flag `eval "$(..."` or `eval \`...\`` patterns, especially those consuming output from other commands. Use a `while IFS=` loop combined with a `case` whitelist to securely parse key-value configuration directly into the shell environment without dynamic evaluation.

--- a/.skillshare/skills/issue-triage/SKILL.md
+++ b/.skillshare/skills/issue-triage/SKILL.md
@@ -77,7 +77,23 @@ EOF
 }
 
 # Source config as environment variables
-eval "$(read_config)"
+config_string="$(read_config)"
+while IFS= read -r line; do
+    case "$line" in
+        DUP_TITLE_HIGH=*)
+            val="${line#*=}"; val="${val%\"}"; val="${val#\"}"; DUP_TITLE_HIGH="$val" ;;
+        DUP_TITLE_MEDIUM=*)
+            val="${line#*=}"; val="${val%\"}"; val="${val#\"}"; DUP_TITLE_MEDIUM="$val" ;;
+        STALENESS_DAYS=*)
+            val="${line#*=}"; val="${val%\"}"; val="${val#\"}"; STALENESS_DAYS="$val" ;;
+        FILE_MISSING_THRESHOLD=*)
+            val="${line#*=}"; val="${val%\"}"; val="${val#\"}"; FILE_MISSING_THRESHOLD="$val" ;;
+        CONSENSUS_HIGH=*)
+            val="${line#*=}"; val="${val%\"}"; val="${val#\"}"; CONSENSUS_HIGH="$val" ;;
+        CONSENSUS_MEDIUM=*)
+            val="${line#*=}"; val="${val%\"}"; val="${val#\"}"; CONSENSUS_MEDIUM="$val" ;;
+    esac
+done <<< "$config_string"
 
 echo "Configuration loaded: DUP_TITLE_HIGH=$DUP_TITLE_HIGH, STALENESS_DAYS=$STALENESS_DAYS"
 ```


### PR DESCRIPTION
Replaced an unsafe `eval "$(read_config)"` pattern in `.skillshare/skills/issue-triage/SKILL.md` with a secure whitelist-based variable parsing loop (`while IFS= read -r line; do case ... esac; done`). It securely strips quotes to mimic `eval` parsing while avoiding arbitrary code execution if the configuration output was ever modified or malformed. Also added to Forge's architectural learnings in `.jules/forge.md`.

---
*PR created automatically by Jules for task [5559609225208847894](https://jules.google.com/task/5559609225208847894) started by @RB-chrismandich*