### PR TITLE
🎨 Palette: Add transient=True to Progress and Live displays

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,3 +3,10 @@
 ## 2026-02-06 - Initial Setup
 **Learning:** UX improvements in CLI tools are just as critical as web UIs.
 **Action:** When working on CLI scripts, prioritize readability (colors, spacing) and explicit user guidance (defaults, help text).
+
+## 2025-02-12 - Transient CLI Displays
+**Learning:** In CLI applications that use rich, completed spinners or progress
+bars can clutter the scrollback if left on screen.
+**Action:** When instantiating rich `Progress` or `Live` components for
+temporary tasks, always use `transient=True` to automatically remove them from
+the terminal upon completion, keeping the output clean and accessible.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -141,6 +141,7 @@ class Orchestrator:
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
             console=self.console,
+            transient=True,
         ) as progress:
             _task = progress.add_task(
                 f"Running {len(self.agents)} agents...", total=None
@@ -186,6 +187,7 @@ class Orchestrator:
                 self._build_streaming_layout(agent_panels),
                 refresh_per_second=self.config.get("streaming.refresh_rate", 4),
                 console=self.console,
+                transient=True,
             ) as live:
                 # Run agents in parallel
                 results = await asyncio.gather(


### PR DESCRIPTION
💡 What: Added transient=True to Progress and Live displays in the orchestrator.

🎯 Why: To automatically clear the terminal of spinners once a task is finished, reducing scrollback clutter and improving the CLI experience.

📸 Before/After: Before, completed spinners lingered on the screen. After, the console is cleaner.

♿ Accessibility: Reduces cognitive load and extraneous visual noise on the terminal, making output easier to scan.

---
*PR created automatically by Jules for task [9982428042013226550](https://jules.google.com/task/9982428042013226550) started by @RB-chrismandich*