### PR TITLE
🎨 Palette: Add transient=True to rich UI components for cleaner terminal output

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,3 +3,11 @@
 ## 2026-02-06 - Initial Setup
 **Learning:** UX improvements in CLI tools are just as critical as web UIs.
 **Action:** When working on CLI scripts, prioritize readability (colors, spacing) and explicit user guidance (defaults, help text).
+
+## 2026-06-08 - Rich Terminal UI Persistence
+**Learning:** By default, rich `Progress` and `Live` instances leave their
+final output in the terminal scrollback, causing unnecessary clutter during
+repeated script executions.
+**Action:** Instantiate these UI components with `transient=True` to
+automatically clear them upon completion, keeping the user's terminal history
+clean.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -141,6 +141,7 @@ class Orchestrator:
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
             console=self.console,
+            transient=True,
         ) as progress:
             _task = progress.add_task(
                 f"Running {len(self.agents)} agents...", total=None
@@ -186,6 +187,7 @@ class Orchestrator:
                 self._build_streaming_layout(agent_panels),
                 refresh_per_second=self.config.get("streaming.refresh_rate", 4),
                 console=self.console,
+                transient=True,
             ) as live:
                 # Run agents in parallel
                 results = await asyncio.gather(


### PR DESCRIPTION
💡 What: Added `transient=True` to `rich.progress.Progress` and `rich.live.Live` instantiations in `orchestrator.py`.
🎯 Why: Ensures loading spinners and streaming displays are automatically cleared from the terminal when finished, reducing scrollback clutter for users.
📸 Before/After: The terminal output history will no longer be polluted with stale spinner/progress blocks.
♿ Accessibility: Reduces visual noise for terminal screen readers.

---
*PR created automatically by Jules for task [16071628708223858290](https://jules.google.com/task/16071628708223858290) started by @RB-chrismandich*