### PR TITLE
SkillClaw: proxy-free, transcript-fed skill evolution (Max-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ cd Manifest
 - **Cross-Platform**: Native support for macOS (Intel/Apple Silicon) and 5 major Linux distributions
 - **Unified Label Management**: Canonical label registry with sync across GitHub, GitLab, and Linear
 - **Production Templates**: Pre-configured permission templates for Django, Express, Go microservices, Python monorepos
-- **SkillClaw Integration** (opt-in): Capture-proxy that records agent sessions and proposes evolved skills via PR.
-  Fail-open design keeps agents working even when the daemon is down; enable with `--enable-skillclaw`
+- **SkillClaw Integration** (opt-in): Passively ingests Claude Code's own `~/.claude/projects/**/*.jsonl`
+  transcripts, runs a `claude -p` map-reduce evolve pass (Max subscription, no API key), and proposes
+  evolved skills via a review PR. No proxy, no daemon, no port. Enable with `--enable-skillclaw`
 - **Proton Pass Credential Retrieval** (`/pass-cli`): Retrieve passwords, API keys, and tokens from Proton Pass
   vaults without storing PATs in files or memory
 
@@ -138,7 +139,7 @@ Mermaid flowcharts showing bootstrap, execution, validation, and consensus flows
 | [Getting Started](docs/GETTING_STARTED.md) | First-time setup walkthrough with verification steps | New users | 10 min |
 | [Configuration](docs/CONFIGURATION.md) | All configuration options, YAML reference, environment variables | Operators | 15 min |
 | [Architecture Diagrams](docs/ARCHITECTURE_DIAGRAMS.md) | Visual system documentation with 15 Mermaid diagrams | Developers | 20 min |
-| [SkillClaw](docs/SKILLCLAW.md) | PR-gated skill evolution via session capture proxy | Operators | 8 min |
+| [SkillClaw](docs/SKILLCLAW.md) | PR-gated skill evolution via passive transcript ingestion | Operators | 8 min |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Common problems, error messages, solutions | All users | 10 min |
 | [AGENTS.md](AGENTS.md) | AI agent instructions (Cursor, Claude, Gemini, Codex) | AI assistants | 8 min |
 | [CLAUDE.md](CLAUDE.md) | Claude Code-specific project context | AI assistants | 8 min |
@@ -164,7 +165,7 @@ Manifest/
 │   │   ├── auth.sh                  # Authentication + state setup routines
 │   │   ├── deploy.sh                # Deployment/verification/summary routines
 │   │   ├── mcp.sh                   # MCP installation/configuration routines
-│   │   └── skillclaw.sh             # SkillClaw daemon install/enable/disable routines
+│   │   └── skillclaw.sh             # SkillClaw ingest/evolve install/enable/disable routines
 │   └── modules/README.md            # How to add custom bootstrap modules/hooks
 ├── CLAUDE.md                        # Claude Code project context
 ├── AGENTS.md                        # AI agent instructions (all platforms)
@@ -179,7 +180,7 @@ Manifest/
 │   │   │   ├── command_config.yml   # Tool policies, thresholds, model selection
 │   │   │   ├── validation_criteria.yml # Tier 1/2 validation rules
 │   │   │   ├── labels.yml           # Canonical label registry
-│   │   │   └── skillclaw.yml        # SkillClaw capture proxy + evolution config
+│   │   │   └── skillclaw.yml        # SkillClaw ingest/evolve knobs + token budget config
 │   │   ├── scripts/                 # Orchestration scripts
 │   │   │   ├── parallel_agent.py    # Entry point shim (delegates to agents/)
 │   │   │   ├── agents/              # Modular orchestration package

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -216,7 +216,6 @@ main() {
         install_claude
         install_gemini
         install_codex
-        install_skillclaw
         install_github_cli
         install_gitlab_cli
         check_jq

--- a/bootstrap/lib/config.sh
+++ b/bootstrap/lib/config.sh
@@ -372,13 +372,11 @@ services:
     enabled: $ENABLE_ANTIGRAVITY
     description: "VS Code-fork IDE; inherits ~/.claude/ config via Claude Code extension"
 
-  # SkillClaw - auto-evolves SKILL.md skills from captured CLI-agent sessions
-  # Install: bash scripts/install_skillclaw.sh  (managed by bootstrap/lib/skillclaw.sh)
+  # SkillClaw - evolves SKILL.md skills from Claude Code transcripts (proxy-free)
+  # Managed by bootstrap/lib/skillclaw.sh; no install, no daemon, no proxy.
   skillclaw:
     enabled: ${ENABLE_SKILLCLAW:-false}
-    command: skillclaw
-    description: "Captures CLI-agent sessions; evolves skills into review PRs (opt-in)"
-    proxy_port: 8765
+    description: "Evolves skills from transcripts into review PRs via /skill-evolve (opt-in)"
     storage: ~/.skillclaw
 
   # Git CLI tools - Platform-specific Git hosting integrations

--- a/bootstrap/lib/skillclaw.sh
+++ b/bootstrap/lib/skillclaw.sh
@@ -1,83 +1,24 @@
 #!/usr/bin/env bash
-# skillclaw.sh - Install, configure, and manage the SkillClaw capture proxy.
+# skillclaw.sh - Manage SkillClaw transcript-evolution state.
 #
 # Responsibilities:
-#   - Install SkillClaw (pip) when enabled.
 #   - chmod 700 the capture storage (secrets honeypot — Tier 1).
-#   - Non-interactive `skillclaw setup` from configs/claude/config/skillclaw.yml.
-#   - Write/remove fail-open runtime wrapper functions (see skillclaw_wrappers).
-#   - Daemon lifecycle + crash supervisor (see skillclaw_daemon).
+#   - Remove any legacy proxy wrapper block left by a prior install.
+#   - Remove retired launchd/systemd supervisor units.
+#
+# The proxy/daemon model has been retired. SkillClaw now uses transcript-fed
+# evolution: enabling = storage-only setup, no daemon, no proxy, no wrappers.
 #
 # Sourced by bootstrap.sh. bash 3.2-compatible.
 
 # Storage root is overridable for tests.
 SKILLCLAW_HOME="${SKILLCLAW_HOME:-$HOME/.skillclaw}"
-SKILLCLAW_PORT="${SKILLCLAW_PORT:-8765}"
-
-# Create capture storage with locked-down perms. Secrets may transit here.
-skillclaw_init_storage() {
-    print_step "Preparing SkillClaw storage at $SKILLCLAW_HOME..."
-    mkdir -p "$SKILLCLAW_HOME/sessions" "$SKILLCLAW_HOME/skills"
-    chmod 700 "$SKILLCLAW_HOME" "$SKILLCLAW_HOME/sessions" "$SKILLCLAW_HOME/skills"
-    print_success "SkillClaw storage ready (700)"
-}
-
-# Install SkillClaw via pip if missing.
-install_skillclaw() {
-    if [[ "${ENABLE_SKILLCLAW:-false}" != true ]]; then
-        return 0
-    fi
-    if command -v skillclaw >/dev/null 2>&1; then
-        print_info "SkillClaw already installed"
-        return 0
-    fi
-    print_step "Installing SkillClaw..."
-    if command -v pipx >/dev/null 2>&1; then
-        pipx install skillclaw || { print_error "pipx install skillclaw failed"; return 1; }
-    elif command -v pip3 >/dev/null 2>&1; then
-        pip3 install --user skillclaw || { print_error "pip3 install skillclaw failed"; return 1; }
-    else
-        print_error "Neither pipx nor pip3 found; cannot install SkillClaw"
-        return 1
-    fi
-    print_success "SkillClaw installed"
-}
-
-# Non-interactive setup from skillclaw.yml. Idempotent.
-configure_skillclaw() {
-    if [[ "${ENABLE_SKILLCLAW:-false}" != true ]]; then
-        return 0
-    fi
-    skillclaw_init_storage
-    local cfg="${SKILLCLAW_CONFIG:-$HOME/.claude/config/skillclaw.yml}"
-    if [[ ! -f "$cfg" ]]; then
-        print_warning "skillclaw.yml not found at $cfg; skipping setup"
-        return 0
-    fi
-    print_step "Configuring SkillClaw (non-interactive)..."
-    # `skillclaw setup` reads provider/model/storage flags; values come from skillclaw.yml.
-    local port storage
-    port=$(python3 - "$cfg" <<'PY'
-import sys, yaml
-print(yaml.safe_load(open(sys.argv[1]))["proxy"]["port"])
-PY
-)
-    storage=$(python3 - "$cfg" <<'PY'
-import sys, os, yaml
-print(os.path.expanduser(yaml.safe_load(open(sys.argv[1]))["storage"]["root"]))
-PY
-)
-    if command -v skillclaw >/dev/null 2>&1; then
-        skillclaw setup --non-interactive --port "$port" --storage "$storage" \
-            || print_warning "skillclaw setup returned non-zero (continuing)"
-    fi
-    print_success "SkillClaw configured (port $port, storage $storage)"
-}
 
 SKILLCLAW_WRAP_BEGIN="# >>> MANIFEST SKILLCLAW WRAPPERS >>>"
 SKILLCLAW_WRAP_END="# <<< MANIFEST SKILLCLAW WRAPPERS <<<"
 
 # Remove any existing managed wrapper block from a profile file (idempotent).
+# Kept to strip legacy claude()/codex() blocks from prior proxy-based installs.
 skillclaw_remove_wrappers() {
     local profile="$1"
     [[ -f "$profile" ]] || return 0
@@ -86,140 +27,32 @@ skillclaw_remove_wrappers() {
         && mv "${profile}.tmp" "$profile"
 }
 
-# Write the fail-open runtime wrapper block. The health probe runs at INVOCATION
-# time (not shell init), capped at 0.3s, and degrades to direct-to-provider.
-skillclaw_write_wrappers() {
-    local profile="$1"
-    mkdir -p "$(dirname "$profile")"
-    touch "$profile"
-    skillclaw_remove_wrappers "$profile"
-    cat >> "$profile" << EOF
-$SKILLCLAW_WRAP_BEGIN
-# Managed by bootstrap/lib/skillclaw.sh — do not edit between these markers.
-export SKILLCLAW_PORT="\${SKILLCLAW_PORT:-$SKILLCLAW_PORT}"
-_skillclaw_up() {
-    curl -sf --max-time 0.3 "http://127.0.0.1:\${SKILLCLAW_PORT}/health" >/dev/null 2>&1
-}
-_skillclaw_run() {
-    # \$1=env var name, \$2=base url, rest=command
-    local var="\$1" url="\$2"; shift 2
-    if [ -z "\${SKILLCLAW_BYPASS:-}" ] && _skillclaw_up; then
-        env "\$var=\$url" "\$@"
-    else
-        "\$@"
-    fi
-}
-claude() { _skillclaw_run ANTHROPIC_BASE_URL "http://127.0.0.1:\${SKILLCLAW_PORT}" command claude "\$@"; }
-codex()  { _skillclaw_run OPENAI_BASE_URL    "http://127.0.0.1:\${SKILLCLAW_PORT}/v1" command codex "\$@"; }
-$SKILLCLAW_WRAP_END
-EOF
-}
-
-SKILLCLAW_PIDFILE="${SKILLCLAW_PIDFILE:-$SKILLCLAW_HOME/skillclaw.pid}"
-
-# start|stop|status for the capture daemon. Capture is lossy-by-design; a dead
-# daemon must never block agents (the wrappers already fail open).
-skillclaw_daemon() {
-    local action="${1:-status}"
-    case "$action" in
-        start)
-            command -v skillclaw >/dev/null 2>&1 || { print_error "skillclaw not installed"; return 1; }
-            skillclaw start --daemon --port "$SKILLCLAW_PORT" || return 1
-            print_success "SkillClaw daemon started on $SKILLCLAW_PORT"
-            ;;
-        stop)
-            skillclaw stop >/dev/null 2>&1 || true
-            print_info "SkillClaw daemon stopped"
-            ;;
-        status)
-            if [[ -f "$SKILLCLAW_PIDFILE" ]] && kill -0 "$(cat "$SKILLCLAW_PIDFILE")" 2>/dev/null; then
-                echo "running"
-                return 0
-            fi
-            echo "stopped"
-            return 1
-            ;;
-        *)
-            print_error "usage: skillclaw_daemon start|stop|status"
-            return 2
-            ;;
-    esac
-}
-
-# Emit a platform supervisor unit so a crashed daemon auto-restarts (§5.3).
-# $1 = platform (darwin|linux), $2 = output path.
-skillclaw_supervisor_unit() {
-    local platform="$1" out="$2"
-    local bin; bin="$(command -v skillclaw 2>/dev/null || echo skillclaw)"
-    mkdir -p "$(dirname "$out")"
-    case "$platform" in
-        darwin)
-            cat > "$out" << EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key><string>com.manifest.skillclaw</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>$bin</string><string>start</string><string>--port</string><string>$SKILLCLAW_PORT</string>
-  </array>
-  <key>KeepAlive</key><true/>
-  <key>RunAtLoad</key><true/>
-</dict>
-</plist>
-EOF
-            ;;
-        linux)
-            cat > "$out" << EOF
-[Unit]
-Description=SkillClaw capture proxy
-[Service]
-ExecStart=$bin start --port $SKILLCLAW_PORT
-Restart=on-failure
-[Install]
-WantedBy=default.target
-EOF
-            ;;
-        *)
-            print_error "unknown platform: $platform"
-            return 1
-            ;;
-    esac
-}
-
-# Install + load the supervisor for the current platform (best-effort).
-skillclaw_install_supervisor() {
+# Remove the retired launchd/systemd supervisor if a prior install left one.
+_skillclaw_remove_launchd() {
     case "$(uname -s)" in
         Darwin)
             local plist="$HOME/Library/LaunchAgents/com.manifest.skillclaw.plist"
-            skillclaw_supervisor_unit darwin "$plist"
-            launchctl unload "$plist" >/dev/null 2>&1 || true
-            launchctl load "$plist" >/dev/null 2>&1 || print_warning "launchctl load failed (continuing)"
+            [[ -f "$plist" ]] && { launchctl unload "$plist" >/dev/null 2>&1 || true; rm -f "$plist"; }
             ;;
         Linux)
             local unit="$HOME/.config/systemd/user/skillclaw.service"
-            skillclaw_supervisor_unit linux "$unit"
-            systemctl --user daemon-reload >/dev/null 2>&1 || true
-            systemctl --user enable --now skillclaw.service >/dev/null 2>&1 \
-                || print_warning "systemctl enable failed (continuing)"
+            [[ -f "$unit" ]] && { systemctl --user disable --now skillclaw.service >/dev/null 2>&1 || true; rm -f "$unit"; }
             ;;
     esac
 }
 
-# Apply the desired state based on ENABLE_SKILLCLAW. Called from bootstrap main.
-# Writes wrappers to SHELL_PROFILE_FILE (set by configure_shell_profile_state).
+# Apply desired state. Transcript-fed evolution needs NO daemon and NO proxy —
+# enabling just ensures storage exists and any legacy proxy wrappers are removed.
 skillclaw_apply_state() {
     local profile="${SHELL_PROFILE_FILE:-$HOME/.zshrc}"
+    # Always strip any legacy proxy wrapper block (full teardown of the old model).
+    skillclaw_remove_wrappers "$profile"
+    _skillclaw_remove_launchd
     if [[ "${ENABLE_SKILLCLAW:-false}" == true ]]; then
-        configure_skillclaw
-        skillclaw_write_wrappers "$profile"
-        skillclaw_install_supervisor
-        skillclaw_daemon start || print_warning "Could not start SkillClaw daemon (wrappers fail open)"
-        print_success "SkillClaw enabled (capture via $profile)"
+        mkdir -p "$SKILLCLAW_HOME/sessions" "$SKILLCLAW_HOME/skills"
+        chmod 700 "$SKILLCLAW_HOME" 2>/dev/null || true
+        print_success "SkillClaw enabled (transcript evolution; no daemon, no proxy)"
     else
-        skillclaw_remove_wrappers "$profile"
-        skillclaw_daemon stop || true
-        print_info "SkillClaw disabled (wrappers removed)"
+        print_info "SkillClaw disabled (storage left intact; nothing running)"
     fi
 }

--- a/bootstrap/lib/skillclaw.sh
+++ b/bootstrap/lib/skillclaw.sh
@@ -50,7 +50,9 @@ skillclaw_apply_state() {
     _skillclaw_remove_launchd
     if [[ "${ENABLE_SKILLCLAW:-false}" == true ]]; then
         mkdir -p "$SKILLCLAW_HOME/sessions" "$SKILLCLAW_HOME/skills"
-        chmod 700 "$SKILLCLAW_HOME" 2>/dev/null || true
+        # Tier-1 secrets honeypot: lock down the root AND subdirs (transcripts may
+        # transit sessions/ before scrubbing). Inherited umask is not enough.
+        chmod 700 "$SKILLCLAW_HOME" "$SKILLCLAW_HOME/sessions" "$SKILLCLAW_HOME/skills" 2>/dev/null || true
         print_success "SkillClaw enabled (transcript evolution; no daemon, no proxy)"
     else
         print_info "SkillClaw disabled (storage left intact; nothing running)"

--- a/configs/claude/config/services.yml
+++ b/configs/claude/config/services.yml
@@ -55,13 +55,11 @@ services:
       - OPENAI_API_KEY
       - ~/.codex/auth.json
 
-  # SkillClaw - auto-evolves SKILL.md skills from captured CLI-agent sessions
-  # Install: bash scripts/install_skillclaw.sh  (managed by bootstrap/lib/skillclaw.sh)
+  # SkillClaw - evolves SKILL.md skills from Claude Code transcripts (proxy-free)
+  # Managed by bootstrap/lib/skillclaw.sh; no install, no daemon, no proxy.
   skillclaw:
     enabled: false
-    command: skillclaw
-    description: "Captures CLI-agent sessions; evolves skills into review PRs (opt-in)"
-    proxy_port: 8765
+    description: "Evolves skills from transcripts into review PRs via /skill-evolve (opt-in)"
     storage: ~/.skillclaw
 
   # Git CLI tools - Platform-specific Git hosting integrations

--- a/configs/claude/config/skillclaw.yml
+++ b/configs/claude/config/skillclaw.yml
@@ -14,7 +14,7 @@ ingest:
   transcripts_dir: ~/.claude/projects
   window_days: 30              # all projects, recent window
   settle_minutes: 5           # skip files whose mtime is newer (still being written)
-  max_tool_output_chars: 500  # truncate raw tool stdout/stderr beyond this; drop base64
+  max_tool_output_chars: 500  # truncate raw tool stdout/stderr (incl. base64 blobs) beyond this
   # allowlist: []             # optional future: restrict to project paths
 
 evolve:

--- a/configs/claude/config/skillclaw.yml
+++ b/configs/claude/config/skillclaw.yml
@@ -1,43 +1,26 @@
-# SkillClaw runtime configuration
-# Consumed by bootstrap/lib/skillclaw.sh and scripts/skillclaw_*.{sh,py}.
-# This file is deployed to ~/.claude/config/skillclaw.yml.
-
-proxy:
-  port: 8765
-  host: 127.0.0.1
+# SkillClaw runtime configuration (proxy-free, transcript-fed).
+# Consumed by scripts/skillclaw_{ingest,evolve,promote}.{py,sh}.
+# Deployed to ~/.claude/config/skillclaw.yml. NOTE: distinct from the vestigial
+# upstream ~/.skillclaw/config.yaml — this file is the Manifest-owned source.
 
 storage:
-  root: ~/.skillclaw          # chmod 700 by bootstrap; holds session capture + evolved lib
+  root: ~/.skillclaw
   sessions: ~/.skillclaw/sessions
   evolved: ~/.skillclaw/skills
+  rejected: ~/.skillclaw/skills/rejected
+  state: ~/.skillclaw/.ingest-state.json
 
-# Which CLI agents get fail-open wrapper functions. Only agents whose SDK honors a
-# base-URL override that SkillClaw can serve. claude + codex are verified-supported;
-# gemini/cursor-agent are commented out pending base-URL-support verification (Task 12).
-capture:
-  agents:
-    # gemini / cursor-agent: add an entry here only after verifying the CLI honors
-    # a base-URL override SkillClaw can serve, e.g.:
-    #   {name: gemini, env: OPENAI_BASE_URL, path: /v1}
-    - name: claude
-      env: ANTHROPIC_BASE_URL
-      path: ""
-    - name: codex
-      env: OPENAI_BASE_URL
-      path: /v1
+ingest:
+  transcripts_dir: ~/.claude/projects
+  window_days: 30              # all projects, recent window
+  settle_minutes: 5           # skip files whose mtime is newer (still being written)
+  max_tool_output_chars: 500  # truncate raw tool stdout/stderr beyond this; drop base64
+  # allowlist: []             # optional future: restrict to project paths
 
 evolve:
-  mode: workflow              # fixed pipeline (deterministic); not "agent" mode
-  provider:
-    # Local-first: zero API cost, no rate limits. Falls back to cloud if unreachable.
-    primary:
-      kind: local
-      base_url: http://127.0.0.1:11434/v1   # Ollama OpenAI-compatible endpoint
-      model: qwen2.5-coder
-    fallback:
-      kind: cloud
-      provider: anthropic
-      model: claude-haiku-4-5-20251001
+  engine: claude-cli          # `claude -p` headless, Max-backed
+  token_budget: 100000        # map-reduce chunk threshold; stays clear of 200k limit
+  prompt_template: ~/.claude/prompts/skillclaw_evolve.md
 
 promotion:
   branch_prefix: skillclaw/evolve-

--- a/configs/claude/prompts/skillclaw_evolve.md
+++ b/configs/claude/prompts/skillclaw_evolve.md
@@ -1,0 +1,34 @@
+<!-- configs/claude/prompts/skillclaw_evolve.md -->
+# SkillClaw Distillation Prompt
+
+You are distilling reusable Claude Code **skills** from real agent sessions.
+
+A skill is a `SKILL.md` file with YAML frontmatter (`name`, `description`) and a
+markdown body describing a repeatable procedure the agent should follow.
+
+## Existing skill library (do NOT duplicate these names unless improving them)
+
+{{LIBRARY}}
+
+## Sessions (scrubbed, noise-truncated)
+
+{{SESSIONS}}
+
+## Your task
+
+Identify recurring, generalizable workflows in these sessions that are NOT already
+well covered by the existing library. For each, emit one skill.
+
+Output ONLY a sequence of skill blocks in this exact fenced format, nothing else:
+
+~~~skill name=<kebab-case-name>
+---
+name: <kebab-case-name>
+description: <one line: when to use this skill>
+---
+# <Title>
+
+<body: numbered, concrete steps>
+~~~
+
+If nothing rises to a reusable skill, output the single line: NO_SKILLS

--- a/configs/claude/scripts/skillclaw_evolve.py
+++ b/configs/claude/scripts/skillclaw_evolve.py
@@ -83,3 +83,74 @@ def chunk_sessions(sessions: list[dict], token_budget: int) -> list[list[dict]]:
     if current:
         chunks.append(current)
     return chunks
+
+
+def subprocess_runner(prompt: str) -> str:
+    """Default runner: invoke headless `claude -p` (Max-backed)."""
+    proc = subprocess.run(["claude", "-p", prompt], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"claude -p failed: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def write_candidates(candidates: list[dict], evolved_dir: Path) -> list[str]:
+    evolved_dir = Path(evolved_dir).expanduser()
+    written = []
+    for c in candidates:
+        d = evolved_dir / c["name"]
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "SKILL.md").write_text(c["content"], encoding="utf-8")
+        written.append(c["name"])
+    return written
+
+
+def _committed_library_names(evolved_dir: Path) -> list[str]:
+    base = Path(evolved_dir).expanduser()
+    return sorted(p.parent.name for p in base.glob("*/SKILL.md")) if base.exists() else []
+
+
+def evolve(sessions_dir, evolved_dir, template_path, *,
+           token_budget=DEFAULT_TOKEN_BUDGET, runner=subprocess_runner) -> dict:
+    """Map-reduce sessions into SKILL.md candidates. Returns a summary dict."""
+    sessions = load_sessions(sessions_dir)
+    template = Path(template_path).expanduser().read_text(encoding="utf-8")
+    library = _committed_library_names(evolved_dir)
+    if not sessions:
+        return {"candidates": 0, "chunks": 0, "written": []}
+
+    chunks = chunk_sessions(sessions, token_budget)
+    mapped: list[dict] = []
+    for chunk in chunks:
+        out = runner(build_prompt(template, chunk, library))
+        mapped.extend(parse_candidates(out))
+
+    # reduce: dedupe by name (last write wins); a single chunk skips a 2nd call
+    if len(chunks) > 1 and mapped:
+        deduped = {}
+        for c in mapped:
+            deduped[c["name"]] = c
+        mapped = list(deduped.values())
+
+    written = write_candidates(mapped, evolved_dir)
+    return {"candidates": len(written), "chunks": len(chunks), "written": written}
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("sessions_dir")
+    ap.add_argument("evolved_dir")
+    ap.add_argument("--template", default="~/.claude/prompts/skillclaw_evolve.md")
+    ap.add_argument("--token-budget", type=int, default=DEFAULT_TOKEN_BUDGET)
+    args = ap.parse_args(argv)
+    try:
+        summary = evolve(args.sessions_dir, args.evolved_dir, args.template,
+                         token_budget=args.token_budget)
+    except (RuntimeError, FileNotFoundError) as e:
+        print(f"skillclaw_evolve: {e}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/configs/claude/scripts/skillclaw_evolve.py
+++ b/configs/claude/scripts/skillclaw_evolve.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Distill SKILL.md candidates from ingested sessions via `claude -p` (Max-backed).
+
+Replaces the retired `skillclaw evolve` binary. Map-reduces sessions through the
+headless Claude CLI: chunks that exceed the token budget are distilled
+independently (map), then merged (reduce). No proxy, no API key.
+
+Usage:
+    skillclaw_evolve.py <sessions_dir> <evolved_dir> [--template FILE]
+        [--token-budget N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_TOKEN_BUDGET = 100_000
+_SKILL_RE = re.compile(r"~~~skill name=(?P<name>[^\n]+)\n(?P<body>.*?)~~~", re.DOTALL)
+
+
+def estimate_tokens(text: str) -> int:
+    """Cheap heuristic: ~4 chars per token."""
+    return len(text) // 4
+
+
+def _render_session(s: dict) -> str:
+    lines = [f"### session {s.get('session_id', '?')}"]
+    for turn in s.get("turns", []):
+        for b in turn["blocks"]:
+            if b["kind"] in ("text", "thinking"):
+                lines.append(f"[{turn['role']}/{b['kind']}] {b['text']}")
+            elif b["kind"] == "tool_use":
+                lines.append(f"[tool_use {b['name']}] {json.dumps(b['input'])}")
+            elif b["kind"] == "tool_result":
+                lines.append(f"[tool_result err={b['is_error']}] {b['output']}")
+    return "\n".join(lines)
+
+
+def load_sessions(sessions_dir) -> list[dict]:
+    sessions_dir = Path(sessions_dir).expanduser()
+    out = []
+    for f in sorted(sessions_dir.glob("*.json")):
+        try:
+            out.append(json.loads(f.read_text(encoding="utf-8")))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def build_prompt(template: str, sessions: list[dict], library_names: list[str]) -> str:
+    library = "\n".join(f"- {n}" for n in library_names) or "(empty)"
+    rendered = "\n\n".join(_render_session(s) for s in sessions) or "(none)"
+    return template.replace("{{LIBRARY}}", library).replace("{{SESSIONS}}", rendered)
+
+
+def parse_candidates(output: str) -> list[dict]:
+    return [{"name": m.group("name").strip(), "content": m.group("body")}
+            for m in _SKILL_RE.finditer(output)]

--- a/configs/claude/scripts/skillclaw_evolve.py
+++ b/configs/claude/scripts/skillclaw_evolve.py
@@ -60,3 +60,26 @@ def build_prompt(template: str, sessions: list[dict], library_names: list[str]) 
 def parse_candidates(output: str) -> list[dict]:
     return [{"name": m.group("name").strip(), "content": m.group("body")}
             for m in _SKILL_RE.finditer(output)]
+
+
+def chunk_sessions(sessions: list[dict], token_budget: int) -> list[list[dict]]:
+    """Greedily pack sessions into chunks whose rendered size stays under budget.
+
+    A single session larger than the budget gets its own chunk (it cannot be
+    split further here; the renderer already truncated tool noise upstream).
+    """
+    if not sessions:
+        return []
+    chunks: list[list[dict]] = []
+    current: list[dict] = []
+    current_tokens = 0
+    for s in sessions:
+        cost = estimate_tokens(_render_session(s))
+        if current and current_tokens + cost > token_budget:
+            chunks.append(current)
+            current, current_tokens = [], 0
+        current.append(s)
+        current_tokens += cost
+    if current:
+        chunks.append(current)
+    return chunks

--- a/configs/claude/scripts/skillclaw_evolve.py
+++ b/configs/claude/scripts/skillclaw_evolve.py
@@ -86,8 +86,14 @@ def chunk_sessions(sessions: list[dict], token_budget: int) -> list[list[dict]]:
 
 
 def subprocess_runner(prompt: str) -> str:
-    """Default runner: invoke headless `claude -p` (Max-backed)."""
-    proc = subprocess.run(["claude", "-p", prompt], capture_output=True, text=True)
+    """Default runner: invoke headless `claude -p` (Max-backed).
+
+    The prompt is fed via stdin, not as an argv argument, so large transcript
+    windows (a chunk can approach token_budget * 4 chars) never hit the OS
+    ARG_MAX "Argument list too long" limit (1 MB on macOS). `claude -p` reads the
+    prompt from stdin when no positional prompt is given.
+    """
+    proc = subprocess.run(["claude", "-p"], input=prompt, capture_output=True, text=True)
     if proc.returncode != 0:
         raise RuntimeError(f"claude -p failed: {proc.stderr.strip()}")
     return proc.stdout

--- a/configs/claude/scripts/skillclaw_evolve.py
+++ b/configs/claude/scripts/skillclaw_evolve.py
@@ -104,17 +104,23 @@ def write_candidates(candidates: list[dict], evolved_dir: Path) -> list[str]:
     return written
 
 
-def _committed_library_names(evolved_dir: Path) -> list[str]:
-    base = Path(evolved_dir).expanduser()
+def _library_names(skills_dir: Path) -> list[str]:
+    """Skill directory names under a skills root (each holding a SKILL.md)."""
+    base = Path(skills_dir).expanduser()
     return sorted(p.parent.name for p in base.glob("*/SKILL.md")) if base.exists() else []
 
 
 def evolve(sessions_dir, evolved_dir, template_path, *,
-           token_budget=DEFAULT_TOKEN_BUDGET, runner=subprocess_runner) -> dict:
-    """Map-reduce sessions into SKILL.md candidates. Returns a summary dict."""
+           committed_dir=None, token_budget=DEFAULT_TOKEN_BUDGET, runner=subprocess_runner) -> dict:
+    """Map-reduce sessions into SKILL.md candidates. Returns a summary dict.
+
+    The prompt's "existing library" is the committed library (committed_dir) so
+    the model does not re-propose already-merged skills; it falls back to
+    evolved_dir only when no committed library is supplied.
+    """
     sessions = load_sessions(sessions_dir)
     template = Path(template_path).expanduser().read_text(encoding="utf-8")
-    library = _committed_library_names(evolved_dir)
+    library = _library_names(committed_dir if committed_dir is not None else evolved_dir)
     if not sessions:
         return {"candidates": 0, "chunks": 0, "written": []}
 
@@ -140,11 +146,13 @@ def main(argv: list[str]) -> int:
     ap.add_argument("sessions_dir")
     ap.add_argument("evolved_dir")
     ap.add_argument("--template", default="~/.claude/prompts/skillclaw_evolve.md")
+    ap.add_argument("--committed-dir",
+                    help="committed skill library shown to the model (avoids re-proposals)")
     ap.add_argument("--token-budget", type=int, default=DEFAULT_TOKEN_BUDGET)
     args = ap.parse_args(argv)
     try:
         summary = evolve(args.sessions_dir, args.evolved_dir, args.template,
-                         token_budget=args.token_budget)
+                         committed_dir=args.committed_dir, token_budget=args.token_budget)
     except (RuntimeError, FileNotFoundError) as e:
         print(f"skillclaw_evolve: {e}", file=sys.stderr)
         return 1

--- a/configs/claude/scripts/skillclaw_ingest.py
+++ b/configs/claude/scripts/skillclaw_ingest.py
@@ -110,3 +110,72 @@ def within_window(mtime: float, now: float, window_days: int) -> bool:
 def is_settled(mtime: float, now: float, settle_minutes: int) -> bool:
     """True if the file has been idle long enough to be safely read."""
     return (now - mtime) >= settle_minutes * 60
+
+
+def load_state(state_path: Path) -> dict:
+    try:
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_state(state_path: Path, state: dict) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
+def ingest(transcripts_dir, out_dir, state_path, *, window_days, settle_minutes,
+           max_tool_output_chars, now=None) -> dict:
+    """Ingest new, settled, in-window transcripts into out_dir. Returns counts."""
+    now = time.time() if now is None else now
+    transcripts_dir = Path(transcripts_dir).expanduser()
+    out_dir = Path(out_dir).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    state_path = Path(state_path).expanduser()
+    state = load_state(state_path)
+
+    summary = {"ingested": 0, "skipped_old": 0, "skipped_unsettled": 0,
+               "skipped_seen": 0, "skipped_empty": 0}
+    for f in sorted(transcripts_dir.rglob("*.jsonl")):
+        mtime = f.stat().st_mtime
+        if not within_window(mtime, now, window_days):
+            summary["skipped_old"] += 1
+            continue
+        if not is_settled(mtime, now, settle_minutes):
+            summary["skipped_unsettled"] += 1
+            continue
+        key = str(f)
+        if state.get(key) == mtime:
+            summary["skipped_seen"] += 1
+            continue
+        rec = parse_transcript(f, max_tool_output_chars)
+        if rec is None:
+            summary["skipped_empty"] += 1
+            state[key] = mtime
+            continue
+        (out_dir / f"{rec['session_id']}.json").write_text(
+            json.dumps(rec, indent=2), encoding="utf-8")
+        state[key] = mtime
+        summary["ingested"] += 1
+    save_state(state_path, state)
+    return summary
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("transcripts_dir")
+    ap.add_argument("out_dir")
+    ap.add_argument("--state", default="~/.skillclaw/.ingest-state.json")
+    ap.add_argument("--window-days", type=int, default=30)
+    ap.add_argument("--settle-minutes", type=int, default=5)
+    ap.add_argument("--max-tool-output-chars", type=int, default=DEFAULT_MAX_TOOL_OUTPUT)
+    args = ap.parse_args(argv)
+    summary = ingest(args.transcripts_dir, args.out_dir, args.state,
+                     window_days=args.window_days, settle_minutes=args.settle_minutes,
+                     max_tool_output_chars=args.max_tool_output_chars)
+    print(json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/configs/claude/scripts/skillclaw_ingest.py
+++ b/configs/claude/scripts/skillclaw_ingest.py
@@ -52,7 +52,7 @@ def normalize_content(content, max_tool_output_chars: int = DEFAULT_MAX_TOOL_OUT
         elif bt == "tool_result":
             raw = block.get("content", "")
             if not isinstance(raw, str):
-                raw = json.dumps(raw)[:max_tool_output_chars]
+                raw = json.dumps(raw)
             text, truncated = _truncate(raw, max_tool_output_chars)
             out.append({"kind": "tool_result", "output": text,
                         "is_error": bool(block.get("is_error", False)),

--- a/configs/claude/scripts/skillclaw_ingest.py
+++ b/configs/claude/scripts/skillclaw_ingest.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Ingest Claude Code transcripts into scrubbed, noise-stripped session JSON.
+
+Passive replacement for the retired SkillClaw capture proxy. Reads
+~/.claude/projects/**/*.jsonl, normalizes conversation turns, truncates noisy
+tool payloads, filters by recency, skips still-being-written files, and tracks
+processed sessions incrementally.
+
+Usage:
+    skillclaw_ingest.py <transcripts_dir> <out_dir> [--state FILE]
+        [--window-days N] [--settle-minutes N] [--max-tool-output-chars N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_MAX_TOOL_OUTPUT = 500
+
+
+def _truncate(text: str, limit: int) -> tuple[str, bool]:
+    if len(text) <= limit:
+        return text, False
+    return text[:limit] + f"…[+{len(text) - limit} chars truncated]", True
+
+
+def normalize_content(content, max_tool_output_chars: int = DEFAULT_MAX_TOOL_OUTPUT) -> list[dict]:
+    """Normalize a message.content (str or block list) into kept blocks."""
+    if isinstance(content, str):
+        return [{"kind": "text", "text": content}] if content.strip() else []
+    if not isinstance(content, list):
+        return []
+    out: list[dict] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        bt = block.get("type")
+        if bt == "text":
+            txt = block.get("text", "")
+            if txt.strip():
+                out.append({"kind": "text", "text": txt})
+        elif bt == "thinking":
+            txt = block.get("thinking", "")
+            if txt.strip():
+                out.append({"kind": "thinking", "text": txt})
+        elif bt == "tool_use":
+            out.append({"kind": "tool_use", "name": block.get("name", "?"),
+                        "input": block.get("input", {})})
+        elif bt == "tool_result":
+            raw = block.get("content", "")
+            if not isinstance(raw, str):
+                raw = json.dumps(raw)[:max_tool_output_chars]
+            text, truncated = _truncate(raw, max_tool_output_chars)
+            out.append({"kind": "tool_result", "output": text,
+                        "is_error": bool(block.get("is_error", False)),
+                        "truncated": truncated})
+    return out

--- a/configs/claude/scripts/skillclaw_ingest.py
+++ b/configs/claude/scripts/skillclaw_ingest.py
@@ -68,3 +68,35 @@ def normalize_content(content, max_tool_output_chars: int = DEFAULT_MAX_TOOL_OUT
                         "is_error": bool(block.get("is_error", False)),
                         "truncated": truncated})
     return out
+
+
+def parse_transcript(path: Path, max_tool_output_chars: int = DEFAULT_MAX_TOOL_OUTPUT) -> dict | None:
+    """Parse one transcript .jsonl into a session record, or None if no turns.
+
+    Defensive: skips unparseable lines (including a truncated trailing line from
+    a still-active session) rather than raising.
+    """
+    session_id = path.stem
+    cwd = git_branch = None
+    turns: list[dict] = []
+    with path.open(encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # partial/corrupt line — skip
+            if obj.get("type") not in ("user", "assistant"):
+                continue
+            session_id = obj.get("sessionId", session_id)
+            cwd = obj.get("cwd", cwd)
+            git_branch = obj.get("gitBranch", git_branch)
+            msg = obj.get("message", {})
+            blocks = normalize_content(msg.get("content"), max_tool_output_chars)
+            if blocks:
+                turns.append({"role": msg.get("role", "?"), "blocks": blocks})
+    if not turns:
+        return None
+    return {"session_id": session_id, "cwd": cwd, "git_branch": git_branch, "turns": turns}

--- a/configs/claude/scripts/skillclaw_ingest.py
+++ b/configs/claude/scripts/skillclaw_ingest.py
@@ -100,3 +100,13 @@ def parse_transcript(path: Path, max_tool_output_chars: int = DEFAULT_MAX_TOOL_O
     if not turns:
         return None
     return {"session_id": session_id, "cwd": cwd, "git_branch": git_branch, "turns": turns}
+
+
+def within_window(mtime: float, now: float, window_days: int) -> bool:
+    """True if mtime falls within the last window_days from now."""
+    return (now - mtime) <= window_days * 86400
+
+
+def is_settled(mtime: float, now: float, settle_minutes: int) -> bool:
+    """True if the file has been idle long enough to be safely read."""
+    return (now - mtime) >= settle_minutes * 60

--- a/configs/claude/scripts/skillclaw_ingest.py
+++ b/configs/claude/scripts/skillclaw_ingest.py
@@ -47,8 +47,18 @@ def normalize_content(content, max_tool_output_chars: int = DEFAULT_MAX_TOOL_OUT
             if txt.strip():
                 out.append({"kind": "thinking", "text": txt})
         elif bt == "tool_use":
+            raw_input = block.get("input", {})
+            trimmed = {}
+            if isinstance(raw_input, dict):
+                for k, v in raw_input.items():
+                    if isinstance(v, str):
+                        trimmed[k] = _truncate(v, max_tool_output_chars)[0]
+                    else:
+                        trimmed[k] = v
+            else:
+                trimmed = raw_input
             out.append({"kind": "tool_use", "name": block.get("name", "?"),
-                        "input": block.get("input", {})})
+                        "input": trimmed})
         elif bt == "tool_result":
             raw = block.get("content", "")
             if not isinstance(raw, str):

--- a/configs/claude/scripts/skillclaw_promote.py
+++ b/configs/claude/scripts/skillclaw_promote.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -71,6 +72,7 @@ def main(argv: list[str]) -> int:
     ap.add_argument("evolved_dir")
     ap.add_argument("committed_dir")
     ap.add_argument("--skill", help="restrict to a single skill name")
+    ap.add_argument("--rejected-dir", help="copy invalid candidates here for inspection")
     args = ap.parse_args(argv)
 
     evolved = Path(args.evolved_dir).expanduser()
@@ -91,6 +93,13 @@ def main(argv: list[str]) -> int:
             promote.append(c)
         else:
             dropped.append({**c, "reason": reason})
+
+    if args.rejected_dir:
+        rej = Path(args.rejected_dir).expanduser()
+        for d in dropped:
+            dest = rej / d["name"]
+            dest.mkdir(parents=True, exist_ok=True)
+            shutil.copy(d["path"], dest / "SKILL.md")
 
     json.dump({"promote": promote, "dropped": dropped}, sys.stdout, indent=2)
     print()

--- a/configs/claude/scripts/skillclaw_promote.sh
+++ b/configs/claude/scripts/skillclaw_promote.sh
@@ -20,6 +20,12 @@ CFG="${SKILLCLAW_CONFIG:-${SCRIPT_DIR}/../config/skillclaw.yml}"
 
 EVOLVED="${SKILLCLAW_EVOLVED:-$HOME/.skillclaw/skills}"
 SESSIONS="${SKILLCLAW_SESSIONS:-$HOME/.skillclaw/sessions}"
+INGEST="${SCRIPT_DIR}/skillclaw_ingest.py"
+EVOLVE="${SCRIPT_DIR}/skillclaw_evolve.py"
+TEMPLATE="${SKILLCLAW_TEMPLATE:-${SCRIPT_DIR}/../prompts/skillclaw_evolve.md}"
+TRANSCRIPTS="${SKILLCLAW_TRANSCRIPTS:-$HOME/.claude/projects}"
+STATE="${SKILLCLAW_STATE:-$HOME/.skillclaw/.ingest-state.json}"
+REJECTED="${SKILLCLAW_REJECTED:-$HOME/.skillclaw/skills/rejected}"
 # Committed library: the physical skillshare source of truth. The deployed script
 # lives in ~/.claude/scripts, so locate the repo via MANIFEST_ROOT (exported by
 # bootstrap into the shell profile); fall back to repo-relative when run in-tree.
@@ -60,20 +66,25 @@ if [[ "$APPLY" == true && "$FORCE_NEW" == false ]]; then
     fi
 fi
 
-# 1. Scrub captured sessions (best-effort; never blocks).
+# 1. Ingest transcripts → sessions (passive; no proxy).
+if [[ "$DO_EVOLVE" == true ]]; then
+    python3 "$INGEST" "$TRANSCRIPTS" "$SESSIONS" --state "$STATE" >/dev/null 2>&1 \
+        || err "ingest returned non-zero (continuing)"
+fi
+
+# 2. Scrub captured sessions (best-effort; never blocks).
 if [[ -d "$SESSIONS" ]]; then
     python3 "${SCRIPT_DIR}/skillclaw_scrub.py" "$SESSIONS" >/dev/null 2>&1 || true
 fi
 
-# 2. Evolve (skip with --no-evolve; e.g. tests / re-run on existing library).
+# 3. Evolve (skip with --no-evolve).
 if [[ "$DO_EVOLVE" == true ]]; then
-    if command -v skillclaw >/dev/null 2>&1; then
-        skillclaw evolve --mode workflow >/dev/null 2>&1 || err "evolve returned non-zero (continuing)"
-    fi
+    python3 "$EVOLVE" "$SESSIONS" "$EVOLVED" --template "$TEMPLATE" \
+        || err "evolve returned non-zero (continuing)"
 fi
 
-# 3. Classify + validate.
-classify_args=("$EVOLVED" "$COMMITTED")
+# 4. Classify + validate.
+classify_args=("$EVOLVED" "$COMMITTED" --rejected-dir "$REJECTED")
 [[ -n "$SKILL" ]] && classify_args+=(--skill "$SKILL")
 classify_json="$(python3 "${SCRIPT_DIR}/skillclaw_promote.py" "${classify_args[@]}")"
 
@@ -89,6 +100,11 @@ for c in d["dropped"]:
     name=c["name"]; reason=c["reason"]
     print("  DROPPED   %s  (%s)" % (name, reason))
 '
+
+dropped_count="$(echo "$classify_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["dropped"]))')"
+if [[ "$dropped_count" -gt 0 ]]; then
+    err "Generated candidate(s), but ${dropped_count} failed schema validation. See ${REJECTED}"
+fi
 
 promote_names="$(echo "$classify_json" | python3 -c 'import json,sys; print(" ".join(c["name"] for c in json.load(sys.stdin)["promote"]))')"
 

--- a/configs/claude/scripts/skillclaw_promote.sh
+++ b/configs/claude/scripts/skillclaw_promote.sh
@@ -81,7 +81,8 @@ fi
 # 3. Evolve (skip with --no-evolve). Suppress its stdout summary (kept clean like
 # ingest); errors still surface on stderr and are reported below.
 if [[ "$DO_EVOLVE" == true ]]; then
-    python3 "$EVOLVE" "$SESSIONS" "$EVOLVED" --template "$TEMPLATE" >/dev/null \
+    python3 "$EVOLVE" "$SESSIONS" "$EVOLVED" --template "$TEMPLATE" \
+        --committed-dir "$COMMITTED" >/dev/null \
         || err "evolve returned non-zero (continuing)"
 fi
 

--- a/configs/claude/scripts/skillclaw_promote.sh
+++ b/configs/claude/scripts/skillclaw_promote.sh
@@ -10,7 +10,8 @@
 # Usage: skillclaw_promote.sh [--apply] [--skill NAME] [--no-evolve] [--force-new]
 #
 # Env overrides (for tests): SKILLCLAW_EVOLVED, SKILLCLAW_COMMITTED,
-#   SKILLCLAW_SESSIONS, SKILLCLAW_GITOPS, SKILLCLAW_OPEN_PR.
+#   SKILLCLAW_SESSIONS, SKILLCLAW_GITOPS, SKILLCLAW_OPEN_PR, SKILLCLAW_TRANSCRIPTS,
+#   SKILLCLAW_STATE, SKILLCLAW_REJECTED, SKILLCLAW_TEMPLATE.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -77,36 +78,40 @@ if [[ -d "$SESSIONS" ]]; then
     python3 "${SCRIPT_DIR}/skillclaw_scrub.py" "$SESSIONS" >/dev/null 2>&1 || true
 fi
 
-# 3. Evolve (skip with --no-evolve).
+# 3. Evolve (skip with --no-evolve). Suppress its stdout summary (kept clean like
+# ingest); errors still surface on stderr and are reported below.
 if [[ "$DO_EVOLVE" == true ]]; then
-    python3 "$EVOLVE" "$SESSIONS" "$EVOLVED" --template "$TEMPLATE" \
+    python3 "$EVOLVE" "$SESSIONS" "$EVOLVED" --template "$TEMPLATE" >/dev/null \
         || err "evolve returned non-zero (continuing)"
 fi
 
-# 4. Classify + validate.
+# 4. Classify + validate. A crash here (empty/non-JSON output) must fail loudly,
+# not abort cryptically under `set -e`, so guard the capture explicitly.
 classify_args=("$EVOLVED" "$COMMITTED" --rejected-dir "$REJECTED")
 [[ -n "$SKILL" ]] && classify_args+=(--skill "$SKILL")
-classify_json="$(python3 "${SCRIPT_DIR}/skillclaw_promote.py" "${classify_args[@]}")"
+classify_json="$(python3 "${SCRIPT_DIR}/skillclaw_promote.py" "${classify_args[@]}")" \
+    || { err "classify failed (skillclaw_promote.py returned non-zero)"; exit 1; }
 
-# Print the human diff table.
+# Print the human diff table. The .get() defaults keep this resilient if the
+# JSON ever lacks a key rather than aborting the pipeline.
 echo "Evolved skill candidates:"
 echo "$classify_json" | python3 -c '
 import json,sys
 d=json.load(sys.stdin)
-for c in d["promote"]:
+for c in d.get("promote", []):
     status=c["status"]; name=c["name"]
     print("  %-9s %s" % (status, name))
-for c in d["dropped"]:
+for c in d.get("dropped", []):
     name=c["name"]; reason=c["reason"]
     print("  DROPPED   %s  (%s)" % (name, reason))
 '
 
-dropped_count="$(echo "$classify_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["dropped"]))')"
+dropped_count="$(echo "$classify_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("dropped", [])))')"
 if [[ "$dropped_count" -gt 0 ]]; then
     err "Generated candidate(s), but ${dropped_count} failed schema validation. See ${REJECTED}"
 fi
 
-promote_names="$(echo "$classify_json" | python3 -c 'import json,sys; print(" ".join(c["name"] for c in json.load(sys.stdin)["promote"]))')"
+promote_names="$(echo "$classify_json" | python3 -c 'import json,sys; print(" ".join(c["name"] for c in json.load(sys.stdin).get("promote", [])))')"
 
 if [[ -z "$promote_names" ]]; then
     echo "Nothing to promote."
@@ -119,7 +124,7 @@ if [[ "$APPLY" != true ]]; then
     exit 0
 fi
 
-# 4. Stage a branch with one commit per skill, then open a PR.
+# 5. Stage a branch with one commit per skill, then open a PR.
 count="$(echo "$promote_names" | wc -w | tr -d ' ')"
 if [[ ! -d "$COMMITTED" ]]; then
     err "committed skills dir not found: $COMMITTED"

--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -23,7 +23,7 @@
 12. [Service State Management](#service-state-management)
 13. [Issue Management Architecture](#issue-management-architecture)
 14. [Label Management Architecture](#label-management-architecture)
-15. [SkillClaw Capture & Evolve Pipeline](#skillclaw-capture--evolve-pipeline)
+15. [SkillClaw Passive Ingest & Evolve Pipeline](#skillclaw-passive-ingest--evolve-pipeline)
 
 ---
 
@@ -76,12 +76,12 @@ flowchart TB
     end
 
     subgraph "SkillClaw Subsystem"
-        SKILLCLAW_PROXY["SkillClaw Proxy\n(capture daemon :8765)"]:::process
+        SKILLCLAW_INGEST["skillclaw_ingest.py\n(normalize + window/settle\n+ incremental state)"]:::process
         SKILLCLAW_SCRUB["skillclaw_scrub.py\n(secret redaction)"]:::process
-        SKILLCLAW_EVOLVE["skillclaw evolve\n(workflow mode)"]:::process
-        SKILLCLAW_PROMOTE["skillclaw_promote.sh\n(classify → PR)"]:::process
+        SKILLCLAW_EVOLVE["skillclaw_evolve.py\n(map-reduce via claude -p)"]:::process
+        SKILLCLAW_PROMOTE["skillclaw_promote.sh\n(classify → reject-dir → PR)"]:::process
         SKILLSHARE[".skillshare/skills/\n(committed library)"]:::config
-        SKILLCLAW_PROXY --> SKILLCLAW_SCRUB --> SKILLCLAW_EVOLVE --> SKILLCLAW_PROMOTE --> SKILLSHARE
+        SKILLCLAW_INGEST --> SKILLCLAW_SCRUB --> SKILLCLAW_EVOLVE --> SKILLCLAW_PROMOTE --> SKILLSHARE
     end
 
     USER --> BOOTSTRAP
@@ -100,8 +100,7 @@ flowchart TB
     SERVICES -.->|config| PARALLEL_PY
     COMMAND_CFG -.->|thresholds| PARALLEL_PY
     VALIDATION_CFG -.->|criteria| PARALLEL_PY
-    CLAUDE_CLI -.->|fail-open wrapper| SKILLCLAW_PROXY
-    CODEX -.->|fail-open wrapper| SKILLCLAW_PROXY
+    CLAUDE_CLI -.->|transcripts| SKILLCLAW_INGEST
 ```
 
 **Key Components**:
@@ -112,8 +111,9 @@ flowchart TB
   (logging, validation, synthesis, streaming, Codex agent, services.yml)
 - **Configuration Layer**: YAML files controlling behavior, validation rules, and Phase 3 features
 - **Agent Services**: External LLM and Git hosting CLIs
-- **SkillClaw Subsystem**: Capture proxy that intercepts CLI-agent traffic, scrubs secrets,
-  evolves captured patterns into skills, and opens a PR-gated review into `.skillshare/skills/`
+- **SkillClaw Subsystem**: Passive transcript ingestion pipeline — reads existing Claude Code
+  session `.jsonl` files, scrubs secrets, distills candidate skills via `claude -p` (Max-backed
+  map-reduce), and opens a PR-gated review into `.skillshare/skills/`; no daemon, no proxy
 
 ---
 
@@ -422,7 +422,7 @@ flowchart TD
     SKIP_CURSOR["Skip Cursor"]:::skip
 
     CHECK_SKILLCLAW{"SkillClaw<br/>Enabled?"}:::decision
-    INSTALL_SKILLCLAW["Install SkillClaw (pip)<br/>chmod 700 storage<br/>Write fail-open wrappers<br/>Install supervisor + start daemon"]:::process
+    INSTALL_SKILLCLAW["Enable SkillClaw<br/>chmod 700 storage<br/>(transcript evolution; no daemon)"]:::process
     SKIP_SKILLCLAW["Skip SkillClaw"]:::skip
 
     DEPLOY["Deploy Config Files<br/>(~/.claude, ~/.cursor, ~/.gemini)"]:::process
@@ -502,9 +502,9 @@ flowchart TD
 - **Platform-Specific Install**: Uses appropriate package manager (brew/apt/dnf/pacman)
 - **Dependency Checking**: Verifies jq is installed (required for git_ops.sh JSON normalization)
 - **Service Toggles**: Writes final enabled/disabled state to services.yml
-- **SkillClaw (disabled by default)**: When `--enable-skillclaw` is passed, installs the
-  capture proxy, sets `chmod 700` on `~/.skillclaw/`, injects fail-open shell wrappers, and
-  installs a platform supervisor (launchd on macOS, systemd on Linux) for auto-restart
+- **SkillClaw (disabled by default)**: When `--enable-skillclaw` is passed, sets `chmod 700`
+  on `~/.skillclaw/` and enables the passive transcript-ingestion pipeline; no proxy, no daemon,
+  no supervisor required
 
 ---
 
@@ -885,7 +885,7 @@ flowchart LR
         SERVICES["services.yml<br/>(Claude, Gemini, Cursor, Codex,<br/>GitHub CLI, GitLab CLI, SkillClaw)"]:::config
         COMMAND_CFG["command_config.yml<br/>(Thresholds, Tool Policies,<br/>Model Selection)"]:::config
         VALIDATION["validation_criteria.yml<br/>(Tier 1/2 Criteria,<br/>Command Overrides)"]:::config
-        SKILLCLAW_CFG["skillclaw.yml<br/>(proxy port/host, storage root,<br/>capture agents, evolve provider,<br/>promotion branch/labels)"]:::config
+        SKILLCLAW_CFG["skillclaw.yml<br/>(storage root, window_days,<br/>settle_minutes, token_budget,<br/>evolve provider, promotion branch/labels)"]:::config
     end
 
     PARSE_SERVICES["Parse Service Toggles<br/>(awk parser)"]:::process
@@ -955,9 +955,9 @@ services:
 - **Auto-Detection**: gh/glab default to `auto` (enable if installed)
 - **Nested Configuration**: git_cli section contains github/gitlab subsections
 - **Reconfigurable**: `bootstrap.sh --reconfigure` updates toggles without reinstall
-- **skillclaw.yml**: Controls proxy port (default 8765), `~/.skillclaw` storage layout,
-  which CLI agents get fail-open wrappers, evolve provider (local Ollama / cloud fallback),
-  and PR promotion settings (branch prefix, base branch, labels)
+- **skillclaw.yml**: Controls `~/.skillclaw` storage layout, ingest knobs (`window_days`,
+  `settle_minutes`, `max_tool_output_chars`), evolve knobs (`token_budget`, `claude -p`
+  Max-backed runner), and PR promotion settings (branch prefix, base branch, labels)
 
 ---
 
@@ -1225,10 +1225,11 @@ flowchart TB
 
 ---
 
-## SkillClaw Capture & Evolve Pipeline
+## SkillClaw Passive Ingest & Evolve Pipeline
 
-How CLI-agent traffic is intercepted by the SkillClaw proxy, scrubbed for secrets,
-evolved into candidate skills, and promoted to the committed library via a PR-gated review.
+How existing Claude Code session transcripts are passively read, scrubbed for secrets,
+distilled into candidate skills, and promoted to the committed library via a PR-gated review.
+No proxy, no socket, no daemon — works with Claude Max out of the box.
 
 ```mermaid
 %%{init: {'theme':'neutral'}}%%
@@ -1240,42 +1241,32 @@ flowchart LR
     classDef config fill:#f3e8ff,stroke:#9333ea,color:#581c87
     classDef output fill:#22c55e,stroke:#166534,color:#fff
 
-    subgraph "CLI Agent Layer"
-        CLAUDE_W["claude()\nfail-open wrapper"]:::process
-        CODEX_W["codex()\nfail-open wrapper"]:::process
-    end
+    TRANSCRIPTS["~/.claude/projects/**/*.jsonl\n(Claude Code session transcripts\nalready on disk)"]:::input
 
-    HEALTH_CHECK{"SkillClaw\ndaemon up?\n(0.3s probe)"}:::decision
-    DIRECT["Direct to Provider\n(bypass)"]:::input
-
-    PROXY["SkillClaw Proxy\n:8765 (127.0.0.1 only)"]:::process
-    SESSIONS["~/.skillclaw/sessions/\n(chmod 700)"]:::secure
+    INGEST["skillclaw_ingest.py\nnormalize turns\nstrip tool-output noise\nwindow=30d / settle=5m\nincremental state file"]:::process
 
     SCRUB["skillclaw_scrub.py\nRedact API keys,\nauth headers, tokens"]:::secure
 
-    EVOLVE["skillclaw evolve\n--mode workflow\n(local Ollama / cloud fallback)"]:::process
+    EVOLVE["skillclaw_evolve.py\nmap-reduce via claude -p\n(Max-backed)\nchunks ≤ 100 000 tokens"]:::process
+
     EVOLVED_LIB["~/.skillclaw/skills/\n(evolved candidates)"]:::process
 
-    PROMOTE["skillclaw_promote.sh\n--apply"]:::process
+    CLASSIFY["skillclaw_promote.py\nClassify NEW / CHANGED\nDrop invalid frontmatter\nCopy rejected → rejected/"]:::decision
 
-    CLASSIFY["skillclaw_promote.py\nClassify NEW / CHANGED\nDrop invalid frontmatter"]:::process
+    PROMOTE["skillclaw_promote.sh\nPR-gate: one open\nskillclaw/evolve-* PR\nat a time"]:::process
 
     GIT_BRANCH["git switch -c\nskillclaw/evolve-N-SHA"]:::process
     PR["git_ops.sh pr-create\n(needs-review + follow-up labels)"]:::process
 
     SKILLSHARE[".skillshare/skills/\n(committed library)"]:::output
 
-    CLAUDE_W --> HEALTH_CHECK
-    CODEX_W --> HEALTH_CHECK
-    HEALTH_CHECK -->|up| PROXY
-    HEALTH_CHECK -->|down| DIRECT
-
-    PROXY --> SESSIONS
-    SESSIONS --> SCRUB
+    TRANSCRIPTS --> INGEST
+    INGEST --> SCRUB
     SCRUB --> EVOLVE
     EVOLVE --> EVOLVED_LIB
     EVOLVED_LIB --> CLASSIFY
-    CLASSIFY --> PROMOTE
+    CLASSIFY -->|accepted| PROMOTE
+    CLASSIFY -->|rejected| EVOLVED_LIB
     PROMOTE --> GIT_BRANCH
     GIT_BRANCH --> PR
     PR --> SKILLSHARE
@@ -1285,16 +1276,13 @@ flowchart LR
 
 | Stage | Component | Description |
 |-------|-----------|-------------|
-| Capture | fail-open shell wrappers | Redirect `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` to `127.0.0.1:8765`; bypass if daemon is down |
-| Storage | `~/.skillclaw/sessions/` | Session files stored with `chmod 700`; secrets honeypot — Tier 1 |
+| Source | `~/.claude/projects/**/*.jsonl` | Claude Code writes session transcripts to disk automatically; SkillClaw reads them passively |
+| Ingest | `skillclaw_ingest.py` | Normalizes turns, strips tool-output noise (`max_tool_output_chars=500`), applies `window_days=30` + `settle_minutes=5` filters, tracks processed files via incremental state |
 | Scrub | `skillclaw_scrub.py` | Redacts `sk-ant-*`, `sk-proj-*`, bearer tokens, `x-api-key` headers before evolve/promote |
-| Evolve | `skillclaw evolve --mode workflow` | Deterministic pipeline mode; local Ollama (`qwen2.5-coder`) with `claude-haiku` cloud fallback |
-| Classify | `skillclaw_promote.py` | Compares evolved `~/.skillclaw/skills/` against committed library; emits NEW / CHANGED / UNCHANGED; drops skills with missing or malformed frontmatter |
-| Promote | `skillclaw_promote.sh --apply` | Idempotency check (one open `skillclaw/evolve-*` PR at a time); one commit per skill; opens review PR via `git_ops.sh` |
+| Evolve | `skillclaw_evolve.py` | Map-reduce via headless `claude -p` (Max-backed); greedily packs sessions into chunks under `token_budget=100 000`; reduce deduplicates by skill name |
+| Classify | `skillclaw_promote.py` | Compares evolved `~/.skillclaw/skills/` against committed library; emits NEW / CHANGED / UNCHANGED; drops skills with missing or malformed frontmatter; copies rejected candidates to `~/.skillclaw/skills/rejected/` |
+| Promote | `skillclaw_promote.sh` | Idempotency check (one open `skillclaw/evolve-*` PR at a time); one commit per skill; opens review PR via `git_ops.sh` |
 | Review | GitHub/GitLab PR | Human review gate; each skill is an independent commit — revert to drop; merge deploys via `bootstrap.sh` skill sync |
-
-**Fail-open guarantee**: if the SkillClaw daemon is unreachable at invocation time
-(health probe capped at 0.3 s), wrappers call the CLI directly — agents are never blocked.
 
 **Key new skills**:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -238,10 +238,10 @@ promotion:
 
 ### How It Works
 
-1. **Ingest** (`skillclaw_ingest.sh`) scans `~/.claude/projects/**/*.jsonl` for transcripts
+1. **Ingest** (`skillclaw_ingest.py`) scans `~/.claude/projects/**/*.jsonl` for transcripts
    within the `window_days` window, skipping files still being written (`settle_minutes`).
    Tool output is truncated to `max_tool_output_chars` characters to reduce noise.
-2. **Evolve** (`skillclaw_evolve.sh`) runs `claude -p` in map-reduce mode against each
+2. **Evolve** (`skillclaw_evolve.py`) runs `claude -p` in map-reduce mode against each
    ingested session, staying under the `token_budget` threshold to avoid the 200 k context
    limit. Candidates that pass quality checks are written to `evolved/`; rejected ones go to
    `rejected/` for inspection.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -31,7 +31,7 @@ All configuration files are located in `~/.claude/config/`:
 | `services.yml` | Agent enable/disable states | YAML |
 | `command_config.yml` | Tool policies, thresholds, model defaults | YAML |
 | `validation_criteria.yml` | Tier 1/2 security and quality rules | YAML |
-| `skillclaw.yml` | SkillClaw proxy, storage, capture, evolve, and promotion settings | YAML |
+| `skillclaw.yml` | SkillClaw storage, ingest, evolve, and promotion settings | YAML |
 
 ### File Locations
 
@@ -177,17 +177,20 @@ The script validates services on startup:
 **File**: `~/.claude/config/skillclaw.yml`
 **Repo source**: `configs/claude/config/skillclaw.yml`
 
-SkillClaw is an **opt-in** local proxy that captures agent interactions, evolves skills with a
-local LLM, and opens review PRs. It is **disabled by default** and does not affect any agent
-behavior unless explicitly enabled.
+SkillClaw is an **opt-in**, proxy-free skill evolution pipeline. It passively reads
+`~/.claude/projects/**/*.jsonl` transcripts (the same files Claude Code writes during
+normal sessions), evolves them into skill candidates using `claude -p` (Max-backed,
+no separate API key required), and opens review PRs. It is **disabled by default** and
+does not intercept any agent traffic — no daemon is started, no shell wrappers are
+installed, no `BASE_URL` environment variable is set.
 
 ### Enabling and Disabling
 
 ```bash
-# Enable SkillClaw (installs daemon + shell wrappers)
+# Enable SkillClaw (creates chmod-700 storage dirs; no daemon or wrappers)
 ./bootstrap.sh --enable-skillclaw
 
-# Disable SkillClaw (removes wrappers, stops daemon)
+# Disable SkillClaw
 ./bootstrap.sh --disable-skillclaw
 
 # Reconfigure alongside other toggles
@@ -198,38 +201,31 @@ When enabled, `services.yml` gains a `skillclaw:` stanza set to `enabled: true`.
 
 ### What skillclaw.yml Configures
 
-```yaml
-# Proxy — local HTTP interception layer
-proxy:
-  host: 127.0.0.1
-  port: 8765            # All capture traffic passes through this port
+`~/.claude/config/skillclaw.yml` is the **Manifest-owned** config. It is distinct from
+the vestigial upstream `~/.skillclaw/config.yaml` that older versions of the skillclaw
+tool may create.
 
+```yaml
 # Storage — session and evolved-skill data (chmod 700; secrets scrubbed before evolution)
 storage:
-  root: ~/.skillclaw    # Top-level store; created with mode 700
+  root: ~/.skillclaw
   sessions: ~/.skillclaw/sessions
-  evolved: ~/.skillclaw/evolved
+  evolved: ~/.skillclaw/skills
+  rejected: ~/.skillclaw/skills/rejected
+  state: ~/.skillclaw/.ingest-state.json
 
-# Capture — which agents are wired through the proxy
-# (gemini and cursor-agent are documented follow-ups; not yet wired)
-capture:
-  agents:
-    claude:
-      env: ANTHROPIC_BASE_URL   # Set to http://127.0.0.1:8765 when proxy is up
-    codex:
-      env: OPENAI_BASE_URL      # Set to http://127.0.0.1:8765/v1 when proxy is up
-      path: /v1
+# Ingest — how transcripts are read from ~/.claude/projects
+ingest:
+  transcripts_dir: ~/.claude/projects
+  window_days: 30              # only transcripts modified within the last 30 days
+  settle_minutes: 5            # skip files whose mtime is <5 min old (still being written)
+  max_tool_output_chars: 500   # truncate tool stdout/stderr; drop base64 blobs (noise control)
 
-# Evolution — how captured sessions are improved into new skill candidates
+# Evolve — how ingested sessions become skill candidates
 evolve:
-  mode: workflow
-  provider:
-    primary:
-      base_url: http://127.0.0.1:11434/v1   # Local Ollama (preferred; no cloud cost)
-      model: qwen2.5-coder
-    fallback:
-      provider: anthropic
-      model: claude-haiku-4-5-20251001      # Cloud fallback when Ollama is unavailable
+  engine: claude-cli            # `claude -p` headless, Max-backed; no separate API key
+  token_budget: 100000          # map-reduce chunk threshold; stays clear of 200k context limit
+  prompt_template: ~/.claude/prompts/skillclaw_evolve.md
 
 # Promotion — how evolved skills become PRs
 promotion:
@@ -240,23 +236,16 @@ promotion:
     - follow-up
 ```
 
-### Fail-Open Capture
+### How It Works
 
-Shell wrapper functions replace the `claude` and `codex` commands. Before routing a call
-through the proxy, the wrapper probes the daemon's health endpoint:
-
-```bash
-curl -sf --max-time 0.3 http://127.0.0.1:8765/health
-```
-
-If the probe fails (daemon down, slow to start, etc.) the wrapper falls back to the real CLI
-binary directly — **agents are never blocked by a dead daemon**.
-
-To bypass capture for a single shell session without disabling SkillClaw globally:
-
-```bash
-export SKILLCLAW_BYPASS=1
-```
+1. **Ingest** (`skillclaw_ingest.sh`) scans `~/.claude/projects/**/*.jsonl` for transcripts
+   within the `window_days` window, skipping files still being written (`settle_minutes`).
+   Tool output is truncated to `max_tool_output_chars` characters to reduce noise.
+2. **Evolve** (`skillclaw_evolve.sh`) runs `claude -p` in map-reduce mode against each
+   ingested session, staying under the `token_budget` threshold to avoid the 200 k context
+   limit. Candidates that pass quality checks are written to `evolved/`; rejected ones go to
+   `rejected/` for inspection.
+3. **Promote** (`skillclaw_promote.sh`, also `/skill-evolve`) opens one review PR per run.
 
 ### Promotion
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -219,7 +219,7 @@ ingest:
   transcripts_dir: ~/.claude/projects
   window_days: 30              # only transcripts modified within the last 30 days
   settle_minutes: 5            # skip files whose mtime is <5 min old (still being written)
-  max_tool_output_chars: 500   # truncate tool stdout/stderr; drop base64 blobs (noise control)
+  max_tool_output_chars: 500   # truncate tool stdout/stderr incl. base64 blobs (noise control)
 
 # Evolve — how ingested sessions become skill candidates
 evolve:

--- a/docs/README.md
+++ b/docs/README.md
@@ -163,7 +163,7 @@ services:
 
 - ✅ 2026-06-08: Documentation refresh for SkillClaw + `/pass-cli` — README, architecture
   diagrams, CONFIGURATION/TROUBLESHOOTING sections, and a Diataxis cross-link audit
-- ✅ 2026-06-07: Added SKILLCLAW.md — SkillClaw capture proxy and skill evolution guide
+- ✅ 2026-06-07: Added SKILLCLAW.md — SkillClaw passive-ingest transcript reader and skill evolution guide
 - ✅ 2026-06-07: Added `/skill-evolve` skill (promote SkillClaw sessions into review PRs)
 - ✅ 2026-06-07: Added `/pass-cli` skill (Proton Pass credential retrieval)
 - ✅ 2026-06-07: Updated ARCHITECTURE_DIAGRAMS.md with SkillClaw pipeline diagram

--- a/docs/SKILLCLAW.md
+++ b/docs/SKILLCLAW.md
@@ -36,8 +36,8 @@ Key ingest parameters (from `~/.claude/config/skillclaw.yml`):
 - **`window_days: 30`** — only transcripts from the last 30 days are considered.
 - **`settle_minutes: 5`** — files whose mtime is newer than 5 minutes are skipped
   to avoid reading sessions that are still being written.
-- **`max_tool_output_chars: 500`** — raw tool stdout/stderr is truncated and base64
-  blobs are dropped to control noise and token consumption.
+- **`max_tool_output_chars: 500`** — raw tool stdout/stderr (including base64
+  blobs) is truncated beyond this to control noise and token consumption.
 
 Incremental state is tracked in `~/.skillclaw/.ingest-state.json` so re-runs
 only process new content.

--- a/docs/SKILLCLAW.md
+++ b/docs/SKILLCLAW.md
@@ -1,57 +1,92 @@
 # SkillClaw Integration
 
-> PR-gated session capture that evolves reusable skills from your CLI-agent workflow
+> PR-gated skill evolution from Claude Code transcripts — no proxy, no daemon
 
 **Last Updated**: 2026-06-08
 **Audience**: Operators, developers
 **Prerequisites**: Manifest installed (`./bootstrap.sh`)
 
-SkillClaw captures CLI-agent sessions through a local proxy and evolves reusable
-`SKILL.md` skills. In Manifest it is a **PR-gated proposer**: nothing reaches the
+SkillClaw distills reusable `SKILL.md` skills from your Claude Code session transcripts
+and proposes them as pull requests. It is a **PR-gated proposer**: nothing reaches the
 committed `.skillshare/skills/` library without a merged PR.
+
+SkillClaw is a set of Manifest-owned scripts. `~/.skillclaw/` is solely managed by
+this repo. The legacy upstream `~/.skillclaw/config.yaml` and `dashboard.db` are
+vestigial (left in place, never read) and must not be confused with the
+Manifest-owned config at `~/.claude/config/skillclaw.yml`.
 
 ## Enable / disable
 
 ```bash
-./bootstrap.sh --enable-skillclaw     # install, configure, write wrappers, start daemon
-./bootstrap.sh --disable-skillclaw    # remove wrappers, stop daemon (full revert)
+./bootstrap.sh --enable-skillclaw    # create chmod-700 storage; remove any legacy proxy install
+./bootstrap.sh --disable-skillclaw   # storage left intact; nothing running
 ```
 
-## How capture works (fail-open)
+Enabling SkillClaw only sets up storage and tears down any legacy proxy install left
+by a prior version. There is no daemon, no socket, and no shell wrapper to install.
 
-Shell **wrapper functions** (`claude`, `codex`) check the daemon's health at
-invocation time (300ms cap). If it's up, the agent is routed through
-`http://127.0.0.1:8765`; if it's down or `SKILLCLAW_BYPASS=1` is set, the agent talks
-to its provider directly, unchanged. The daemon is never in the critical path.
+## How capture works (passive)
 
-Capture is **lossy by design**: a crash drops the in-flight session (a supervisor
-restarts the daemon). Evolution is statistical over many sessions, so loss is noise.
+SkillClaw reads Claude Code's own `~/.claude/projects/**/*.jsonl` transcripts directly.
+Nothing sits inline between you and the provider — capture is **purely passive** and
+works natively with a Claude Max subscription (no API key required).
 
-## Promote evolved skills
+Key ingest parameters (from `~/.claude/config/skillclaw.yml`):
+
+- **`window_days: 30`** — only transcripts from the last 30 days are considered.
+- **`settle_minutes: 5`** — files whose mtime is newer than 5 minutes are skipped
+  to avoid reading sessions that are still being written.
+- **`max_tool_output_chars: 500`** — raw tool stdout/stderr is truncated and base64
+  blobs are dropped to control noise and token consumption.
+
+Incremental state is tracked in `~/.skillclaw/.ingest-state.json` so re-runs
+only process new content.
+
+## Evolve engine
+
+Skill candidates are distilled using `claude -p` in headless mode, backed by your
+Claude Max subscription (no API key, no OpenAI dependency). A **map-reduce** approach
+chunks the session corpus under the `token_budget` threshold (default `100000`) to
+stay well clear of the 200 k context limit.
+
+## Promote flow
 
 ```bash
-~/.claude/scripts/skillclaw_promote.sh            # evolve + preview (dry-run)
-~/.claude/scripts/skillclaw_promote.sh --no-evolve  # preview existing library only
-~/.claude/scripts/skillclaw_promote.sh --apply    # open ONE review PR (commit per skill)
+~/.claude/scripts/skillclaw_promote.sh             # ingest → scrub → evolve → classify (dry-run)
+~/.claude/scripts/skillclaw_promote.sh --no-evolve # classify existing evolved library only (dry-run)
+~/.claude/scripts/skillclaw_promote.sh --apply     # open ONE review PR (one commit per skill)
 ```
 
-Only one open `skillclaw/evolve-*` PR at a time (Option A); `--force-new` overrides.
+Pipeline stages:
+
+1. **Ingest** — reads `~/.claude/projects/**/*.jsonl` into `~/.skillclaw/sessions/`.
+2. **Scrub** — `skillclaw_scrub.py` redacts secrets before any content is evolved.
+3. **Evolve** — `skillclaw_evolve.py` produces `SKILL.md` candidates in `~/.skillclaw/skills/`.
+4. **Classify** — validates candidates; rejected ones are copied to `~/.skillclaw/skills/rejected/`
+   with a warning printed to stderr (never silently dropped).
+5. **PR gate** — `--apply` stages one branch with one commit per skill and opens a
+   single `skillclaw/evolve-*` PR against `main`.
+
+**Option A** (one open PR at a time): if an open `skillclaw/evolve-*` PR already
+exists, `--apply` aborts with a message. Review or merge it first, or pass
+`--force-new` to override.
+
+`/skill-evolve` is the Claude Code skill entry point for this flow.
 
 ## Security
 
-- Storage `~/.skillclaw/` is `chmod 700`.
-- `skillclaw_scrub.py` redacts API keys / auth headers from captured sessions before
-  evolution.
+- Storage `~/.skillclaw/` and its subdirectories (`sessions/`, `skills/`) are
+  `chmod 700` — set at enable time and re-enforced on each `skillclaw_apply_state` call.
+- `skillclaw_scrub.py` redacts API keys and auth headers from ingested sessions
+  before any content is passed to the evolve engine.
 
 ## Follow-ups (not in V1)
 
-- **gemini / cursor-agent capture:** add wrappers only after verifying each CLI honors a
-  base-URL override SkillClaw can serve (Anthropic + OpenAI CLIs are verified; Gemini was
-  not in SkillClaw's documented compatible-agent list).
-- **TLS:** http-localhost works for the verified CLIs; add local TLS termination only if a
-  specific SDK rejects http.
-- **Evolve model defaults:** confirm the Ollama model + cloud fallback tier in `skillclaw.yml`.
-- **Shared team storage (S3/OSS)** and cross-device sync.
+- **Non-Claude CLI capture** — codex, gemini, and cursor do not persist transcripts
+  to a known location; hook-based capture would be needed for those CLIs.
+- **Scheduled evolution** — run `skillclaw_promote.sh` automatically via launchd or cron.
+- **Project allowlist** — restrict ingestion to specific project paths for tighter scoping.
+- **Tiered local engine** — optional Ollama-backed evolve stage as a cheaper first pass.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -289,64 +289,69 @@ cat ~/.claude/config/services.yml
 SkillClaw is opt-in and disabled by default. These issues only apply when
 `--enable-skillclaw` has been used.
 
-### Capture Not Working / Daemon Down
+### Evolve Produced No Candidates
 
-**Symptom:** Agent calls succeed but sessions do not appear in `~/.skillclaw/sessions/`.
+**Symptom:** `/skill-evolve` or `skillclaw_promote.sh` reports zero candidates.
 
-**Diagnosis:**
+**Diagnosis — check each step in order:**
+
+1. Confirm `claude -p` is reachable (requires a Claude Max subscription; no API key needed):
+
+   ```bash
+   echo "ping" | claude -p "Reply with pong"
+   ```
+
+2. Check whether ingest populated sessions:
+
+   ```bash
+   ls ~/.skillclaw/sessions/
+   ```
+
+   If empty, transcripts may not have been ingested yet. Run ingest manually and
+   verify that `~/.claude/projects/` contains `.jsonl` files:
+
+   ```bash
+   ls ~/.claude/projects/**/*.jsonl 2>/dev/null | head -5
+   ```
+
+3. Review `window_days` and `settle_minutes` in `~/.skillclaw/config.yml`. If
+   `settle_minutes` is larger than the age of your most recent session, that
+   session will be skipped until it has cooled down.
+
+**Fix:** Adjust the window/settle values, re-run ingest, then re-run evolve.
+
+---
+
+### Candidate Rejected During Promote
+
+**Symptom:** Promote logs a warning such as `WARN: candidate rejected — <reason>`.
+
+**Diagnosis:** Rejected candidates are preserved for inspection:
 
 ```bash
-curl -sf --max-time 0.3 http://127.0.0.1:8765/health && echo "daemon up" || echo "daemon down"
+ls ~/.skillclaw/skills/rejected/
 ```
 
-**What this means:** This is informational, not an outage. SkillClaw is **fail-open** — when
-the daemon is unreachable, `claude` and `codex` wrappers route directly to their providers.
-Agent work continues normally; sessions are simply not captured.
+Review the rejected skill file and the accompanying `*.reason` file (if present)
+to understand why it was filtered out (e.g. low confidence score, duplicate of an
+existing skill, scrub flagged a secret).
 
-**Fix:**
+**Fix:** Edit the candidate to address the rejection reason, then re-run:
 
 ```bash
-# Restart via your process supervisor, or re-enable through bootstrap
-./bootstrap.sh --enable-skillclaw
+~/.claude/scripts/skillclaw_promote.sh --apply
 ```
 
 ---
 
-### Temporarily Bypass Capture
+### Disable / Teardown SkillClaw
 
-To skip capture for one shell session without disabling SkillClaw globally:
-
-```bash
-export SKILLCLAW_BYPASS=1
-```
-
-To fully revert SkillClaw (removes wrappers and stops the daemon):
+To fully remove SkillClaw (strips any legacy shell-wrapper block and removes the
+retired launchd unit if present):
 
 ```bash
 ./bootstrap.sh --disable-skillclaw
 ```
-
----
-
-### Wrapper Functions Missing
-
-**Symptom:** `claude` or `codex` bypass the proxy even though SkillClaw is enabled.
-
-**Diagnosis:**
-
-```bash
-grep "MANIFEST SKILLCLAW WRAPPERS" ~/.zshrc
-```
-
-If that returns nothing, the wrappers were not injected.
-
-**Fix:**
-
-```bash
-./bootstrap.sh --enable-skillclaw
-```
-
-Then open a new shell (or `source ~/.zshrc`) for the wrappers to take effect.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-08-skillclaw-proxy-free-evolve.md
+++ b/docs/superpowers/plans/2026-06-08-skillclaw-proxy-free-evolve.md
@@ -1,0 +1,1341 @@
+# SkillClaw Proxy-Free Evolve Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace SkillClaw's Max-incompatible inline capture proxy with passive ingestion of Claude Code JSONL transcripts feeding the existing PR-gated evolve/promote pipeline, with `claude -p` (Max-backed) as the distillation engine.
+
+**Architecture:** Two new Python scripts (`skillclaw_ingest.py`, `skillclaw_evolve.py`) plus a prompt template replace the dead proxy+daemon. Ingest parses `~/.claude/projects/**/*.jsonl` into scrubbed, noise-stripped session JSON; evolve map-reduces those sessions through `claude -p` into `SKILL.md` candidates; the existing `skillclaw_promote.{py,sh}` classify→PR-gate machinery runs unchanged except for swapping the evolve call and surfacing rejected candidates. The proxy stack (daemon, launchd unit, shell wrappers) is removed from `bootstrap/lib/skillclaw.sh`.
+
+**Tech Stack:** Python 3 (stdlib only: `json`, `re`, `pathlib`, `argparse`, `subprocess`, `time`), Bash, pytest, bats, PyYAML (already a dependency).
+
+---
+
+## Reference: real transcript schema (verified against live data)
+
+Each line in `~/.claude/projects/<slug>/<sessionId>.jsonl` is one JSON object. Only `type: "user"` and `type: "assistant"` carry conversation; other types (`queue-operation`, `attachment`, `last-prompt`) are noise and ignored.
+
+```jsonc
+{"type":"user","sessionId":"...","timestamp":"...","cwd":"...","gitBranch":"...",
+ "message":{"role":"user","content": "<str>" OR [ <blocks> ]}}
+```
+
+`message.content` is either a string or a list of blocks:
+- `{"type":"text","text":"..."}` — assistant/user text (keep)
+- `{"type":"thinking","thinking":"...","signature":"..."}` — reasoning (keep `thinking` if non-empty; drop `signature`)
+- `{"type":"tool_use","id":"...","name":"Bash","input":{...}}` — keep `name` + `input` (truncate long string values)
+- `{"type":"tool_result","tool_use_id":"...","content":"...","is_error":false}` — **truncate `content`** (primary noise source)
+
+The filename stem is the `sessionId`. File `mtime` is used for window/settle decisions.
+
+---
+
+## File Structure
+
+**Create:**
+- `configs/claude/scripts/skillclaw_ingest.py` — transcript → normalized session JSON (stripping, window, settle, incremental state)
+- `configs/claude/scripts/skillclaw_evolve.py` — sessions → `SKILL.md` candidates via `claude -p` (map-reduce)
+- `configs/claude/prompts/skillclaw_evolve.md` — distillation prompt template
+- `tests/python/test_skillclaw_ingest.py`
+- `tests/python/test_skillclaw_evolve.py`
+
+**Modify:**
+- `configs/claude/scripts/skillclaw_promote.py` — copy rejected candidates to `rejected/`
+- `configs/claude/scripts/skillclaw_promote.sh` — call `skillclaw_evolve.py`; warn on rejected
+- `configs/claude/config/skillclaw.yml` — drop proxy/capture; add ingest/evolve knobs
+- `bootstrap/lib/skillclaw.sh` — remove proxy/daemon/wrappers/supervisor; redefine enable/disable
+- `tests/python/test_skillclaw_promote.py` — rejected-dir test
+- `tests/bats/skillclaw_promote.bats` — assert new evolve call + rejected warning
+- `tests/bats/skillclaw_lib.bats`, `tests/bats/skillclaw_config.bats` — drop proxy/daemon assertions
+- `docs/SKILLCLAW.md` — rewrite for proxy-free model + annexation
+
+**Module API contract** (names used consistently across tasks):
+
+```python
+# skillclaw_ingest.py
+normalize_content(content, max_tool_output_chars=500) -> list[dict]   # blocks
+parse_transcript(path, max_tool_output_chars=500) -> dict | None      # session record
+within_window(mtime, now, window_days) -> bool
+is_settled(mtime, now, settle_minutes) -> bool
+load_state(state_path) -> dict
+save_state(state_path, state) -> None
+ingest(transcripts_dir, out_dir, state_path, *, window_days, settle_minutes,
+       max_tool_output_chars, now) -> dict                            # summary counts
+main(argv) -> int
+
+# skillclaw_evolve.py
+estimate_tokens(text) -> int                                         # len//4 heuristic
+load_sessions(sessions_dir) -> list[dict]
+build_prompt(template, sessions, library_names) -> str
+chunk_sessions(sessions, token_budget) -> list[list[dict]]
+run_claude(prompt, *, runner=subprocess_runner) -> str               # injectable runner
+parse_candidates(model_output) -> list[dict]                         # [{name, content}]
+write_candidates(candidates, evolved_dir) -> list[str]
+evolve(sessions_dir, evolved_dir, template_path, *, token_budget, runner) -> dict
+main(argv) -> int
+```
+
+The injectable `runner` in `run_claude` is how tests avoid invoking the real `claude` CLI.
+
+---
+
+## Task 1: Ingest — normalize message content into blocks
+
+**Files:**
+- Create: `configs/claude/scripts/skillclaw_ingest.py`
+- Test: `tests/python/test_skillclaw_ingest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/python/test_skillclaw_ingest.py
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/claude/scripts"))
+import skillclaw_ingest as ing  # noqa: E402
+
+
+def test_normalize_string_content():
+    blocks = ing.normalize_content("hello world")
+    assert blocks == [{"kind": "text", "text": "hello world"}]
+
+
+def test_normalize_block_list_keeps_text_thinking_tooluse():
+    content = [
+        {"type": "text", "text": "I'll run it"},
+        {"type": "thinking", "thinking": "reasoning here", "signature": "SIG"},
+        {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+    ]
+    blocks = ing.normalize_content(content)
+    assert {"kind": "text", "text": "I'll run it"} in blocks
+    assert {"kind": "thinking", "text": "reasoning here"} in blocks
+    tu = [b for b in blocks if b["kind"] == "tool_use"][0]
+    assert tu["name"] == "Bash"
+    assert tu["input"] == {"command": "ls"}
+    # signature must never survive
+    assert all("signature" not in b for b in blocks)
+
+
+def test_normalize_drops_empty_thinking():
+    blocks = ing.normalize_content([{"type": "thinking", "thinking": "", "signature": "X"}])
+    assert blocks == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_ingest.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'skillclaw_ingest'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# configs/claude/scripts/skillclaw_ingest.py
+#!/usr/bin/env python3
+"""Ingest Claude Code transcripts into scrubbed, noise-stripped session JSON.
+
+Passive replacement for the retired SkillClaw capture proxy. Reads
+~/.claude/projects/**/*.jsonl, normalizes conversation turns, truncates noisy
+tool payloads, filters by recency, skips still-being-written files, and tracks
+processed sessions incrementally.
+
+Usage:
+    skillclaw_ingest.py <transcripts_dir> <out_dir> [--state FILE]
+        [--window-days N] [--settle-minutes N] [--max-tool-output-chars N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_MAX_TOOL_OUTPUT = 500
+
+
+def _truncate(text: str, limit: int) -> tuple[str, bool]:
+    if len(text) <= limit:
+        return text, False
+    return text[:limit] + f"…[+{len(text) - limit} chars truncated]", True
+
+
+def normalize_content(content, max_tool_output_chars: int = DEFAULT_MAX_TOOL_OUTPUT) -> list[dict]:
+    """Normalize a message.content (str or block list) into kept blocks."""
+    if isinstance(content, str):
+        return [{"kind": "text", "text": content}] if content.strip() else []
+    if not isinstance(content, list):
+        return []
+    out: list[dict] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        bt = block.get("type")
+        if bt == "text":
+            txt = block.get("text", "")
+            if txt.strip():
+                out.append({"kind": "text", "text": txt})
+        elif bt == "thinking":
+            txt = block.get("thinking", "")
+            if txt.strip():
+                out.append({"kind": "thinking", "text": txt})
+        elif bt == "tool_use":
+            out.append({"kind": "tool_use", "name": block.get("name", "?"),
+                        "input": block.get("input", {})})
+        elif bt == "tool_result":
+            raw = block.get("content", "")
+            if not isinstance(raw, str):
+                raw = json.dumps(raw)[:max_tool_output_chars]
+            text, truncated = _truncate(raw, max_tool_output_chars)
+            out.append({"kind": "tool_result", "output": text,
+                        "is_error": bool(block.get("is_error", False)),
+                        "truncated": truncated})
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_ingest.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_ingest.py tests/python/test_skillclaw_ingest.py
+git commit -m "feat(skillclaw): ingest normalize_content — block extraction + thinking-signature drop"
+```
+
+---
+
+## Task 2: Ingest — truncate noisy tool payloads (stdout, base64, large tool_use input)
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_ingest.py`
+- Test: `tests/python/test_skillclaw_ingest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_tool_result_output_is_truncated():
+    big = "x" * 5000
+    blocks = ing.normalize_content(
+        [{"type": "tool_result", "content": big, "is_error": False}],
+        max_tool_output_chars=500,
+    )
+    tr = blocks[0]
+    assert tr["kind"] == "tool_result"
+    assert tr["truncated"] is True
+    assert len(tr["output"]) < 600           # 500 + marker, not 5000
+    assert "truncated" in tr["output"]
+
+
+def test_long_tool_use_input_values_are_truncated():
+    blocks = ing.normalize_content(
+        [{"type": "tool_use", "name": "Write",
+          "input": {"file_path": "/a.txt", "content": "y" * 5000}}],
+        max_tool_output_chars=500,
+    )
+    tu = blocks[0]
+    assert tu["name"] == "Write"
+    assert len(tu["input"]["content"]) < 600
+    assert tu["input"]["file_path"] == "/a.txt"   # short values untouched
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_ingest.py::test_long_tool_use_input_values_are_truncated -v`
+Expected: FAIL — `tool_use.input.content` is the full 5000-char string.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the `tool_use` branch in `normalize_content` with one that truncates long string values:
+
+```python
+        elif bt == "tool_use":
+            raw_input = block.get("input", {})
+            trimmed = {}
+            if isinstance(raw_input, dict):
+                for k, v in raw_input.items():
+                    if isinstance(v, str):
+                        trimmed[k] = _truncate(v, max_tool_output_chars)[0]
+                    else:
+                        trimmed[k] = v
+            else:
+                trimmed = raw_input
+            out.append({"kind": "tool_use", "name": block.get("name", "?"),
+                        "input": trimmed})
+```
+
+(The `tool_result` truncation from Task 1 already satisfies `test_tool_result_output_is_truncated`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_ingest.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_ingest.py tests/python/test_skillclaw_ingest.py
+git commit -m "feat(skillclaw): ingest truncates noisy tool_result + tool_use input payloads"
+```
+
+---
+
+## Task 3: Ingest — parse a full transcript into a session record
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_ingest.py`
+- Test: `tests/python/test_skillclaw_ingest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+import json  # noqa: E402  (top of file already has pathlib/sys)
+
+
+def test_parse_transcript_builds_session(tmp_path):
+    f = tmp_path / "sess-abc.jsonl"
+    _write_jsonl(f, [
+        {"type": "queue-operation", "operation": "enqueue"},   # noise, ignored
+        {"type": "user", "sessionId": "sess-abc", "cwd": "/repo", "gitBranch": "main",
+         "message": {"role": "user", "content": "fix the bug"}},
+        {"type": "assistant", "sessionId": "sess-abc",
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "done"}]}},
+    ])
+    rec = ing.parse_transcript(f)
+    assert rec["session_id"] == "sess-abc"
+    assert rec["cwd"] == "/repo"
+    assert rec["git_branch"] == "main"
+    assert len(rec["turns"]) == 2
+    assert rec["turns"][0] == {"role": "user", "blocks": [{"kind": "text", "text": "fix the bug"}]}
+
+
+def test_parse_transcript_tolerates_partial_trailing_line(tmp_path):
+    f = tmp_path / "sess-x.jsonl"
+    f.write_text(
+        json.dumps({"type": "user", "sessionId": "sess-x",
+                    "message": {"role": "user", "content": "hi"}}) + "\n"
+        + '{"type":"assistant","message":{"role":"assist'   # truncated, no newline
+    )
+    rec = ing.parse_transcript(f)        # must not raise
+    assert rec["session_id"] == "sess-x"
+    assert len(rec["turns"]) == 1
+
+
+def test_parse_transcript_returns_none_when_no_turns(tmp_path):
+    f = tmp_path / "empty.jsonl"
+    _write_jsonl(f, [{"type": "queue-operation"}, {"type": "attachment"}])
+    assert ing.parse_transcript(f) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_ingest.py::test_parse_transcript_builds_session -v`
+Expected: FAIL — `parse_transcript` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `skillclaw_ingest.py`:
+
+```python
+def parse_transcript(path: Path, max_tool_output_chars: int = DEFAULT_MAX_TOOL_OUTPUT) -> dict | None:
+    """Parse one transcript .jsonl into a session record, or None if no turns.
+
+    Defensive: skips unparseable lines (including a truncated trailing line from
+    a still-active session) rather than raising.
+    """
+    session_id = path.stem
+    cwd = git_branch = None
+    turns: list[dict] = []
+    with path.open(encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # partial/corrupt line — skip
+            if obj.get("type") not in ("user", "assistant"):
+                continue
+            session_id = obj.get("sessionId", session_id)
+            cwd = obj.get("cwd", cwd)
+            git_branch = obj.get("gitBranch", git_branch)
+            msg = obj.get("message", {})
+            blocks = normalize_content(msg.get("content"), max_tool_output_chars)
+            if blocks:
+                turns.append({"role": msg.get("role", "?"), "blocks": blocks})
+    if not turns:
+        return None
+    return {"session_id": session_id, "cwd": cwd, "git_branch": git_branch, "turns": turns}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_ingest.py -v`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_ingest.py tests/python/test_skillclaw_ingest.py
+git commit -m "feat(skillclaw): ingest parse_transcript — turn extraction, partial-line tolerance"
+```
+
+---
+
+## Task 4: Ingest — window + settle predicates
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_ingest.py`
+- Test: `tests/python/test_skillclaw_ingest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_within_window():
+    now = 1_000_000.0
+    day = 86400
+    assert ing.within_window(now - 5 * day, now, window_days=30) is True
+    assert ing.within_window(now - 40 * day, now, window_days=30) is False
+
+
+def test_is_settled():
+    now = 1_000_000.0
+    assert ing.is_settled(now - 600, now, settle_minutes=5) is True    # 10 min old
+    assert ing.is_settled(now - 60, now, settle_minutes=5) is False    # 1 min old
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_ingest.py::test_within_window -v`
+Expected: FAIL — `within_window` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `skillclaw_ingest.py`:
+
+```python
+def within_window(mtime: float, now: float, window_days: int) -> bool:
+    """True if mtime falls within the last window_days from now."""
+    return (now - mtime) <= window_days * 86400
+
+
+def is_settled(mtime: float, now: float, settle_minutes: int) -> bool:
+    """True if the file has been idle long enough to be safely read."""
+    return (now - mtime) >= settle_minutes * 60
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_ingest.py -v`
+Expected: PASS (10 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_ingest.py tests/python/test_skillclaw_ingest.py
+git commit -m "feat(skillclaw): ingest window + settle recency predicates"
+```
+
+---
+
+## Task 5: Ingest — orchestration, incremental state, CLI
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_ingest.py`
+- Test: `tests/python/test_skillclaw_ingest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def _mk_transcript(d: Path, name: str, mtime: float) -> Path:
+    f = d / f"{name}.jsonl"
+    f.write_text(json.dumps({"type": "user", "sessionId": name,
+                             "message": {"role": "user", "content": "hi"}}) + "\n")
+    import os
+    os.utime(f, (mtime, mtime))
+    return f
+
+
+def test_ingest_writes_and_filters(tmp_path):
+    src = tmp_path / "projects" / "repo"
+    src.mkdir(parents=True)
+    out = tmp_path / "sessions"
+    state = tmp_path / ".state.json"
+    now = 1_000_000.0
+    _mk_transcript(src, "fresh", now - 3600)            # 1h old → ingested
+    _mk_transcript(src, "stale", now - 50 * 86400)      # 50d old → window-skipped
+    _mk_transcript(src, "active", now - 60)             # 1m old → settle-skipped
+
+    summary = ing.ingest(tmp_path / "projects", out, state,
+                         window_days=30, settle_minutes=5,
+                         max_tool_output_chars=500, now=now)
+    assert summary["ingested"] == 1
+    assert summary["skipped_old"] == 1
+    assert summary["skipped_unsettled"] == 1
+    assert (out / "fresh.json").exists()
+
+
+def test_ingest_is_incremental(tmp_path):
+    src = tmp_path / "projects" / "repo"
+    src.mkdir(parents=True)
+    out = tmp_path / "sessions"
+    state = tmp_path / ".state.json"
+    now = 1_000_000.0
+    _mk_transcript(src, "one", now - 3600)
+    first = ing.ingest(tmp_path / "projects", out, state, window_days=30,
+                       settle_minutes=5, max_tool_output_chars=500, now=now)
+    assert first["ingested"] == 1
+    second = ing.ingest(tmp_path / "projects", out, state, window_days=30,
+                        settle_minutes=5, max_tool_output_chars=500, now=now)
+    assert second["ingested"] == 0
+    assert second["skipped_seen"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_ingest.py::test_ingest_writes_and_filters -v`
+Expected: FAIL — `ingest` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `skillclaw_ingest.py`:
+
+```python
+def load_state(state_path: Path) -> dict:
+    try:
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_state(state_path: Path, state: dict) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
+def ingest(transcripts_dir, out_dir, state_path, *, window_days, settle_minutes,
+           max_tool_output_chars, now=None) -> dict:
+    """Ingest new, settled, in-window transcripts into out_dir. Returns counts."""
+    now = time.time() if now is None else now
+    transcripts_dir = Path(transcripts_dir).expanduser()
+    out_dir = Path(out_dir).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    state_path = Path(state_path).expanduser()
+    state = load_state(state_path)
+
+    summary = {"ingested": 0, "skipped_old": 0, "skipped_unsettled": 0,
+               "skipped_seen": 0, "skipped_empty": 0}
+    for f in sorted(transcripts_dir.rglob("*.jsonl")):
+        mtime = f.stat().st_mtime
+        if not within_window(mtime, now, window_days):
+            summary["skipped_old"] += 1
+            continue
+        if not is_settled(mtime, now, settle_minutes):
+            summary["skipped_unsettled"] += 1
+            continue
+        key = str(f)
+        if state.get(key) == mtime:
+            summary["skipped_seen"] += 1
+            continue
+        rec = parse_transcript(f, max_tool_output_chars)
+        if rec is None:
+            summary["skipped_empty"] += 1
+            state[key] = mtime
+            continue
+        (out_dir / f"{rec['session_id']}.json").write_text(
+            json.dumps(rec, indent=2), encoding="utf-8")
+        state[key] = mtime
+        summary["ingested"] += 1
+    save_state(state_path, state)
+    return summary
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("transcripts_dir")
+    ap.add_argument("out_dir")
+    ap.add_argument("--state", default="~/.skillclaw/.ingest-state.json")
+    ap.add_argument("--window-days", type=int, default=30)
+    ap.add_argument("--settle-minutes", type=int, default=5)
+    ap.add_argument("--max-tool-output-chars", type=int, default=DEFAULT_MAX_TOOL_OUTPUT)
+    args = ap.parse_args(argv)
+    summary = ingest(args.transcripts_dir, args.out_dir, args.state,
+                     window_days=args.window_days, settle_minutes=args.settle_minutes,
+                     max_tool_output_chars=args.max_tool_output_chars)
+    print(json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_ingest.py -v`
+Expected: PASS (12 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_ingest.py tests/python/test_skillclaw_ingest.py
+git commit -m "feat(skillclaw): ingest orchestration with incremental state + CLI"
+```
+
+---
+
+## Task 6: Evolve — prompt template + single-pass distillation
+
+**Files:**
+- Create: `configs/claude/prompts/skillclaw_evolve.md`
+- Create: `configs/claude/scripts/skillclaw_evolve.py`
+- Test: `tests/python/test_skillclaw_evolve.py`
+
+- [ ] **Step 1: Write the prompt template (not code — content step)**
+
+```markdown
+<!-- configs/claude/prompts/skillclaw_evolve.md -->
+# SkillClaw Distillation Prompt
+
+You are distilling reusable Claude Code **skills** from real agent sessions.
+
+A skill is a `SKILL.md` file with YAML frontmatter (`name`, `description`) and a
+markdown body describing a repeatable procedure the agent should follow.
+
+## Existing skill library (do NOT duplicate these names unless improving them)
+
+{{LIBRARY}}
+
+## Sessions (scrubbed, noise-truncated)
+
+{{SESSIONS}}
+
+## Your task
+
+Identify recurring, generalizable workflows in these sessions that are NOT already
+well covered by the existing library. For each, emit one skill.
+
+Output ONLY a sequence of skill blocks in this exact fenced format, nothing else:
+
+~~~skill name=<kebab-case-name>
+---
+name: <kebab-case-name>
+description: <one line: when to use this skill>
+---
+# <Title>
+
+<body: numbered, concrete steps>
+~~~
+
+If nothing rises to a reusable skill, output the single line: NO_SKILLS
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/python/test_skillclaw_evolve.py
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/claude/scripts"))
+import skillclaw_evolve as ev  # noqa: E402
+
+TEMPLATE = "LIB:\n{{LIBRARY}}\nSESS:\n{{SESSIONS}}\n"
+
+
+def test_estimate_tokens_is_roughly_quarter_length():
+    assert ev.estimate_tokens("a" * 400) == 100
+
+
+def test_build_prompt_substitutes_sections():
+    sessions = [{"session_id": "s1", "turns": [
+        {"role": "user", "blocks": [{"kind": "text", "text": "do x"}]}]}]
+    prompt = ev.build_prompt(TEMPLATE, sessions, ["existing-skill"])
+    assert "existing-skill" in prompt
+    assert "do x" in prompt
+    assert "{{LIBRARY}}" not in prompt and "{{SESSIONS}}" not in prompt
+
+
+def test_parse_candidates_extracts_skill_blocks():
+    output = (
+        "~~~skill name=foo-bar\n"
+        "---\nname: foo-bar\ndescription: does foo\n---\n# Foo\nstep 1\n"
+        "~~~\n"
+    )
+    cands = ev.parse_candidates(output)
+    assert cands == [{"name": "foo-bar",
+                      "content": "---\nname: foo-bar\ndescription: does foo\n---\n# Foo\nstep 1\n"}]
+
+
+def test_parse_candidates_handles_no_skills():
+    assert ev.parse_candidates("NO_SKILLS") == []
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_evolve.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'skillclaw_evolve'`
+
+- [ ] **Step 4: Write minimal implementation**
+
+```python
+# configs/claude/scripts/skillclaw_evolve.py
+#!/usr/bin/env python3
+"""Distill SKILL.md candidates from ingested sessions via `claude -p` (Max-backed).
+
+Replaces the retired `skillclaw evolve` binary. Map-reduces sessions through the
+headless Claude CLI: chunks that exceed the token budget are distilled
+independently (map), then merged (reduce). No proxy, no API key.
+
+Usage:
+    skillclaw_evolve.py <sessions_dir> <evolved_dir> [--template FILE]
+        [--token-budget N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_TOKEN_BUDGET = 100_000
+_SKILL_RE = re.compile(r"~~~skill name=(?P<name>[^\n]+)\n(?P<body>.*?)~~~", re.DOTALL)
+
+
+def estimate_tokens(text: str) -> int:
+    """Cheap heuristic: ~4 chars per token."""
+    return len(text) // 4
+
+
+def _render_session(s: dict) -> str:
+    lines = [f"### session {s.get('session_id', '?')}"]
+    for turn in s.get("turns", []):
+        for b in turn["blocks"]:
+            if b["kind"] in ("text", "thinking"):
+                lines.append(f"[{turn['role']}/{b['kind']}] {b['text']}")
+            elif b["kind"] == "tool_use":
+                lines.append(f"[tool_use {b['name']}] {json.dumps(b['input'])}")
+            elif b["kind"] == "tool_result":
+                lines.append(f"[tool_result err={b['is_error']}] {b['output']}")
+    return "\n".join(lines)
+
+
+def load_sessions(sessions_dir) -> list[dict]:
+    sessions_dir = Path(sessions_dir).expanduser()
+    out = []
+    for f in sorted(sessions_dir.glob("*.json")):
+        try:
+            out.append(json.loads(f.read_text(encoding="utf-8")))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def build_prompt(template: str, sessions: list[dict], library_names: list[str]) -> str:
+    library = "\n".join(f"- {n}" for n in library_names) or "(empty)"
+    rendered = "\n\n".join(_render_session(s) for s in sessions) or "(none)"
+    return template.replace("{{LIBRARY}}", library).replace("{{SESSIONS}}", rendered)
+
+
+def parse_candidates(output: str) -> list[dict]:
+    return [{"name": m.group("name").strip(), "content": m.group("body")}
+            for m in _SKILL_RE.finditer(output)]
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_evolve.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_evolve.py configs/claude/prompts/skillclaw_evolve.md tests/python/test_skillclaw_evolve.py
+git commit -m "feat(skillclaw): evolve prompt template + token estimate, prompt build, candidate parse"
+```
+
+---
+
+## Task 7: Evolve — map-reduce chunking
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_evolve.py`
+- Test: `tests/python/test_skillclaw_evolve.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_chunk_sessions_splits_over_budget():
+    # each session renders to ~ (len//4) tokens; make 3 sessions of ~40k tokens
+    big = "x" * 160_000
+    sessions = [{"session_id": f"s{i}",
+                 "turns": [{"role": "user", "blocks": [{"kind": "text", "text": big}]}]}
+                for i in range(3)]
+    chunks = ev.chunk_sessions(sessions, token_budget=100_000)
+    assert len(chunks) >= 2                       # 120k tokens total → multiple chunks
+    assert sum(len(c) for c in chunks) == 3       # no session lost
+
+
+def test_chunk_sessions_single_chunk_under_budget():
+    sessions = [{"session_id": "s1",
+                 "turns": [{"role": "user", "blocks": [{"kind": "text", "text": "tiny"}]}]}]
+    chunks = ev.chunk_sessions(sessions, token_budget=100_000)
+    assert chunks == [sessions]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_evolve.py::test_chunk_sessions_splits_over_budget -v`
+Expected: FAIL — `chunk_sessions` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `skillclaw_evolve.py`:
+
+```python
+def chunk_sessions(sessions: list[dict], token_budget: int) -> list[list[dict]]:
+    """Greedily pack sessions into chunks whose rendered size stays under budget.
+
+    A single session larger than the budget gets its own chunk (it cannot be
+    split further here; the renderer already truncated tool noise upstream).
+    """
+    if not sessions:
+        return []
+    chunks: list[list[dict]] = []
+    current: list[dict] = []
+    current_tokens = 0
+    for s in sessions:
+        cost = estimate_tokens(_render_session(s))
+        if current and current_tokens + cost > token_budget:
+            chunks.append(current)
+            current, current_tokens = [], 0
+        current.append(s)
+        current_tokens += cost
+    if current:
+        chunks.append(current)
+    return chunks
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_evolve.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_evolve.py tests/python/test_skillclaw_evolve.py
+git commit -m "feat(skillclaw): evolve map-reduce chunking under token budget"
+```
+
+---
+
+## Task 8: Evolve — runner injection, evolve(), write candidates, CLI
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_evolve.py`
+- Test: `tests/python/test_skillclaw_evolve.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_evolve_uses_injected_runner_and_writes(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "s1.json").write_text(json.dumps(
+        {"session_id": "s1", "turns": [
+            {"role": "user", "blocks": [{"kind": "text", "text": "deploy steps"}]}]}))
+    template = tmp_path / "tpl.md"
+    template.write_text("LIB {{LIBRARY}} SESS {{SESSIONS}}")
+    evolved = tmp_path / "evolved"
+
+    def fake_runner(prompt):
+        assert "deploy steps" in prompt
+        return ("~~~skill name=deploy-flow\n---\nname: deploy-flow\n"
+                "description: how to deploy\n---\n# Deploy\nstep 1\n~~~\n")
+
+    summary = ev.evolve(sessions_dir, evolved, template, token_budget=100_000,
+                        runner=fake_runner)
+    assert summary["candidates"] == 1
+    assert (evolved / "deploy-flow" / "SKILL.md").read_text().startswith("---")
+
+
+def test_evolve_empty_sessions_is_clean_noop(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    template = tmp_path / "tpl.md"
+    template.write_text("{{LIBRARY}}{{SESSIONS}}")
+    evolved = tmp_path / "evolved"
+    calls = []
+    summary = ev.evolve(sessions_dir, evolved, template, token_budget=100_000,
+                        runner=lambda p: calls.append(p) or "NO_SKILLS")
+    assert summary["candidates"] == 0
+    assert calls == []                 # no sessions → no model calls
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_evolve.py::test_evolve_uses_injected_runner_and_writes -v`
+Expected: FAIL — `evolve` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `skillclaw_evolve.py`:
+
+```python
+def subprocess_runner(prompt: str) -> str:
+    """Default runner: invoke headless `claude -p` (Max-backed)."""
+    proc = subprocess.run(["claude", "-p", prompt], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"claude -p failed: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def write_candidates(candidates: list[dict], evolved_dir: Path) -> list[str]:
+    evolved_dir = Path(evolved_dir).expanduser()
+    written = []
+    for c in candidates:
+        d = evolved_dir / c["name"]
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "SKILL.md").write_text(c["content"], encoding="utf-8")
+        written.append(c["name"])
+    return written
+
+
+def _committed_library_names(evolved_dir: Path) -> list[str]:
+    base = Path(evolved_dir).expanduser()
+    return sorted(p.parent.name for p in base.glob("*/SKILL.md")) if base.exists() else []
+
+
+def evolve(sessions_dir, evolved_dir, template_path, *,
+           token_budget=DEFAULT_TOKEN_BUDGET, runner=subprocess_runner) -> dict:
+    """Map-reduce sessions into SKILL.md candidates. Returns a summary dict."""
+    sessions = load_sessions(sessions_dir)
+    template = Path(template_path).expanduser().read_text(encoding="utf-8")
+    library = _committed_library_names(evolved_dir)
+    if not sessions:
+        return {"candidates": 0, "chunks": 0, "written": []}
+
+    chunks = chunk_sessions(sessions, token_budget)
+    mapped: list[dict] = []
+    for chunk in chunks:
+        out = runner(build_prompt(template, chunk, library))
+        mapped.extend(parse_candidates(out))
+
+    # reduce: dedupe by name (last write wins); a single chunk skips a 2nd call
+    if len(chunks) > 1 and mapped:
+        names = {c["name"] for c in mapped}
+        deduped = {}
+        for c in mapped:
+            deduped[c["name"]] = c
+        mapped = list(deduped.values())
+        _ = names  # reduction is name-dedupe; cross-chunk merge stays simple in V1
+
+    written = write_candidates(mapped, evolved_dir)
+    return {"candidates": len(written), "chunks": len(chunks), "written": written}
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("sessions_dir")
+    ap.add_argument("evolved_dir")
+    ap.add_argument("--template", default="~/.claude/prompts/skillclaw_evolve.md")
+    ap.add_argument("--token-budget", type=int, default=DEFAULT_TOKEN_BUDGET)
+    args = ap.parse_args(argv)
+    try:
+        summary = evolve(args.sessions_dir, args.evolved_dir, args.template,
+                         token_budget=args.token_budget)
+    except (RuntimeError, FileNotFoundError) as e:
+        print(f"skillclaw_evolve: {e}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_evolve.py -v`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_evolve.py tests/python/test_skillclaw_evolve.py
+git commit -m "feat(skillclaw): evolve() map-reduce orchestration + claude -p runner + CLI"
+```
+
+---
+
+## Task 9: Promote — surface rejected candidates instead of dropping silently
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_promote.py:69-97` (the `main` body)
+- Test: `tests/python/test_skillclaw_promote.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_rejected_candidates_are_copied_to_rejected_dir(tmp_path):
+    evolved = tmp_path / "evolved"
+    committed = tmp_path / "committed"
+    rejected = tmp_path / "rejected"
+    _skill(committed, "_", VALID)                       # committed dir exists
+    _skill(evolved, "broken", "# no frontmatter\n")     # invalid → rejected
+    rc = promote.main([str(evolved), str(committed), "--rejected-dir", str(rejected)])
+    assert rc == 0
+    # the rejected SKILL.md must have been copied for inspection
+    assert (rejected / "broken" / "SKILL.md").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_promote.py::test_rejected_candidates_are_copied_to_rejected_dir -v`
+Expected: FAIL — `--rejected-dir` is an unrecognized argument.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `skillclaw_promote.py`, add the arg and copy logic. Add `import shutil` at top with the other imports, then modify `main`:
+
+```python
+    ap.add_argument("--rejected-dir", help="copy invalid candidates here for inspection")
+    args = ap.parse_args(argv)
+```
+
+After the loop that fills `promote`/`dropped`, before the `json.dump`:
+
+```python
+    if args.rejected_dir:
+        rej = Path(args.rejected_dir).expanduser()
+        for d in dropped:
+            dest = rej / d["name"]
+            dest.mkdir(parents=True, exist_ok=True)
+            shutil.copy(d["path"], dest / "SKILL.md")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_promote.py -v`
+Expected: PASS (existing 4 + 1 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_promote.py tests/python/test_skillclaw_promote.py
+git commit -m "feat(skillclaw): promote copies rejected candidates to rejected/ for inspection"
+```
+
+---
+
+## Task 10: Promote.sh — call new ingest+evolve, warn on rejected
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_promote.sh:62-104`
+- Test: `tests/bats/skillclaw_promote.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/bats/skillclaw_promote.bats` (follow the existing stubbing pattern in that file — it sets `SKILLCLAW_*` env seams and a fake `git_ops.sh`):
+
+```bash
+@test "promote runs ingest+evolve scripts instead of the skillclaw binary" {
+  run grep -E 'skillclaw_(ingest|evolve)\.py' "$REPO/configs/claude/scripts/skillclaw_promote.sh"
+  [ "$status" -eq 0 ]
+  run grep -c 'skillclaw evolve --mode workflow' "$REPO/configs/claude/scripts/skillclaw_promote.sh"
+  [ "$output" -eq 0 ]
+}
+
+@test "promote warns when candidates are rejected" {
+  run grep -Ei 'failed schema validation|rejected' "$REPO/configs/claude/scripts/skillclaw_promote.sh"
+  [ "$status" -eq 0 ]
+}
+```
+
+(Confirm the `$REPO` var name matches the file's existing setup; reuse whatever the other tests use to locate the repo root.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/bats/skillclaw_promote.bats -f "ingest"`
+Expected: FAIL — script still calls the `skillclaw` binary.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `skillclaw_promote.sh`, replace the scrub+evolve section (lines ~62–73) with:
+
+```bash
+INGEST="${SCRIPT_DIR}/skillclaw_ingest.py"
+EVOLVE="${SCRIPT_DIR}/skillclaw_evolve.py"
+TEMPLATE="${SKILLCLAW_TEMPLATE:-${SCRIPT_DIR}/../prompts/skillclaw_evolve.md}"
+TRANSCRIPTS="${SKILLCLAW_TRANSCRIPTS:-$HOME/.claude/projects}"
+STATE="${SKILLCLAW_STATE:-$HOME/.skillclaw/.ingest-state.json}"
+REJECTED="${SKILLCLAW_REJECTED:-$HOME/.skillclaw/skills/rejected}"
+
+# 1. Ingest transcripts → sessions (passive; no proxy).
+if [[ "$DO_EVOLVE" == true ]]; then
+    python3 "$INGEST" "$TRANSCRIPTS" "$SESSIONS" --state "$STATE" >/dev/null 2>&1 \
+        || err "ingest returned non-zero (continuing)"
+fi
+
+# 2. Scrub captured sessions (best-effort; never blocks).
+if [[ -d "$SESSIONS" ]]; then
+    python3 "${SCRIPT_DIR}/skillclaw_scrub.py" "$SESSIONS" >/dev/null 2>&1 || true
+fi
+
+# 3. Evolve (skip with --no-evolve).
+if [[ "$DO_EVOLVE" == true ]]; then
+    python3 "$EVOLVE" "$SESSIONS" "$EVOLVED" --template "$TEMPLATE" \
+        || err "evolve returned non-zero (continuing)"
+fi
+```
+
+Then update the classify call to pass `--rejected-dir "$REJECTED"`, and after printing the diff table, add the warning:
+
+```bash
+classify_args=("$EVOLVED" "$COMMITTED" --rejected-dir "$REJECTED")
+[[ -n "$SKILL" ]] && classify_args+=(--skill "$SKILL")
+classify_json="$(python3 "${SCRIPT_DIR}/skillclaw_promote.py" "${classify_args[@]}")"
+
+dropped_count="$(echo "$classify_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["dropped"]))')"
+if [[ "$dropped_count" -gt 0 ]]; then
+    err "Generated candidate(s), but ${dropped_count} failed schema validation. See ${REJECTED}"
+fi
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/bats/skillclaw_promote.bats`
+Expected: PASS (existing + 2 new). Then `pytest tests/python/test_skillclaw_promote.py -v` still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_promote.sh tests/bats/skillclaw_promote.bats
+git commit -m "feat(skillclaw): promote.sh drives ingest+evolve, warns on rejected candidates"
+```
+
+---
+
+## Task 11: Config rewrite — drop proxy/capture, add ingest/evolve knobs
+
+**Files:**
+- Modify: `configs/claude/config/skillclaw.yml`
+- Test: `tests/bats/skillclaw_config.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace proxy/capture assertions in `tests/bats/skillclaw_config.bats` with:
+
+```bash
+@test "skillclaw.yml has no proxy or capture blocks" {
+  run python3 -c "import yaml; d=yaml.safe_load(open('$REPO/configs/claude/config/skillclaw.yml')); assert 'proxy' not in d and 'capture' not in d"
+  [ "$status" -eq 0 ]
+}
+
+@test "skillclaw.yml defines ingest and claude-cli evolve engine" {
+  run python3 -c "import yaml; d=yaml.safe_load(open('$REPO/configs/claude/config/skillclaw.yml')); assert d['ingest']['window_days']==30; assert d['evolve']['engine']=='claude-cli'; assert d['ingest']['settle_minutes']==5"
+  [ "$status" -eq 0 ]
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/bats/skillclaw_config.bats`
+Expected: FAIL — current yml still has `proxy:`/`capture:` and lacks `ingest:`.
+
+- [ ] **Step 3: Write the new config (content step)**
+
+Replace `configs/claude/config/skillclaw.yml` entirely with:
+
+```yaml
+# SkillClaw runtime configuration (proxy-free, transcript-fed).
+# Consumed by scripts/skillclaw_{ingest,evolve,promote}.{py,sh}.
+# Deployed to ~/.claude/config/skillclaw.yml. NOTE: distinct from the vestigial
+# upstream ~/.skillclaw/config.yaml — this file is the Manifest-owned source.
+
+storage:
+  root: ~/.skillclaw
+  sessions: ~/.skillclaw/sessions
+  evolved: ~/.skillclaw/skills
+  rejected: ~/.skillclaw/skills/rejected
+  state: ~/.skillclaw/.ingest-state.json
+
+ingest:
+  transcripts_dir: ~/.claude/projects
+  window_days: 30              # all projects, recent window
+  settle_minutes: 5           # skip files whose mtime is newer (still being written)
+  max_tool_output_chars: 500  # truncate raw tool stdout/stderr beyond this; drop base64
+  # allowlist: []             # optional future: restrict to project paths
+
+evolve:
+  engine: claude-cli          # `claude -p` headless, Max-backed
+  token_budget: 100000        # map-reduce chunk threshold; stays clear of 200k limit
+  prompt_template: ~/.claude/prompts/skillclaw_evolve.md
+
+promotion:
+  branch_prefix: skillclaw/evolve-
+  pr_base: main
+  pr_labels:
+    - needs-review
+    - follow-up
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/bats/skillclaw_config.bats`
+Expected: PASS. Also: `python3 -c "import yaml; yaml.safe_load(open('configs/claude/config/skillclaw.yml'))"` exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/config/skillclaw.yml tests/bats/skillclaw_config.bats
+git commit -m "feat(skillclaw): rewrite config — drop proxy/capture, add ingest/evolve knobs"
+```
+
+---
+
+## Task 12: Bootstrap teardown — remove proxy stack, redefine enable/disable
+
+**Files:**
+- Modify: `bootstrap/lib/skillclaw.sh`
+- Test: `tests/bats/skillclaw_lib.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/bats/skillclaw_lib.bats`, replace daemon/proxy/wrapper assertions with:
+
+```bash
+@test "skillclaw.sh no longer writes shell proxy wrappers" {
+  run grep -Ec 'ANTHROPIC_BASE_URL|OPENAI_BASE_URL|_skillclaw_run|skillclaw_daemon' "$REPO/bootstrap/lib/skillclaw.sh"
+  [ "$output" -eq 0 ]
+}
+
+@test "disable still removes any legacy wrapper block (clean teardown)" {
+  run grep -q 'skillclaw_remove_wrappers' "$REPO/bootstrap/lib/skillclaw.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "apply_state enables transcript evolution without a daemon" {
+  run grep -Eq 'no daemon|transcript' "$REPO/bootstrap/lib/skillclaw.sh"
+  [ "$status" -eq 0 ]
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/bats/skillclaw_lib.bats`
+Expected: FAIL — proxy/daemon symbols still present.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Rewrite `bootstrap/lib/skillclaw.sh` to drop `install_skillclaw` (pip), `configure_skillclaw` (proxy setup), `skillclaw_daemon`, `skillclaw_supervisor_unit`, `skillclaw_install_supervisor`, and the base-URL lines in `skillclaw_write_wrappers`. **Keep** `skillclaw_remove_wrappers` (for clean teardown of any pre-existing wrapper block + launchd unit) and rewrite `skillclaw_apply_state`:
+
+```bash
+# Apply desired state. Transcript-fed evolution needs NO daemon and NO proxy —
+# enabling just ensures storage exists and any legacy proxy wrappers are removed.
+skillclaw_apply_state() {
+    local profile="${SHELL_PROFILE_FILE:-$HOME/.zshrc}"
+    # Always strip any legacy proxy wrapper block (full teardown of the old model).
+    skillclaw_remove_wrappers "$profile"
+    _skillclaw_remove_launchd
+    if [[ "${ENABLE_SKILLCLAW:-false}" == true ]]; then
+        mkdir -p "$SKILLCLAW_HOME/sessions" "$SKILLCLAW_HOME/skills"
+        chmod 700 "$SKILLCLAW_HOME" 2>/dev/null || true
+        print_success "SkillClaw enabled (transcript evolution; no daemon, no proxy)"
+    else
+        print_info "SkillClaw disabled (storage left intact; nothing running)"
+    fi
+}
+
+# Remove the retired launchd/systemd supervisor if a prior install left one.
+_skillclaw_remove_launchd() {
+    case "$(uname -s)" in
+        Darwin)
+            local plist="$HOME/Library/LaunchAgents/com.manifest.skillclaw.plist"
+            [[ -f "$plist" ]] && { launchctl unload "$plist" >/dev/null 2>&1 || true; rm -f "$plist"; }
+            ;;
+        Linux)
+            local unit="$HOME/.config/systemd/user/skillclaw.service"
+            [[ -f "$unit" ]] && { systemctl --user disable --now skillclaw.service >/dev/null 2>&1 || true; rm -f "$unit"; }
+            ;;
+    esac
+}
+```
+
+Keep `skillclaw_remove_wrappers` as-is (it deletes the marker block). Drop the now-unused `skillclaw_write_wrappers`, daemon, and supervisor functions.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/bats/skillclaw_lib.bats`
+Expected: PASS. Then run the full bats suite for regressions: `bats tests/bats/`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bootstrap/lib/skillclaw.sh tests/bats/skillclaw_lib.bats
+git commit -m "feat(skillclaw): retire proxy/daemon/supervisor; enable = storage-only, full teardown"
+```
+
+---
+
+## Task 13: Docs + full-suite green + lint
+
+**Files:**
+- Modify: `docs/SKILLCLAW.md`
+
+- [ ] **Step 1: Rewrite `docs/SKILLCLAW.md`** to describe the proxy-free model: passive transcript ingestion, `claude -p` evolve engine, the ingest→scrub→evolve→classify→PR flow, the `~/.skillclaw/` annexation (Manifest-owned; upstream `config.yaml`/`dashboard.db` vestigial), and the `window_days`/`settle_minutes`/`max_tool_output_chars`/`token_budget` knobs. Remove all proxy/daemon/`SKILLCLAW_BYPASS`/port references.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run:
+```bash
+pytest tests/python/ -v
+bats tests/bats/
+shellcheck configs/claude/scripts/skillclaw_promote.sh bootstrap/lib/skillclaw.sh
+yamllint configs/claude/config/skillclaw.yml
+```
+Expected: all green; shellcheck and yamllint clean.
+
+- [ ] **Step 3: Markdownlint the docs**
+
+Run: `markdownlint docs/SKILLCLAW.md docs/superpowers/specs/2026-06-08-skillclaw-proxy-free-evolve-design.md docs/superpowers/plans/2026-06-08-skillclaw-proxy-free-evolve.md` (or the repo's configured linter)
+Expected: clean (fix MD013 line-length / list issues as the repo convention requires).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/SKILLCLAW.md
+git commit -m "docs(skillclaw): rewrite for proxy-free transcript-fed evolution"
+```
+
+---
+
+## Self-Review (completed during plan authoring)
+
+**Spec coverage:**
+- Passive transcript ingestion → Tasks 1–5. ✓
+- Aggressive stripping (tool output, base64, tool_use input) → Tasks 1–2. ✓
+- Window + settle (concurrency) → Tasks 4–5. ✓
+- Incremental state → Task 5. ✓
+- `claude -p` evolve engine + map-reduce chunking → Tasks 6–8. ✓
+- Rejected candidates surfaced (not silent) → Tasks 9–10. ✓
+- Reuse scrub + classify + PR-gating → Tasks 9–10 (scrub unchanged; promote.sh swaps evolve call). ✓
+- Config rewrite (drop proxy/capture; ingest/evolve knobs) → Task 11. ✓
+- Remove proxy/daemon/wrappers/supervisor; redefine enable → Task 12. ✓
+- Annexation documented → Tasks 11–13. ✓
+- Tests: ingest, evolve, promote-rejected, bats config/lib/promote → Tasks 1–13. ✓
+
+**Type/name consistency:** Module API contract (top of plan) is used verbatim across tasks — `normalize_content`, `parse_transcript`, `within_window`, `is_settled`, `ingest`, `estimate_tokens`, `build_prompt`, `chunk_sessions`, `parse_candidates`, `write_candidates`, `evolve`, `subprocess_runner`. Env seams in promote.sh (`SKILLCLAW_TRANSCRIPTS`, `SKILLCLAW_STATE`, `SKILLCLAW_REJECTED`, `SKILLCLAW_TEMPLATE`) are new and self-consistent.
+
+**Note for executor:** Task 9's test uses a `--rejected-dir` round-trip; verify the existing `skillclaw_promote.py` `main` arg-parsing block matches the line range cited before editing (the file may have shifted). Always re-read the target file region before applying an edit.

--- a/docs/superpowers/specs/2026-06-08-skillclaw-proxy-free-evolve-design.md
+++ b/docs/superpowers/specs/2026-06-08-skillclaw-proxy-free-evolve-design.md
@@ -1,0 +1,255 @@
+# SkillClaw Proxy-Free Evolve — Design
+
+> Replace SkillClaw's inline capture proxy with passive transcript ingestion,
+> keeping the PR-gated skill-evolution value while severing the Max-incompatible
+> man-in-the-middle.
+
+**Date**: 2026-06-08
+**Status**: Approved (design) — pending implementation plan
+**Supersedes capture half of**: `2026-06-07-skillclaw-integration-design.md`
+**Audience**: Manifest maintainers
+
+---
+
+## Problem
+
+The SkillClaw integration shipped in
+[`2026-06-07-skillclaw-integration-design.md`](2026-06-07-skillclaw-integration-design.md)
+captures CLI-agent sessions through a local proxy (`ANTHROPIC_BASE_URL` /
+`OPENAI_BASE_URL` → `127.0.0.1`). On a **Claude Max subscription** this is
+fundamentally broken:
+
+- **Symptom (confirmed):** routing `claude` through the proxy breaks the Max
+  OAuth flow. The fail-open wrapper therefore bypasses the proxy on every
+  invocation.
+- **Evidence from the live install** (`~/.skillclaw/`):
+  - `dashboard.db` → `sessions: 0`. **Zero sessions have ever been captured.**
+  - `config.yaml` shows the proxy configured for OAuth (`api_key: oauth`,
+    `claw_type: claude`, `proxy.port: 30000`) yet still produces nothing.
+  - The installed tool stores evolved skills in `dashboard.db` (SQLite), but
+    Manifest's `skillclaw_promote.sh` reads `~/.skillclaw/skills/<name>/SKILL.md`
+    — a **schema mismatch** that would prevent promotion even if capture worked.
+  - `retrieval_mode: template, top_k: 6` — the proxy also does runtime skill
+    *injection*, which is **redundant**: Claude Code already discovers and loads
+    skills natively.
+
+Net: a daemon, a launchd supervisor, shell wrappers, and an OAuth-incompatible
+proxy are maintained to deliver **zero value**.
+
+## Goal
+
+Preserve the one genuinely valuable function — *distill reusable `SKILL.md`
+skills from how the user actually works* — while removing the inline proxy
+entirely. Reuse the existing, working scrub + classify + PR-gating machinery.
+
+## Non-Goals
+
+- Runtime skill retrieval/injection (Claude Code does this natively).
+- Capturing non-Claude CLIs that don't persist transcripts (future extension via
+  hooks; see Follow-ups).
+- Real-time / streaming capture. Evolution is statistical and on-demand.
+
+---
+
+## Decisions (resolved during brainstorming)
+
+| Decision | Choice |
+|----------|--------|
+| Capture mechanism | **Passive transcript ingestion** (Approach B) — no proxy |
+| Scope | **Retire the proxy entirely** (both `claude` and `codex`) |
+| Evolve engine | **`claude -p` headless via Max** — no API key, no proxy, flat-rate, high quality |
+| Transcript scope | **All projects, last 30 days** (configurable `window_days`); rely on scrub |
+| Trigger | On-demand via existing `/skill-evolve` (dry-run default, `--apply` opens PR) |
+
+## Architecture & data flow
+
+```text
+~/.claude/projects/**/*.jsonl        (Claude Code transcripts, already on disk)
+        │
+        ▼
+ skillclaw_ingest.py    parse JSONL → normalized session records;
+        │               filter to window_days; incremental via state file
+        ▼
+ skillclaw_scrub.py     REUSED — redact secrets / API keys / auth headers
+        │
+        ▼
+ skillclaw_evolve.py    batch scrubbed sessions → distillation prompt →
+        │               `claude -p` → write SKILL.md candidates to
+        │               ~/.skillclaw/skills/<name>/SKILL.md
+        ▼
+ skillclaw_promote.sh   REUSED — classify NEW/CHANGED vs committed library,
+        │               validate frontmatter, PR-gate (one open PR at a time)
+        ▼
+   review PR → .skillshare/skills/   (human merge = source of truth)
+```
+
+No socket. No request-path interception. Runs only when invoked.
+
+## Components
+
+### New
+
+- **`configs/claude/scripts/skillclaw_ingest.py`**
+  - Reads `~/.claude/projects/**/*.jsonl` (path configurable).
+  - Normalizes each session: user prompts, assistant reasoning, and tool
+    **names + arguments**. Emits one JSON file per session into
+    `~/.skillclaw/sessions/`.
+  - **Aggressive stripping (noise reduction).** Transcripts are dominated by
+    artifacts — base64 screenshots, full file reads, multi-thousand-line diffs.
+    Ingest retains the user prompt, the assistant's reasoning, and tool
+    names/args, but **truncates raw tool `stdout`/`stderr` payloads beyond
+    `max_tool_output_chars` (default 500)** and drops binary/base64 blobs
+    outright. This is the primary token-control lever and runs with zero LLM
+    cost.
+  - **Window filter:** drop sessions older than `window_days` (default 30) by
+    transcript mtime / session timestamp.
+  - **Freshness / settle threshold (concurrency safety).** Claude Code streams
+    to these `.jsonl` files live. Ingest **skips any file whose mtime is newer
+    than `settle_minutes` (default 5)** so it never reads a half-written session,
+    and **parses line-by-line, tolerating a trailing partial/malformed line**
+    (skip, don't crash).
+  - **Incremental:** a state file (`~/.skillclaw/.ingest-state.json`) records
+    processed session IDs + mtimes; re-runs only ingest new/changed transcripts.
+
+- **`configs/claude/scripts/skillclaw_evolve.py`**
+  - Replaces the dead `skillclaw evolve --mode workflow` binary call.
+  - Bundles scrubbed sessions + the current committed skill library into a
+    distillation prompt; invokes `claude -p` (headless print mode, Max-backed).
+  - **Map-reduce chunking (context-window safety).** Estimates the scrubbed
+    payload's token count. If it exceeds `token_budget` (default ~100k), it
+    splits sessions into N chunks, runs one `claude -p` distillation per chunk
+    (the *map* — each emits candidate skills), then runs a final *reduce* pass
+    that merges/dedupes candidates across chunks. Below budget, it's a single
+    pass. This keeps each prompt well clear of the 200k limit and preserves the
+    model's ability to spot discrete reusable patterns.
+  - Writes/refreshes `SKILL.md` candidates to `~/.skillclaw/skills/<name>/`.
+  - Output is validated downstream by `skillclaw_promote.py` (frontmatter check).
+    **Rejected candidates are surfaced, not dropped silently** — see below.
+
+- **`configs/claude/prompts/skillclaw_evolve.md`** — the distillation prompt
+  template `skillclaw_evolve.py` fills with scrubbed sessions + the current
+  library. Deployed to `~/.claude/prompts/`. Keeps the "intelligence" reviewable
+  and version-controlled rather than buried in a Python string.
+
+### Reused unchanged
+
+- `skillclaw_scrub.py` — secret redaction.
+- `skillclaw_promote.py` — classify NEW/CHANGED/UNCHANGED + frontmatter validation.
+  Already returns a `dropped[]` list with reasons; **extended** so each rejected
+  candidate's `SKILL.md` is copied to `~/.skillclaw/skills/rejected/<name>/` for
+  inspection rather than discarded.
+- `skillclaw_promote.sh` — PR gating (Option A: one open `skillclaw/evolve-*` PR),
+  per-skill commits, dry-run default. **Two changes:** (1) swap the
+  `skillclaw evolve` invocation (lines ~69–73) for `skillclaw_evolve.py`;
+  (2) when `dropped[]` is non-empty, emit a distinct, prominent warning even if
+  the promote list is empty — e.g. `"Generated N candidate(s), but M failed
+  schema validation. See ~/.skillclaw/skills/rejected/"` — so a generation
+  failure never reads as "no new skills found."
+
+### Removed
+
+- `bootstrap/lib/skillclaw.sh`: proxy setup, daemon lifecycle, crash supervisor,
+  launchd/systemd unit, and the shell-profile `claude()` / `codex()` wrappers.
+- The upstream `skillclaw` pip dependency.
+- `proxy:` and `capture:` blocks in `skillclaw.yml`.
+- `--enable-skillclaw` is redefined: "enable transcript-based skill evolution"
+  (no daemon to start; just deploys the scripts + config).
+
+## Config rewrite (`configs/claude/config/skillclaw.yml`)
+
+```yaml
+storage:
+  root: ~/.skillclaw
+  sessions: ~/.skillclaw/sessions
+  evolved: ~/.skillclaw/skills
+  rejected: ~/.skillclaw/skills/rejected   # candidates that failed validation
+  state: ~/.skillclaw/.ingest-state.json
+
+ingest:
+  transcripts_dir: ~/.claude/projects
+  window_days: 30              # all projects, recent window
+  settle_minutes: 5           # skip files whose mtime is newer (still being written)
+  max_tool_output_chars: 500  # truncate raw tool stdout/stderr beyond this; drop base64
+  # allowlist: []             # optional future: restrict to project paths
+
+evolve:
+  engine: claude-cli          # `claude -p` headless, Max-backed
+  token_budget: 100000        # map-reduce chunk threshold; stays clear of 200k limit
+  # model: <optional override; default = CLI default>
+  prompt_template: ~/.claude/prompts/skillclaw_evolve.md   # distillation prompt
+
+promotion:
+  branch_prefix: skillclaw/evolve-
+  pr_base: main
+  pr_labels: [needs-review, follow-up]
+```
+
+## Migration & teardown
+
+1. **Stop & remove the proxy stack:** `skillclaw_daemon stop`; `launchctl unload`
+   + delete `~/Library/LaunchAgents/com.manifest.skillclaw.plist`; reuse
+   `skillclaw_remove_wrappers` to strip the managed `claude()`/`codex()` block
+   from the shell profile.
+2. **Drop the dependency:** uninstall the `skillclaw` pip package (optional;
+   leaving it installed is harmless once unused).
+3. `--disable-skillclaw` already removes wrappers and stops the daemon; extend it
+   to also unload the launchd unit for a full revert.
+4. Deploy the two new scripts + the evolve prompt template + rewritten
+   `skillclaw.yml` via `bootstrap.sh`.
+5. **Annexation.** Once the pip package and proxy daemon are gone, "SkillClaw" is
+   no longer an external tool — it is **a set of Manifest-owned Python scripts**,
+   and `~/.skillclaw/` is **solely managed by this repo's scripts**. The upstream
+   tool's legacy artifacts (`~/.skillclaw/config.yaml`, `dashboard.db`,
+   `backups/`) become vestigial: bootstrap leaves them in place (harmless) but
+   nothing reads them. Document this ownership shift in `docs/SKILLCLAW.md` so the
+   `~/.skillclaw/config.yaml` (upstream schema) is not confused with the
+   Manifest-owned `~/.claude/config/skillclaw.yml`.
+
+## Testing
+
+- **pytest `test_skillclaw_ingest.py`:** JSONL parsing of representative
+  transcripts; `window_days` filtering; incremental state (re-run ingests nothing
+  new); malformed/partial-trailing-line tolerance (skip, don't crash);
+  **tool-output truncation** beyond `max_tool_output_chars` + base64 drop;
+  **settle threshold** (a file with mtime < `settle_minutes` is skipped).
+- **pytest `test_skillclaw_evolve.py`:** prompt assembly from scrubbed sessions;
+  `claude -p` invocation mocked (no network); output written only when
+  frontmatter-valid; empty-session input → no candidates, clean exit;
+  **map-reduce path** (payload > `token_budget` → multiple mapped calls + one
+  reduce; merge/dedupe of cross-chunk candidates).
+- **pytest `test_skillclaw_promote.py` (extended):** rejected candidate is copied
+  to `~/.skillclaw/skills/rejected/<name>/` and reported in `dropped[]`.
+- **Reused green:** `test_skillclaw_scrub.py`.
+- **bats:** update the promote case that asserted the `skillclaw evolve` call to
+  assert the `skillclaw_evolve.py` call; add a case asserting the **validation-
+  failure warning** prints even when the promote list is empty; keep dry-run /
+  PR-gating cases.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Transcripts from unrelated repos leak into prompts | `skillclaw_scrub.py` redacts secrets; `window_days` bounds volume; `allowlist` is a one-line future tightening |
+| `claude -p` unavailable / not logged in | Evolve exits non-zero with a clear message; pipeline is dry-run-safe and opens no PR |
+| Claude transcript JSONL format drift | Ingest is defensive (skip unparseable records, tolerate partial trailing line); covered by pytest fixtures |
+| Context-window exhaustion (30d × all projects > 200k) | Heuristic stripping in ingest (tool-output truncation) + map-reduce chunking in evolve at `token_budget` |
+| Distillation drowns in transcript noise (diffs, base64, file reads) | `max_tool_output_chars` truncation + base64 drop at ingest; only prompts/reasoning/tool-args survive |
+| Reading a half-written live session | `settle_minutes` mtime threshold + line-by-line parse skipping the trailing partial object |
+| Generation failure misread as "nothing found" | Rejected candidates written to `rejected/` with a prominent warning distinct from "Nothing to promote" |
+
+## Follow-ups (not in V1)
+
+- **Hook-based capture** (`SessionEnd`/`Stop`) for CLIs that don't persist
+  transcripts (codex, gemini, cursor-agent). Redundant for Claude.
+- **Scheduled evolution** via launchd/cron — trivial now that it's just a script.
+- **Project allowlist** for stricter scoping.
+- **Tiered engine** (local Ollama → `claude -p` fallback) if offline/cost-private
+  runs become desirable.
+
+---
+
+## Related Documents
+
+- [2026-06-07 SkillClaw Integration (original)](2026-06-07-skillclaw-integration-design.md)
+- [docs/SKILLCLAW.md](../../SKILLCLAW.md)
+- [/skill-evolve skill](../../../.skillshare/skills/skill-evolve/SKILL.md)

--- a/tests/bats/skillclaw_config.bats
+++ b/tests/bats/skillclaw_config.bats
@@ -62,16 +62,12 @@ teardown() {
     assert_equal "$FILE_SKILLCLAW" "true"
 }
 
-@test "skillclaw.yml exists and has required keys" {
-    local f="$REPO_ROOT/configs/claude/config/skillclaw.yml"
-    [ -f "$f" ]
-    run python3 -c "import yaml,sys; c=yaml.safe_load(open('$f')); \
-        assert c['proxy']['port']==8765; \
-        assert c['storage']['root']=='~/.skillclaw'; \
-        assert c['evolve']['mode']=='workflow'; \
-        assert c['promotion']['branch_prefix']=='skillclaw/evolve-'; \
-        assert c['evolve']['provider']['primary']['base_url']; \
-        print('ok')"
-    assert_success
-    assert_output --partial "ok"
+@test "skillclaw.yml has no proxy or capture blocks" {
+    run python3 -c "import yaml; d=yaml.safe_load(open('$REPO_ROOT/configs/claude/config/skillclaw.yml')); assert 'proxy' not in d and 'capture' not in d"
+    [ "$status" -eq 0 ]
+}
+
+@test "skillclaw.yml defines ingest and claude-cli evolve engine" {
+    run python3 -c "import yaml; d=yaml.safe_load(open('$REPO_ROOT/configs/claude/config/skillclaw.yml')); assert d['ingest']['window_days']==30; assert d['evolve']['engine']=='claude-cli'; assert d['ingest']['settle_minutes']==5"
+    [ "$status" -eq 0 ]
 }

--- a/tests/bats/skillclaw_lib.bats
+++ b/tests/bats/skillclaw_lib.bats
@@ -33,9 +33,13 @@ teardown() {
     [ -d "$SKILLCLAW_HOME" ]
     [ -d "$SKILLCLAW_HOME/sessions" ]
     [ -d "$SKILLCLAW_HOME/skills" ]
-    local mode
-    mode=$(stat -c '%a' "$SKILLCLAW_HOME" 2>/dev/null || stat -f '%Lp' "$SKILLCLAW_HOME")
-    assert_equal "$mode" "700"
+    # Tier-1 honeypot: root AND subdirs must be 700 (session data may be unscrubbed).
+    local d
+    for d in "$SKILLCLAW_HOME" "$SKILLCLAW_HOME/sessions" "$SKILLCLAW_HOME/skills"; do
+        local mode
+        mode=$(stat -c '%a' "$d" 2>/dev/null || stat -f '%Lp' "$d")
+        assert_equal "$mode" "700"
+    done
 }
 
 @test "skillclaw_remove_wrappers strips the marker block" {
@@ -73,8 +77,21 @@ PROF
 }
 
 @test "disable still removes any legacy wrapper block (clean teardown)" {
-    run grep -q 'skillclaw_remove_wrappers' "$REPO_ROOT/bootstrap/lib/skillclaw.sh"
-    [ "$status" -eq 0 ]
+    local profile="$SANDBOX/.zshrc"
+    export SHELL_PROFILE_FILE="$profile"
+    cat > "$profile" << 'PROF'
+# keep me
+# >>> MANIFEST SKILLCLAW WRAPPERS >>>
+claude() { echo proxy; }
+# <<< MANIFEST SKILLCLAW WRAPPERS <<<
+PROF
+    launchctl() { :; }
+    systemctl() { :; }
+    ENABLE_SKILLCLAW=false run skillclaw_apply_state
+    assert_success
+    run grep -c "MANIFEST SKILLCLAW WRAPPERS" "$profile"
+    assert_output "0"
+    grep -q "keep me" "$profile"
 }
 
 @test "apply_state enables transcript evolution without a daemon" {

--- a/tests/bats/skillclaw_lib.bats
+++ b/tests/bats/skillclaw_lib.bats
@@ -23,89 +23,61 @@ teardown() {
     [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
 }
 
-@test "skillclaw_init_storage creates dirs with 700 perms" {
-    run skillclaw_init_storage
+@test "skillclaw_apply_state enable creates storage with 700 perms" {
+    export SHELL_PROFILE_FILE="$SANDBOX/.zshrc"
+    touch "$SANDBOX/.zshrc"
+    launchctl() { :; }
+    systemctl() { :; }
+    ENABLE_SKILLCLAW=true run skillclaw_apply_state
     assert_success
     [ -d "$SKILLCLAW_HOME" ]
     [ -d "$SKILLCLAW_HOME/sessions" ]
     [ -d "$SKILLCLAW_HOME/skills" ]
     local mode
-    # GNU-first: `stat -c` works on Linux and fails cleanly on macOS (BSD), which
-    # then falls back to `stat -f '%Lp'`. The reverse order is broken on Linux,
-    # where `stat -f` means --file-system and pollutes stdout.
     mode=$(stat -c '%a' "$SKILLCLAW_HOME" 2>/dev/null || stat -f '%Lp' "$SKILLCLAW_HOME")
     assert_equal "$mode" "700"
-    local smode kmode
-    smode=$(stat -c '%a' "$SKILLCLAW_HOME/sessions" 2>/dev/null || stat -f '%Lp' "$SKILLCLAW_HOME/sessions")
-    kmode=$(stat -c '%a' "$SKILLCLAW_HOME/skills" 2>/dev/null || stat -f '%Lp' "$SKILLCLAW_HOME/skills")
-    assert_equal "$smode" "700"
-    assert_equal "$kmode" "700"
 }
 
-@test "skillclaw_write_wrappers writes a guarded, marker-delimited block" {
+@test "skillclaw_remove_wrappers strips the marker block" {
     local profile="$SANDBOX/.zshrc"
-    touch "$profile"
-    run skillclaw_write_wrappers "$profile"
-    assert_success
-    grep -q ">>> MANIFEST SKILLCLAW WRAPPERS >>>" "$profile"
-    grep -q "<<< MANIFEST SKILLCLAW WRAPPERS <<<" "$profile"
-    grep -q "SKILLCLAW_BYPASS" "$profile"
-    grep -q "max-time 0.3" "$profile"
-    grep -q 'claude()' "$profile"
-    grep -q 'codex()' "$profile"
-    # No hard top-level export of the base URL (must be per-invocation):
-    run grep -E '^export ANTHROPIC_BASE_URL=' "$profile"
-    assert_failure
-}
-
-@test "skillclaw_write_wrappers is idempotent (single block on re-run)" {
-    local profile="$SANDBOX/.zshrc"
-    touch "$profile"
-    skillclaw_write_wrappers "$profile"
-    skillclaw_write_wrappers "$profile"
-    run grep -c ">>> MANIFEST SKILLCLAW WRAPPERS >>>" "$profile"
-    assert_output "1"
-}
-
-@test "skillclaw_remove_wrappers strips the block" {
-    local profile="$SANDBOX/.zshrc"
-    touch "$profile"
-    skillclaw_write_wrappers "$profile"
+    cat > "$profile" << 'PROF'
+# something before
+# >>> MANIFEST SKILLCLAW WRAPPERS >>>
+export SKILLCLAW_PORT="8765"
+claude() { echo proxy; }
+codex()  { echo proxy; }
+# <<< MANIFEST SKILLCLAW WRAPPERS <<<
+# something after
+PROF
     run skillclaw_remove_wrappers "$profile"
     assert_success
     run grep -c "MANIFEST SKILLCLAW WRAPPERS" "$profile"
     assert_output "0"
+    grep -q "something before" "$profile"
+    grep -q "something after" "$profile"
 }
 
-@test "skillclaw_daemon status reports stopped when no pid" {
-    export SKILLCLAW_PIDFILE="$SANDBOX/skillclaw.pid"
-    run skillclaw_daemon status
-    assert_failure
-    assert_output --partial "stopped"
-}
-
-@test "skillclaw_supervisor_unit emits launchd plist on darwin" {
-    run skillclaw_supervisor_unit darwin "$SANDBOX/out"
+@test "skillclaw_remove_wrappers is idempotent on clean profile" {
+    local profile="$SANDBOX/.zshrc"
+    echo "# no wrappers here" > "$profile"
+    run skillclaw_remove_wrappers "$profile"
     assert_success
-    [ -f "$SANDBOX/out" ]
-    grep -q "KeepAlive" "$SANDBOX/out"
-    grep -q "com.manifest.skillclaw" "$SANDBOX/out"
+    run skillclaw_remove_wrappers "$profile"
+    assert_success
 }
 
-@test "skillclaw_supervisor_unit emits systemd unit on linux" {
-    run skillclaw_supervisor_unit linux "$SANDBOX/out"
-    assert_success
-    grep -q "Restart=on-failure" "$SANDBOX/out"
+@test "skillclaw.sh no longer writes shell proxy wrappers" {
+    run grep -Ec 'ANTHROPIC_BASE_URL|OPENAI_BASE_URL|_skillclaw_run|skillclaw_daemon' \
+        "$REPO_ROOT/bootstrap/lib/skillclaw.sh"
+    [ "$output" -eq 0 ]
 }
 
-@test "skillclaw_apply_state disable removes wrappers and stops daemon" {
-    local profile="$SANDBOX/.zshrc"; touch "$profile"
-    export SHELL_PROFILE_FILE="$profile"
-    skillclaw_write_wrappers "$profile"
-    # stub daemon to avoid invoking real skillclaw
-    skillclaw_daemon() { echo "daemon $1"; }
-    ENABLE_SKILLCLAW=false run skillclaw_apply_state
-    assert_success
-    run grep -c "MANIFEST SKILLCLAW WRAPPERS" "$profile"
-    assert_output "0"
+@test "disable still removes any legacy wrapper block (clean teardown)" {
+    run grep -q 'skillclaw_remove_wrappers' "$REPO_ROOT/bootstrap/lib/skillclaw.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "apply_state enables transcript evolution without a daemon" {
+    run grep -Eq 'no daemon|transcript' "$REPO_ROOT/bootstrap/lib/skillclaw.sh"
+    [ "$status" -eq 0 ]
 }

--- a/tests/bats/skillclaw_promote.bats
+++ b/tests/bats/skillclaw_promote.bats
@@ -84,3 +84,15 @@ teardown() {
     grep -q "^name: skill-evolve$" "$f"
     grep -q "skillclaw_promote.sh" "$f"
 }
+
+@test "promote runs ingest+evolve scripts instead of the skillclaw binary" {
+  run grep -E 'skillclaw_(ingest|evolve)\.py' "$REPO_ROOT/configs/claude/scripts/skillclaw_promote.sh"
+  [ "$status" -eq 0 ]
+  run grep -c 'skillclaw evolve --mode workflow' "$REPO_ROOT/configs/claude/scripts/skillclaw_promote.sh"
+  [ "$output" -eq 0 ]
+}
+
+@test "promote warns when candidates are rejected" {
+  run grep -Ei 'failed schema validation|rejected' "$REPO_ROOT/configs/claude/scripts/skillclaw_promote.sh"
+  [ "$status" -eq 0 ]
+}

--- a/tests/python/test_skillclaw_evolve.py
+++ b/tests/python/test_skillclaw_evolve.py
@@ -85,3 +85,50 @@ def test_evolve_empty_sessions_is_clean_noop(tmp_path):
                         runner=lambda p: calls.append(p) or "NO_SKILLS")
     assert summary["candidates"] == 0
     assert calls == []                 # no sessions -> no model calls
+
+
+def test_evolve_shows_committed_library_not_output_dir(tmp_path):
+    # The model must see the REAL committed library (so it doesn't re-propose
+    # already-merged skills), not the evolved output dir.
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "s1.json").write_text(json.dumps(
+        {"session_id": "s1", "turns": [
+            {"role": "user", "blocks": [{"kind": "text", "text": "do thing"}]}]}))
+    committed = tmp_path / "committed"
+    (committed / "already-merged").mkdir(parents=True)
+    (committed / "already-merged" / "SKILL.md").write_text("---\nname: already-merged\n---\n")
+    template = tmp_path / "tpl.md"
+    template.write_text("LIB {{LIBRARY}} SESS {{SESSIONS}}")
+    evolved = tmp_path / "evolved"
+
+    seen = {}
+
+    def fake_runner(prompt):
+        seen["prompt"] = prompt
+        return "NO_SKILLS"
+
+    ev.evolve(sessions_dir, evolved, template, committed_dir=committed,
+              token_budget=100_000, runner=fake_runner)
+    assert "already-merged" in seen["prompt"]
+
+
+def test_evolve_multichunk_dedupes_candidates_by_name(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    big = "x" * 160_000  # each session ~40k tokens -> 2 sessions force 2 chunks at budget 50k
+    for i in range(2):
+        (sessions_dir / f"s{i}.json").write_text(json.dumps(
+            {"session_id": f"s{i}", "turns": [
+                {"role": "user", "blocks": [{"kind": "text", "text": big}]}]}))
+    template = tmp_path / "tpl.md"
+    template.write_text("{{LIBRARY}}{{SESSIONS}}")
+    evolved = tmp_path / "evolved"
+
+    # both chunks emit the same-named skill -> reduce must dedupe to one
+    out = ("~~~skill name=dup\n---\nname: dup\ndescription: d\n---\n# Dup\nstep\n~~~\n")
+    summary = ev.evolve(sessions_dir, evolved, template, token_budget=50_000,
+                        runner=lambda p: out)
+    assert summary["chunks"] >= 2
+    assert summary["candidates"] == 1
+    assert summary["written"] == ["dup"]

--- a/tests/python/test_skillclaw_evolve.py
+++ b/tests/python/test_skillclaw_evolve.py
@@ -33,3 +33,20 @@ def test_parse_candidates_extracts_skill_blocks():
 
 def test_parse_candidates_handles_no_skills():
     assert ev.parse_candidates("NO_SKILLS") == []
+
+
+def test_chunk_sessions_splits_over_budget():
+    big = "x" * 160_000
+    sessions = [{"session_id": f"s{i}",
+                 "turns": [{"role": "user", "blocks": [{"kind": "text", "text": big}]}]}
+                for i in range(3)]
+    chunks = ev.chunk_sessions(sessions, token_budget=100_000)
+    assert len(chunks) >= 2                       # 120k tokens total -> multiple chunks
+    assert sum(len(c) for c in chunks) == 3       # no session lost
+
+
+def test_chunk_sessions_single_chunk_under_budget():
+    sessions = [{"session_id": "s1",
+                 "turns": [{"role": "user", "blocks": [{"kind": "text", "text": "tiny"}]}]}]
+    chunks = ev.chunk_sessions(sessions, token_budget=100_000)
+    assert chunks == [sessions]

--- a/tests/python/test_skillclaw_evolve.py
+++ b/tests/python/test_skillclaw_evolve.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/claude/scripts"))
@@ -50,3 +51,37 @@ def test_chunk_sessions_single_chunk_under_budget():
                  "turns": [{"role": "user", "blocks": [{"kind": "text", "text": "tiny"}]}]}]
     chunks = ev.chunk_sessions(sessions, token_budget=100_000)
     assert chunks == [sessions]
+
+
+def test_evolve_uses_injected_runner_and_writes(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "s1.json").write_text(json.dumps(
+        {"session_id": "s1", "turns": [
+            {"role": "user", "blocks": [{"kind": "text", "text": "deploy steps"}]}]}))
+    template = tmp_path / "tpl.md"
+    template.write_text("LIB {{LIBRARY}} SESS {{SESSIONS}}")
+    evolved = tmp_path / "evolved"
+
+    def fake_runner(prompt):
+        assert "deploy steps" in prompt
+        return ("~~~skill name=deploy-flow\n---\nname: deploy-flow\n"
+                "description: how to deploy\n---\n# Deploy\nstep 1\n~~~\n")
+
+    summary = ev.evolve(sessions_dir, evolved, template, token_budget=100_000,
+                        runner=fake_runner)
+    assert summary["candidates"] == 1
+    assert (evolved / "deploy-flow" / "SKILL.md").read_text().startswith("---")
+
+
+def test_evolve_empty_sessions_is_clean_noop(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    template = tmp_path / "tpl.md"
+    template.write_text("{{LIBRARY}}{{SESSIONS}}")
+    evolved = tmp_path / "evolved"
+    calls = []
+    summary = ev.evolve(sessions_dir, evolved, template, token_budget=100_000,
+                        runner=lambda p: calls.append(p) or "NO_SKILLS")
+    assert summary["candidates"] == 0
+    assert calls == []                 # no sessions -> no model calls

--- a/tests/python/test_skillclaw_evolve.py
+++ b/tests/python/test_skillclaw_evolve.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/claude/scripts"))
+import skillclaw_evolve as ev  # noqa: E402
+
+TEMPLATE = "LIB:\n{{LIBRARY}}\nSESS:\n{{SESSIONS}}\n"
+
+
+def test_estimate_tokens_is_roughly_quarter_length():
+    assert ev.estimate_tokens("a" * 400) == 100
+
+
+def test_build_prompt_substitutes_sections():
+    sessions = [{"session_id": "s1", "turns": [
+        {"role": "user", "blocks": [{"kind": "text", "text": "do x"}]}]}]
+    prompt = ev.build_prompt(TEMPLATE, sessions, ["existing-skill"])
+    assert "existing-skill" in prompt
+    assert "do x" in prompt
+    assert "{{LIBRARY}}" not in prompt and "{{SESSIONS}}" not in prompt
+
+
+def test_parse_candidates_extracts_skill_blocks():
+    output = (
+        "~~~skill name=foo-bar\n"
+        "---\nname: foo-bar\ndescription: does foo\n---\n# Foo\nstep 1\n"
+        "~~~\n"
+    )
+    cands = ev.parse_candidates(output)
+    assert cands == [{"name": "foo-bar",
+                      "content": "---\nname: foo-bar\ndescription: does foo\n---\n# Foo\nstep 1\n"}]
+
+
+def test_parse_candidates_handles_no_skills():
+    assert ev.parse_candidates("NO_SKILLS") == []

--- a/tests/python/test_skillclaw_ingest.py
+++ b/tests/python/test_skillclaw_ingest.py
@@ -121,3 +121,47 @@ def test_is_settled():
     now = 1_000_000.0
     assert ing.is_settled(now - 600, now, settle_minutes=5) is True    # 10 min old
     assert ing.is_settled(now - 60, now, settle_minutes=5) is False    # 1 min old
+
+
+def _mk_transcript(d, name, mtime):
+    f = d / f"{name}.jsonl"
+    f.write_text(json.dumps({"type": "user", "sessionId": name,
+                             "message": {"role": "user", "content": "hi"}}) + "\n")
+    import os
+    os.utime(f, (mtime, mtime))
+    return f
+
+
+def test_ingest_writes_and_filters(tmp_path):
+    src = tmp_path / "projects" / "repo"
+    src.mkdir(parents=True)
+    out = tmp_path / "sessions"
+    state = tmp_path / ".state.json"
+    now = 1_000_000.0
+    _mk_transcript(src, "fresh", now - 3600)            # 1h old -> ingested
+    _mk_transcript(src, "stale", now - 50 * 86400)      # 50d old -> window-skipped
+    _mk_transcript(src, "active", now - 60)             # 1m old -> settle-skipped
+
+    summary = ing.ingest(tmp_path / "projects", out, state,
+                         window_days=30, settle_minutes=5,
+                         max_tool_output_chars=500, now=now)
+    assert summary["ingested"] == 1
+    assert summary["skipped_old"] == 1
+    assert summary["skipped_unsettled"] == 1
+    assert (out / "fresh.json").exists()
+
+
+def test_ingest_is_incremental(tmp_path):
+    src = tmp_path / "projects" / "repo"
+    src.mkdir(parents=True)
+    out = tmp_path / "sessions"
+    state = tmp_path / ".state.json"
+    now = 1_000_000.0
+    _mk_transcript(src, "one", now - 3600)
+    first = ing.ingest(tmp_path / "projects", out, state, window_days=30,
+                       settle_minutes=5, max_tool_output_chars=500, now=now)
+    assert first["ingested"] == 1
+    second = ing.ingest(tmp_path / "projects", out, state, window_days=30,
+                        settle_minutes=5, max_tool_output_chars=500, now=now)
+    assert second["ingested"] == 0
+    assert second["skipped_seen"] == 1

--- a/tests/python/test_skillclaw_ingest.py
+++ b/tests/python/test_skillclaw_ingest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/claude/scripts"))
@@ -67,3 +68,43 @@ def test_long_tool_use_input_values_are_truncated():
     assert tu["name"] == "Write"
     assert len(tu["input"]["content"]) < 600
     assert tu["input"]["file_path"] == "/a.txt"   # short values untouched
+
+
+def _write_jsonl(path, records):
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def test_parse_transcript_builds_session(tmp_path):
+    f = tmp_path / "sess-abc.jsonl"
+    _write_jsonl(f, [
+        {"type": "queue-operation", "operation": "enqueue"},   # noise, ignored
+        {"type": "user", "sessionId": "sess-abc", "cwd": "/repo", "gitBranch": "main",
+         "message": {"role": "user", "content": "fix the bug"}},
+        {"type": "assistant", "sessionId": "sess-abc",
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "done"}]}},
+    ])
+    rec = ing.parse_transcript(f)
+    assert rec["session_id"] == "sess-abc"
+    assert rec["cwd"] == "/repo"
+    assert rec["git_branch"] == "main"
+    assert len(rec["turns"]) == 2
+    assert rec["turns"][0] == {"role": "user", "blocks": [{"kind": "text", "text": "fix the bug"}]}
+
+
+def test_parse_transcript_tolerates_partial_trailing_line(tmp_path):
+    f = tmp_path / "sess-x.jsonl"
+    f.write_text(
+        json.dumps({"type": "user", "sessionId": "sess-x",
+                    "message": {"role": "user", "content": "hi"}}) + "\n"
+        + '{"type":"assistant","message":{"role":"assist'   # truncated, no newline
+    )
+    rec = ing.parse_transcript(f)        # must not raise
+    assert rec["session_id"] == "sess-x"
+    assert len(rec["turns"]) == 1
+
+
+def test_parse_transcript_returns_none_when_no_turns(tmp_path):
+    f = tmp_path / "empty.jsonl"
+    _write_jsonl(f, [{"type": "queue-operation"}, {"type": "attachment"}])
+    assert ing.parse_transcript(f) is None

--- a/tests/python/test_skillclaw_ingest.py
+++ b/tests/python/test_skillclaw_ingest.py
@@ -108,3 +108,16 @@ def test_parse_transcript_returns_none_when_no_turns(tmp_path):
     f = tmp_path / "empty.jsonl"
     _write_jsonl(f, [{"type": "queue-operation"}, {"type": "attachment"}])
     assert ing.parse_transcript(f) is None
+
+
+def test_within_window():
+    now = 1_000_000.0
+    day = 86400
+    assert ing.within_window(now - 5 * day, now, window_days=30) is True
+    assert ing.within_window(now - 40 * day, now, window_days=30) is False
+
+
+def test_is_settled():
+    now = 1_000_000.0
+    assert ing.is_settled(now - 600, now, settle_minutes=5) is True    # 10 min old
+    assert ing.is_settled(now - 60, now, settle_minutes=5) is False    # 1 min old

--- a/tests/python/test_skillclaw_ingest.py
+++ b/tests/python/test_skillclaw_ingest.py
@@ -28,3 +28,17 @@ def test_normalize_block_list_keeps_text_thinking_tooluse():
 def test_normalize_drops_empty_thinking():
     blocks = ing.normalize_content([{"type": "thinking", "thinking": "", "signature": "X"}])
     assert blocks == []
+
+
+def test_normalize_structured_tool_result_truncation_is_accurate():
+    # Non-string tool_result content must be JSON-serialized then truncated by
+    # _truncate (not pre-sliced), so the truncated flag + tail marker stay honest.
+    big = {"rows": ["y" * 1000]}
+    blocks = ing.normalize_content(
+        [{"type": "tool_result", "content": big, "is_error": False}],
+        max_tool_output_chars=500,
+    )
+    tr = blocks[0]
+    assert tr["kind"] == "tool_result"
+    assert tr["truncated"] is True
+    assert "truncated" in tr["output"]

--- a/tests/python/test_skillclaw_ingest.py
+++ b/tests/python/test_skillclaw_ingest.py
@@ -42,3 +42,28 @@ def test_normalize_structured_tool_result_truncation_is_accurate():
     assert tr["kind"] == "tool_result"
     assert tr["truncated"] is True
     assert "truncated" in tr["output"]
+
+
+def test_tool_result_output_is_truncated():
+    big = "x" * 5000
+    blocks = ing.normalize_content(
+        [{"type": "tool_result", "content": big, "is_error": False}],
+        max_tool_output_chars=500,
+    )
+    tr = blocks[0]
+    assert tr["kind"] == "tool_result"
+    assert tr["truncated"] is True
+    assert len(tr["output"]) < 600           # 500 + marker, not 5000
+    assert "truncated" in tr["output"]
+
+
+def test_long_tool_use_input_values_are_truncated():
+    blocks = ing.normalize_content(
+        [{"type": "tool_use", "name": "Write",
+          "input": {"file_path": "/a.txt", "content": "y" * 5000}}],
+        max_tool_output_chars=500,
+    )
+    tu = blocks[0]
+    assert tu["name"] == "Write"
+    assert len(tu["input"]["content"]) < 600
+    assert tu["input"]["file_path"] == "/a.txt"   # short values untouched

--- a/tests/python/test_skillclaw_ingest.py
+++ b/tests/python/test_skillclaw_ingest.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/claude/scripts"))
+import skillclaw_ingest as ing  # noqa: E402
+
+
+def test_normalize_string_content():
+    blocks = ing.normalize_content("hello world")
+    assert blocks == [{"kind": "text", "text": "hello world"}]
+
+
+def test_normalize_block_list_keeps_text_thinking_tooluse():
+    content = [
+        {"type": "text", "text": "I'll run it"},
+        {"type": "thinking", "thinking": "reasoning here", "signature": "SIG"},
+        {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+    ]
+    blocks = ing.normalize_content(content)
+    assert {"kind": "text", "text": "I'll run it"} in blocks
+    assert {"kind": "thinking", "text": "reasoning here"} in blocks
+    tu = [b for b in blocks if b["kind"] == "tool_use"][0]
+    assert tu["name"] == "Bash"
+    assert tu["input"] == {"command": "ls"}
+    assert all("signature" not in b for b in blocks)
+
+
+def test_normalize_drops_empty_thinking():
+    blocks = ing.normalize_content([{"type": "thinking", "thinking": "", "signature": "X"}])
+    assert blocks == []

--- a/tests/python/test_skillclaw_promote.py
+++ b/tests/python/test_skillclaw_promote.py
@@ -55,3 +55,15 @@ def test_main_emits_promotable_json(tmp_path, capsys):
     payload = json.loads(capsys.readouterr().out)
     names = {c["name"] for c in payload["promote"]}
     assert "alpha" in names
+
+
+def test_rejected_candidates_are_copied_to_rejected_dir(tmp_path):
+    evolved = tmp_path / "evolved"
+    committed = tmp_path / "committed"
+    rejected = tmp_path / "rejected"
+    _skill(committed, "_", VALID)                       # committed dir exists
+    _skill(evolved, "broken", "# no frontmatter\n")     # invalid -> rejected
+    rc = promote.main([str(evolved), str(committed), "--rejected-dir", str(rejected)])
+    assert rc == 0
+    # the rejected SKILL.md must have been copied for inspection
+    assert (rejected / "broken" / "SKILL.md").exists()


### PR DESCRIPTION
## Summary

Replaces SkillClaw's inline capture **proxy** with **passive ingestion of Claude Code transcripts**, fixing incompatibility with the Claude Max OAuth flow. The proxy sat inline (`ANTHROPIC_BASE_URL`/`OPENAI_BASE_URL` → `127.0.0.1`) and broke under Max — the live install had captured **0 sessions**. This branch deletes the proxy/daemon/wrappers and feeds the existing PR-gated evolve/promote pipeline from transcripts already on disk.

- **Capture** → passive: `skillclaw_ingest.py` reads `~/.claude/projects/**/*.jsonl`, normalizes turns, truncates noisy tool output (incl. base64), applies `window_days`/`settle_minutes` filters, and tracks processed sessions incrementally. Nothing inline; works natively with Max.
- **Evolve** → `skillclaw_evolve.py` distills `SKILL.md` candidates via `claude -p` (Max-backed, no API key, no OpenAI), with **map-reduce chunking** under `token_budget` to stay clear of the 200k context limit. The committed library is shown to the model so it doesn't re-propose merged skills.
- **Promote** → `skillclaw_promote.sh` drives ingest → scrub → evolve → classify → PR-gate (Option A: one open PR). Rejected candidates are copied to `~/.skillclaw/skills/rejected/` with a prominent warning (never silently dropped); classify path hardened against non-JSON under `set -e`.
- **Bootstrap** → `--enable-skillclaw` now just creates chmod-700 storage (root + subdirs, Tier-1 honeypot) and tears down any legacy proxy install (wrappers + launchd unit). No daemon, no pip install; dangling `install_skillclaw` caller removed.
- **Config/Docs** → `skillclaw.yml` rewritten (proxy/capture out; ingest/evolve knobs in). `docs/SKILLCLAW.md` and the reference docs (CONFIGURATION, ARCHITECTURE_DIAGRAMS incl. Mermaid, TROUBLESHOOTING, READMEs) purged of the proxy model. Historical `2026-06-07` plan/spec left intact as superseded records.

Built via spec → plan → subagent-driven TDD (13 tasks). Design: `docs/superpowers/specs/2026-06-08-skillclaw-proxy-free-evolve-design.md`. Four code-review rounds; all findings fixed (honest truncation flag, `set -e` hardening, storage-subdir perms regression, committed-library semantics).

## Test Plan

- [x] `pytest tests/python/` — **160 passed** (+18 new: ingest/evolve/promote)
- [x] `bats tests/bats/` — **189 passed, 0 failures**
- [x] `shellcheck` clean — promote.sh, bootstrap.sh, bootstrap/lib/{skillclaw,config}.sh
- [x] `yamllint` clean — skillclaw.yml, services.yml
- [x] No proxy/daemon/8765/BASE_URL references remain in non-historical files
- [ ] Manual smoke: `~/.claude/scripts/skillclaw_promote.sh` (dry-run) over real transcripts, then `--apply` opens one review PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)