### PR TITLE
/spec-review: independent Gemini cross-reference of project artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ node_modules/
 *.tmp
 .tmp-*
 .tmp-*/
+
+# spec-review runtime (feedback, content-hash, lock, error log)
+.spec-review/

--- a/.skillshare/skills/spec-review/SKILL.md
+++ b/.skillshare/skills/spec-review/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: spec-review
+description: |
+  Cross-reference a project's spec / plan / tasks artifacts for internal
+  consistency using an independent model (Gemini), and surface structured
+  remediation guidance (Location / Gap / Recommended Direction / Reason Why).
+  Analysis-only — never edits artifacts. Works with both speckit
+  (spec.md/plan.md/tasks.md) and superpowers (design + plan-with-embedded-tasks)
+  layouts. Auto-discovers artifacts, or pass explicit paths.
+---
+
+# Spec Review (Gemini cross-reference)
+
+Run an independent, analysis-only consistency check across the project's planning
+artifacts. A second model (Gemini) reviews what Claude authored — catching
+structural blind spots that self-review misses.
+
+## How to run
+
+```bash
+# Auto-discover spec/plan/tasks under the current project and review:
+~/.claude/scripts/spec_review.sh
+
+# Explicit artifacts:
+~/.claude/scripts/spec_review.sh --spec ./spec.md --plan ./plan.md --tasks ./tasks.md
+
+# Machine-readable:
+~/.claude/scripts/spec_review.sh --format json
+```
+
+Findings print as a tree of `CLARIFICATION REQUIRED` blocks, or
+`✓ No inconsistencies found.` Requires the `gemini` CLI (logged in). This skill is
+analysis-only; apply the recommendations yourself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,7 @@ The following slash commands are available in Claude Code:
 | `sync-skills` | Sync .skillshare/skills/ to all home targets (daily skill dev workflow) | NO |
 | `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run default) | NO |
 | `/pass-cli` | Retrieve credentials from Proton Pass vaults via `pass-cli` agent CLI | NO |
+| `/spec-review` | Independent Gemini cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; engine: `~/.claude/scripts/spec_review.sh` (`--spec/--plan/--tasks/--silent/--format`) | NO |
 
 ## Testing Changes
 

--- a/configs/claude/CLAUDE.md
+++ b/configs/claude/CLAUDE.md
@@ -156,6 +156,7 @@ These integrate with the parallel agent orchestration framework.
 | `/branch-clean` | Prune merged/gone/stale branches safely (dry-run, local-only) | CONDITIONAL |
 | `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run default) | NO |
 | `/pass-cli` | Retrieve credentials from Proton Pass (auth is the user's step; PAT never stored) | NO |
+| `/spec-review` | Independent Gemini cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; engine: `~/.claude/scripts/spec_review.sh` (`--spec/--plan/--tasks/--silent/--format`) | NO |
 
 ### Command Usage
 

--- a/configs/claude/prompts/spec_review.md
+++ b/configs/claude/prompts/spec_review.md
@@ -1,0 +1,25 @@
+<!-- configs/claude/prompts/spec_review.md -->
+# Project Artifact Cross-Reference
+
+You are an independent reviewer cross-referencing a project's planning artifacts
+for **internal consistency**. You did not write them. Find places where the
+artifacts contradict each other or leave a decision dangerously ambiguous.
+
+When `tasks` is absent, the task breakdown is embedded inside the plan — review
+the plan's task section against the spec and plan prose.
+
+## Artifacts
+
+{{ARTIFACTS}}
+
+## Output
+
+For EACH inconsistency, output one block in EXACTLY this format:
+
+⚠️  CLARIFICATION REQUIRED: <short title>
+   ├─ Location: <artifact A> vs <artifact B>
+   ├─ The Gap: <one sentence>
+   ├─ Recommended Direction: <concrete remediation>
+   └─ Reason Why: <which constraint it violates / why it matters>
+
+If the artifacts are consistent, output the single token: NO_ISSUES

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -85,14 +85,18 @@ assemble_prompt() {
     done
     # Substitute {{ARTIFACTS}} inline: print lines before the marker, inject
     # artifact file contents, then continue with lines after the marker.
+    # Capture awk's status so the temp file is removed even on failure (set -e
+    # would otherwise abort before cleanup). bash 3.2-safe (no RETURN trap).
+    local rc=0
     awk -v artfile="$artfile" '
         /\{\{ARTIFACTS\}\}/ {
             while ((getline ln < artfile) > 0) print ln
             next
         }
         { print }
-    ' "$template"
+    ' "$template" || rc=$?
     rm -f "$artfile"
+    return "$rc"
 }
 
 main() {

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -121,6 +121,29 @@ format_findings() {
     fi
 }
 
+# Stable combined-content hash of the given files.
+content_hash() {
+    cat "$@" 2>/dev/null | shasum | awk '{print $1}'
+}
+
+# Gating for silent/hook mode. Returns 0 (run) or 1 (skip, with reason on stdout).
+# Records the hash in $SPEC_REVIEW_STATE/.last-run only when it decides to run.
+should_run_silent() {
+    local root="${1:-.}" state="$SPEC_REVIEW_STATE"
+    local paths; paths=$(discover_artifacts "$root" | cut -f2)
+    local count; count=$(printf '%s\n' "$paths" | grep -c . || true)
+    if [[ "$count" -lt 2 ]]; then echo "skip: fewer than 2 artifacts"; return 1; fi
+    mkdir -p "$state"
+    local now prev="$state/.last-run"
+    # shellcheck disable=SC2086
+    now="$(content_hash $paths)"
+    if [[ -f "$prev" && "$(cat "$prev")" == "$now" ]]; then
+        echo "skip: unchanged"; return 1
+    fi
+    echo "$now" > "$prev"
+    return 0
+}
+
 main() {
     if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then usage; return 0; fi
     parse_args "$@" || return $?

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -106,11 +106,18 @@ run_gemini() {
     printf '%s' "$prompt" | "$SPEC_REVIEW_GEMINI" -p "Cross-reference the artifacts above per the instructions; output only the specified blocks or NO_ISSUES."
 }
 
-# format_findings RAW FORMAT -> formatted output. NO_ISSUES -> clean message.
+# format_findings RAW FORMAT [COUNT] -> formatted output. NO_ISSUES -> clean
+# message (with the artifact count when COUNT is supplied).
 format_findings() {
-    local raw="$1" fmt="${2:-tree}"
+    local raw="$1" fmt="${2:-tree}" count="${3:-}"
     if [[ -z "${raw//[[:space:]]/}" || "$raw" == *NO_ISSUES* ]]; then
-        if [[ "$fmt" == "json" ]]; then echo "[]"; else echo "✓ No inconsistencies found."; fi
+        if [[ "$fmt" == "json" ]]; then
+            echo "[]"
+        elif [[ -n "$count" ]]; then
+            echo "✓ No inconsistencies found across ${count} artifacts."
+        else
+            echo "✓ No inconsistencies found."
+        fi
         return 0
     fi
     if [[ "$fmt" == "json" ]]; then
@@ -146,16 +153,29 @@ should_run_silent() {
     return 0
 }
 
-# review ROOT FORMAT -> discover, assemble, run gemini, format. Used on-demand.
+# Emit role<TAB>path lines from explicit --spec/--plan/--tasks if any were given,
+# else auto-discover under ROOT.
+resolve_artifacts() {
+    local root="${1:-.}"
+    if [[ -n "$SPEC" || -n "$PLAN" || -n "$TASKS" ]]; then
+        [[ -n "$SPEC" ]]  && printf 'spec\t%s\n'  "$SPEC"
+        [[ -n "$PLAN" ]]  && printf 'plan\t%s\n'  "$PLAN"
+        [[ -n "$TASKS" ]] && printf 'tasks\t%s\n' "$TASKS"
+        return 0
+    fi
+    discover_artifacts "$root"
+}
+
+# review ROOT FORMAT -> resolve, assemble, run gemini, format. Used on-demand.
 review() {
     local root="${1:-.}" fmt="${2:-tree}"
     local arts=() line
-    while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(discover_artifacts "$root")
+    while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(resolve_artifacts "$root")
     if [[ "${#arts[@]}" -eq 0 ]]; then echo "spec-review: nothing to review (no artifacts found)"; return 0; fi
     echo "[spec-review] Cross-referencing project artifacts with Gemini…"
     local prompt raw; prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]}")"
     raw="$(run_gemini "$prompt")"
-    format_findings "$raw" "$fmt"
+    format_findings "$raw" "$fmt" "${#arts[@]}"
 }
 
 # The actual review for hook mode, fail-open. Writes feedback.md atomically.

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -130,13 +130,15 @@ content_hash() {
 # Records the hash in $SPEC_REVIEW_STATE/.last-run only when it decides to run.
 should_run_silent() {
     local root="${1:-.}" state="$SPEC_REVIEW_STATE"
-    local paths; paths=$(discover_artifacts "$root" | cut -f2)
-    local count; count=$(printf '%s\n' "$paths" | grep -c . || true)
-    if [[ "$count" -lt 2 ]]; then echo "skip: fewer than 2 artifacts"; return 1; fi
+    # Collect paths into an array (bash 3.2-safe) so paths with spaces hash
+    # correctly and the count is exact (no printf/grep off-by-one).
+    local paths=() line
+    while IFS= read -r line; do [[ -n "$line" ]] && paths+=("$line"); done \
+        < <(discover_artifacts "$root" | cut -f2)
+    if [[ "${#paths[@]}" -lt 2 ]]; then echo "skip: fewer than 2 artifacts"; return 1; fi
     mkdir -p "$state"
     local now prev="$state/.last-run"
-    # shellcheck disable=SC2086
-    now="$(content_hash $paths)"
+    now="$(content_hash "${paths[@]}")"
     if [[ -f "$prev" && "$(cat "$prev")" == "$now" ]]; then
         echo "skip: unchanged"; return 1
     fi

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -99,6 +99,28 @@ assemble_prompt() {
     return "$rc"
 }
 
+# run_gemini PROMPT -> raw gemini output. stdin carries the prompt body; the -p
+# instruction is short. Errors propagate (caller decides fail-open vs surface).
+run_gemini() {
+    local prompt="$1"
+    printf '%s' "$prompt" | "$SPEC_REVIEW_GEMINI" -p "Cross-reference the artifacts above per the instructions; output only the specified blocks or NO_ISSUES."
+}
+
+# format_findings RAW FORMAT -> formatted output. NO_ISSUES -> clean message.
+format_findings() {
+    local raw="$1" fmt="${2:-tree}"
+    if [[ -z "${raw//[[:space:]]/}" || "$raw" == *NO_ISSUES* ]]; then
+        if [[ "$fmt" == "json" ]]; then echo "[]"; else echo "✓ No inconsistencies found."; fi
+        return 0
+    fi
+    if [[ "$fmt" == "json" ]]; then
+        # Minimal: wrap raw blocks as a single JSON string element (tolerant).
+        printf '[%s]\n' "$(printf '%s' "$raw" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+    else
+        printf '%s\n' "$raw"
+    fi
+}
+
 main() {
     if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then usage; return 0; fi
     parse_args "$@" || return $?

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -146,9 +146,55 @@ should_run_silent() {
     return 0
 }
 
+# review ROOT FORMAT -> discover, assemble, run gemini, format. Used on-demand.
+review() {
+    local root="${1:-.}" fmt="${2:-tree}"
+    local arts=() line
+    while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(discover_artifacts "$root")
+    if [[ "${#arts[@]}" -eq 0 ]]; then echo "spec-review: nothing to review (no artifacts found)"; return 0; fi
+    echo "[spec-review] Cross-referencing project artifacts with Gemini…"
+    local prompt raw; prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]}")"
+    raw="$(run_gemini "$prompt")"
+    format_findings "$raw" "$fmt"
+}
+
+# The actual review for hook mode, fail-open. Writes feedback.md atomically.
+_silent_review_inline() {
+    local root="$1" state="$SPEC_REVIEW_STATE"
+    mkdir -p "$state"
+    local arts=() line prompt raw
+    while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(discover_artifacts "$root")
+    prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]}")"
+    if ! raw="$(run_gemini "$prompt" 2>>"$state/error.log")"; then
+        return 0   # fail-open: gemini failed, never block
+    fi
+    format_findings "$raw" "tree" > "$state/feedback.md.tmp" && mv "$state/feedback.md.tmp" "$state/feedback.md"
+}
+
+# Silent/hook entry: gate, single-flight lock, detach the gemini call.
+run_silent() {
+    local root="${1:-.}" state="$SPEC_REVIEW_STATE"
+    if ! should_run_silent "$root" >/dev/null; then
+        return 0   # gate said skip (fewer than 2 artifacts / unchanged)
+    fi
+    mkdir -p "$state"
+    # Single-flight lock: skip if a review is already in flight.
+    if ! mkdir "$state/.lock" 2>/dev/null; then return 0; fi
+    if [[ -n "$SPEC_REVIEW_NO_DETACH" ]]; then
+        _silent_review_inline "$root"; rmdir "$state/.lock" 2>/dev/null || true
+    else
+        # Detach so the agent loop never waits on gemini; release lock when done.
+        ( _silent_review_inline "$root"; rmdir "$state/.lock" 2>/dev/null || true ) >/dev/null 2>&1 &
+        disown 2>/dev/null || true
+    fi
+    return 0
+}
+
 main() {
     if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then usage; return 0; fi
     parse_args "$@" || return $?
+    if [[ "$SILENT" == true ]]; then run_silent "$ROOT"; return 0; fi
+    review "$ROOT" "$FORMAT"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -70,6 +70,31 @@ discover_artifacts() {
     return 0
 }
 
+# assemble_prompt TEMPLATE "role\tpath"...  ->  full prompt on stdout
+assemble_prompt() {
+    local template="$1"; shift
+    local artfile line role path
+    artfile="$(mktemp)"
+    for line in "$@"; do
+        role="${line%%$'\t'*}"; path="${line#*$'\t'}"
+        {
+            printf '=== %s: %s ===\n' "$(printf '%s' "$role" | tr '[:lower:]' '[:upper:]')" "$path"
+            cat "$path"
+            printf '\n\n'
+        } >> "$artfile"
+    done
+    # Substitute {{ARTIFACTS}} inline: print lines before the marker, inject
+    # artifact file contents, then continue with lines after the marker.
+    awk -v artfile="$artfile" '
+        /\{\{ARTIFACTS\}\}/ {
+            while ((getline ln < artfile) > 0) print ln
+            next
+        }
+        { print }
+    ' "$template"
+    rm -f "$artfile"
+}
+
 main() {
     if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then usage; return 0; fi
     parse_args "$@" || return $?

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# spec_review.sh — cross-reference spec/plan/tasks artifacts for consistency via
+# the gemini CLI. Analysis-only: never edits artifacts. Front-end-agnostic — the
+# /spec-review skill, the save hook, and any future CLI all wrap this script.
+#
+# Usage: spec_review.sh [--spec F] [--plan F] [--tasks F] [--silent] [--format tree|json] [ROOT]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPEC_REVIEW_GEMINI="${SPEC_REVIEW_GEMINI:-gemini}"
+SPEC_REVIEW_TEMPLATE="${SPEC_REVIEW_TEMPLATE:-${SCRIPT_DIR}/../prompts/spec_review.md}"
+SPEC_REVIEW_STATE="${SPEC_REVIEW_STATE:-.spec-review}"
+SPEC_REVIEW_NO_DETACH="${SPEC_REVIEW_NO_DETACH:-}"
+
+SPEC=""; PLAN=""; TASKS=""; SILENT=false; FORMAT="tree"; ROOT="."
+
+err() { echo "spec-review: $*" >&2; }
+usage() {
+    cat <<'EOF'
+spec-review — cross-reference spec/plan/tasks for consistency (Gemini, analysis-only)
+
+Usage: spec_review.sh [--spec F] [--plan F] [--tasks F] [--silent] [--format tree|json] [ROOT]
+
+  --spec/--plan/--tasks F  explicit artifact paths (else auto-discover under ROOT)
+  --silent                 hook mode: hash-gated, detached, writes .spec-review/feedback.md
+  --format tree|json       output format (default: tree)
+  ROOT                     project root to discover in (default: .)
+EOF
+}
+
+parse_args() {
+    # shellcheck disable=SC2034  # vars consumed by future discovery/invoke tasks
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --spec)  SPEC="$2"; shift 2 ;;
+            --plan)  PLAN="$2"; shift 2 ;;
+            --tasks) TASKS="$2"; shift 2 ;;
+            --silent) SILENT=true; shift ;;
+            --format) FORMAT="$2"; shift 2 ;;
+            -h|--help) usage; return 0 ;;
+            -*) err "unknown flag: $1"; return 2 ;;
+            *) ROOT="$1"; shift ;;
+        esac
+    done
+}
+
+main() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then usage; return 0; fi
+    parse_args "$@" || return $?
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -164,6 +164,7 @@ _silent_review_inline() {
     mkdir -p "$state"
     local arts=() line prompt raw
     while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(discover_artifacts "$root")
+    [[ "${#arts[@]}" -eq 0 ]] && return 0   # defensive: nothing to review (set -u safe)
     prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]}")"
     if ! raw="$(run_gemini "$prompt" 2>>"$state/error.log")"; then
         return 0   # fail-open: gemini failed, never block
@@ -178,13 +179,20 @@ run_silent() {
         return 0   # gate said skip (fewer than 2 artifacts / unchanged)
     fi
     mkdir -p "$state"
+    # Self-heal a stale lock left by a crashed prior run (older than 10 min), so a
+    # killed detached review can never permanently disable the hook.
+    if [[ -d "$state/.lock" ]] && find "$state/.lock" -maxdepth 0 -mmin +10 2>/dev/null | grep -q .; then
+        rmdir "$state/.lock" 2>/dev/null || true
+    fi
     # Single-flight lock: skip if a review is already in flight.
     if ! mkdir "$state/.lock" 2>/dev/null; then return 0; fi
+    # `|| true` after the review so an unexpected non-zero (disk full, etc.) never
+    # skips the lock release or breaks the fail-open contract.
     if [[ -n "$SPEC_REVIEW_NO_DETACH" ]]; then
-        _silent_review_inline "$root"; rmdir "$state/.lock" 2>/dev/null || true
+        _silent_review_inline "$root" || true; rmdir "$state/.lock" 2>/dev/null || true
     else
         # Detach so the agent loop never waits on gemini; release lock when done.
-        ( _silent_review_inline "$root"; rmdir "$state/.lock" 2>/dev/null || true ) >/dev/null 2>&1 &
+        ( _silent_review_inline "$root" || true; rmdir "$state/.lock" 2>/dev/null || true ) >/dev/null 2>&1 &
         disown 2>/dev/null || true
     fi
     return 0

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -44,6 +44,32 @@ parse_args() {
     done
 }
 
+# Print "role\tpath" lines for discovered artifacts. speckit: spec/plan/tasks.md
+# (cwd or specs/<n>/). superpowers: newest *-design.md + newest plans/*.md (tasks
+# are embedded in the plan, so no tasks line). Newest = name sort (date-prefixed).
+discover_artifacts() {
+    local root="${1:-.}" sp pl
+    # speckit: specs/<n>/ first, then cwd
+    # shellcheck disable=SC2012  # ls used intentionally; files are date-prefixed, no special chars
+    sp=$(ls -1 "$root"/specs/*/spec.md 2>/dev/null | sort | tail -1 || true)
+    [[ -z "$sp" && -f "$root/spec.md" ]] && sp="$root/spec.md"
+    if [[ -n "$sp" ]]; then
+        local d; d="$(dirname "$sp")"
+        printf 'spec\t%s\n' "$sp"
+        [[ -f "$d/plan.md" ]]  && printf 'plan\t%s\n'  "$d/plan.md"
+        [[ -f "$d/tasks.md" ]] && printf 'tasks\t%s\n' "$d/tasks.md"
+        return 0
+    fi
+    # superpowers: newest design + newest plan (tasks embedded in plan)
+    # shellcheck disable=SC2012  # ls used intentionally; files are date-prefixed, no special chars
+    sp=$(ls -1 "$root"/docs/superpowers/specs/*-design.md 2>/dev/null | sort | tail -1 || true)
+    # shellcheck disable=SC2012  # ls used intentionally; files are date-prefixed, no special chars
+    pl=$(ls -1 "$root"/docs/superpowers/plans/*.md 2>/dev/null | sort | tail -1 || true)
+    [[ -n "$sp" ]] && printf 'spec\t%s\n' "$sp"
+    [[ -n "$pl" ]] && printf 'plan\t%s\n' "$pl"
+    return 0
+}
+
 main() {
     if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then usage; return 0; fi
     parse_args "$@" || return $?

--- a/configs/claude/settings.local.json
+++ b/configs/claude/settings.local.json
@@ -40,6 +40,15 @@
             "command": "~/.claude/scripts/version_pin_hook.sh"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/spec_review.sh --silent"
+          }
+        ]
       }
     ]
   },

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -47,6 +47,7 @@ Manifest ships with 19 slash commands and 1 CLI tool (34 skills total, 1 auto-tr
 | `/branch-clean` | Prune merged/gone/stale branches safely (dry-run by default, local-only) | CONDITIONAL (--apply) |
 | `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default); requires SkillClaw enabled | NEVER |
 | `/pass-cli` | Retrieve credentials from Proton Pass vaults via `pass-cli` agent CLI | NEVER |
+| `/spec-review` | Independent Gemini cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; works with speckit and superpowers layouts; silent-mode findings land in `.spec-review/feedback.md` | NO |
 
 **CLI tool** (installed to `~/.local/bin/`):
 

--- a/docs/superpowers/plans/2026-06-08-spec-review.md
+++ b/docs/superpowers/plans/2026-06-08-spec-review.md
@@ -1,0 +1,890 @@
+# /spec-review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** An analysis-only `/spec-review` skill + reusable engine script that cross-references spec/plan/tasks artifacts for consistency via the `gemini` CLI, with an optional fail-open, content-hash-debounced, detached PostToolUse save hook.
+
+**Architecture:** One front-end-agnostic engine (`spec_review.sh`) + a prompt template drive `gemini -p`; a `/spec-review` SKILL.md is the on-demand entry point; a PostToolUse hook runs `spec_review.sh --silent` which gates on a content hash + single-flight lock and detaches the `gemini` call so it never stalls the agent loop. Gemini is invoked through one injectable seam (`SPEC_REVIEW_GEMINI`) so tests never hit the network.
+
+**Tech Stack:** Bash (3.2-compatible, `set -euo pipefail`), `gemini` CLI, `shasum`, bats (bats-support/bats-assert), Markdown, JSON (settings).
+
+---
+
+## Reference: engine contract (used consistently across tasks)
+
+`configs/claude/scripts/spec_review.sh` defines these functions and a sourcing guard so bats can source it and test functions in isolation:
+
+```bash
+SPEC_REVIEW_GEMINI="${SPEC_REVIEW_GEMINI:-gemini}"   # injectable engine seam
+SPEC_REVIEW_TEMPLATE="${SPEC_REVIEW_TEMPLATE:-<script_dir>/../prompts/spec_review.md}"
+SPEC_REVIEW_STATE="${SPEC_REVIEW_STATE:-.spec-review}" # runtime dir (gitignored)
+SPEC_REVIEW_NO_DETACH="${SPEC_REVIEW_NO_DETACH:-}"     # set => run gemini inline (tests)
+
+discover_artifacts ROOT        # prints "role\tpath" lines: spec/plan/tasks (tasks optional)
+assemble_prompt TEMPLATE FILE… # prints the full prompt (template + role-labelled artifacts)
+run_gemini PROMPT              # pipes PROMPT to "$SPEC_REVIEW_GEMINI" -p "<instruction>"; prints raw output
+format_findings RAW FORMAT     # RAW gemini output -> tree (default) or json
+content_hash FILE…            # stable hash of combined artifact contents
+should_run_silent ROOT         # 0/skip-reason gating: >=2 artifacts, hash changed, lock free
+review ROOT FORMAT             # orchestrate: discover -> assemble -> run -> format
+main "$@"                       # arg parse; guarded by [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+```
+
+The sourcing guard at the bottom:
+
+```bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi
+```
+
+---
+
+## File Structure
+
+**Create:**
+- `configs/claude/scripts/spec_review.sh` — the engine
+- `configs/claude/prompts/spec_review.md` — the gemini prompt template
+- `.skillshare/skills/spec-review/SKILL.md` — the `/spec-review` on-demand entry point
+- `tests/bats/spec_review.bats` — engine tests
+
+**Modify:**
+- `configs/claude/settings.local.json` — append the PostToolUse hook
+- `.gitignore` — add `.spec-review/`
+- `docs/COMMANDS.md` — add `/spec-review` to the command reference (if present)
+
+---
+
+## Task 1: Scaffold engine — arg parsing, seams, sourcing guard
+
+**Files:**
+- Create: `configs/claude/scripts/spec_review.sh`
+- Create: `tests/bats/spec_review.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+# tests/bats/spec_review.bats
+#!/usr/bin/env bats
+# Tests for configs/claude/scripts/spec_review.sh
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SCRIPT="$REPO_ROOT/configs/claude/scripts/spec_review.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    SANDBOX=$(mktemp -d "$BATS_TMPDIR/spec_review.XXXXXX")
+}
+
+teardown() {
+    [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+@test "spec_review.sh is executable and prints usage on --help" {
+    run bash "$SCRIPT" --help
+    assert_success
+    assert_output --partial "spec-review"
+    assert_output --partial "--silent"
+}
+
+@test "spec_review.sh rejects an unknown flag" {
+    run bash "$SCRIPT" --bogus
+    assert_failure
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: FAIL — script does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```bash
+#!/usr/bin/env bash
+# spec_review.sh — cross-reference spec/plan/tasks artifacts for consistency via
+# the gemini CLI. Analysis-only: never edits artifacts. Front-end-agnostic — the
+# /spec-review skill, the save hook, and any future CLI all wrap this script.
+#
+# Usage: spec_review.sh [--spec F] [--plan F] [--tasks F] [--silent] [--format tree|json] [ROOT]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPEC_REVIEW_GEMINI="${SPEC_REVIEW_GEMINI:-gemini}"
+SPEC_REVIEW_TEMPLATE="${SPEC_REVIEW_TEMPLATE:-${SCRIPT_DIR}/../prompts/spec_review.md}"
+SPEC_REVIEW_STATE="${SPEC_REVIEW_STATE:-.spec-review}"
+SPEC_REVIEW_NO_DETACH="${SPEC_REVIEW_NO_DETACH:-}"
+
+SPEC=""; PLAN=""; TASKS=""; SILENT=false; FORMAT="tree"; ROOT="."
+
+err() { echo "spec-review: $*" >&2; }
+usage() {
+    cat <<'EOF'
+spec-review — cross-reference spec/plan/tasks for consistency (Gemini, analysis-only)
+
+Usage: spec_review.sh [--spec F] [--plan F] [--tasks F] [--silent] [--format tree|json] [ROOT]
+
+  --spec/--plan/--tasks F  explicit artifact paths (else auto-discover under ROOT)
+  --silent                 hook mode: hash-gated, detached, writes .spec-review/feedback.md
+  --format tree|json       output format (default: tree)
+  ROOT                     project root to discover in (default: .)
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --spec)  SPEC="$2"; shift 2 ;;
+            --plan)  PLAN="$2"; shift 2 ;;
+            --tasks) TASKS="$2"; shift 2 ;;
+            --silent) SILENT=true; shift ;;
+            --format) FORMAT="$2"; shift 2 ;;
+            -h|--help) usage; return 0 ;;
+            -*) err "unknown flag: $1"; return 2 ;;
+            *) ROOT="$1"; shift ;;
+        esac
+    done
+}
+
+main() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then usage; return 0; fi
+    parse_args "$@" || return $?
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): scaffold engine — arg parsing, seams, sourcing guard"
+```
+
+---
+
+## Task 2: Artifact discovery (speckit + superpowers)
+
+**Files:**
+- Modify: `configs/claude/scripts/spec_review.sh`
+- Test: `tests/bats/spec_review.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+@test "discover_artifacts finds speckit spec/plan/tasks in a specs dir" {
+    mkdir -p "$SANDBOX/specs/001-feature"
+    : > "$SANDBOX/specs/001-feature/spec.md"
+    : > "$SANDBOX/specs/001-feature/plan.md"
+    : > "$SANDBOX/specs/001-feature/tasks.md"
+    source "$SCRIPT"
+    run discover_artifacts "$SANDBOX"
+    assert_success
+    assert_output --partial "spec	$SANDBOX/specs/001-feature/spec.md"
+    assert_output --partial "plan	$SANDBOX/specs/001-feature/plan.md"
+    assert_output --partial "tasks	$SANDBOX/specs/001-feature/tasks.md"
+}
+
+@test "discover_artifacts finds superpowers design+plan (tasks embedded in plan)" {
+    mkdir -p "$SANDBOX/docs/superpowers/specs" "$SANDBOX/docs/superpowers/plans"
+    : > "$SANDBOX/docs/superpowers/specs/2026-06-08-thing-design.md"
+    : > "$SANDBOX/docs/superpowers/plans/2026-06-08-thing.md"
+    source "$SCRIPT"
+    run discover_artifacts "$SANDBOX"
+    assert_success
+    assert_output --partial "spec	$SANDBOX/docs/superpowers/specs/2026-06-08-thing-design.md"
+    assert_output --partial "plan	$SANDBOX/docs/superpowers/plans/2026-06-08-thing.md"
+    refute_output --partial "tasks	"
+}
+
+@test "discover_artifacts prints nothing when no artifacts exist" {
+    source "$SCRIPT"
+    run discover_artifacts "$SANDBOX"
+    assert_output ""
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats -f discover`
+Expected: FAIL — `discover_artifacts` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert before `main()`:
+
+```bash
+# Print "role\tpath" lines for discovered artifacts. speckit: spec/plan/tasks.md
+# (cwd or specs/<n>/). superpowers: newest *-design.md + newest plans/*.md (tasks
+# are embedded in the plan, so no tasks line). Newest = name sort (date-prefixed).
+discover_artifacts() {
+    local root="${1:-.}" sp pl tk
+    # speckit: specs/<n>/ first, then cwd
+    sp=$(ls -1 "$root"/specs/*/spec.md 2>/dev/null | sort | tail -1 || true)
+    [[ -z "$sp" && -f "$root/spec.md" ]] && sp="$root/spec.md"
+    if [[ -n "$sp" ]]; then
+        local d; d="$(dirname "$sp")"
+        printf 'spec\t%s\n' "$sp"
+        [[ -f "$d/plan.md" ]]  && printf 'plan\t%s\n'  "$d/plan.md"
+        [[ -f "$d/tasks.md" ]] && printf 'tasks\t%s\n' "$d/tasks.md"
+        return 0
+    fi
+    # superpowers: newest design + newest plan (tasks embedded in plan)
+    sp=$(ls -1 "$root"/docs/superpowers/specs/*-design.md 2>/dev/null | sort | tail -1 || true)
+    pl=$(ls -1 "$root"/docs/superpowers/plans/*.md 2>/dev/null | sort | tail -1 || true)
+    [[ -n "$sp" ]] && printf 'spec\t%s\n' "$sp"
+    [[ -n "$pl" ]] && printf 'plan\t%s\n' "$pl"
+    return 0
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): framework-agnostic artifact discovery (speckit + superpowers)"
+```
+
+---
+
+## Task 3: Prompt template + assembly
+
+**Files:**
+- Create: `configs/claude/prompts/spec_review.md`
+- Modify: `configs/claude/scripts/spec_review.sh`
+- Test: `tests/bats/spec_review.bats`
+
+- [ ] **Step 1: Create the prompt template (content step)**
+
+```markdown
+<!-- configs/claude/prompts/spec_review.md -->
+# Project Artifact Cross-Reference
+
+You are an independent reviewer cross-referencing a project's planning artifacts
+for **internal consistency**. You did not write them. Find places where the
+artifacts contradict each other or leave a decision dangerously ambiguous.
+
+When `tasks` is absent, the task breakdown is embedded inside the plan — review
+the plan's task section against the spec and plan prose.
+
+## Artifacts
+
+{{ARTIFACTS}}
+
+## Output
+
+For EACH inconsistency, output one block in EXACTLY this format:
+
+⚠️  CLARIFICATION REQUIRED: <short title>
+   ├─ Location: <artifact A> vs <artifact B>
+   ├─ The Gap: <one sentence>
+   ├─ Recommended Direction: <concrete remediation>
+   └─ Reason Why: <which constraint it violates / why it matters>
+
+If the artifacts are consistent, output the single token: NO_ISSUES
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```bash
+@test "assemble_prompt embeds template and role-labelled artifact contents" {
+    local tpl="$SANDBOX/tpl.md"; printf 'HEAD\n{{ARTIFACTS}}\nTAIL\n' > "$tpl"
+    printf 'spec body here\n' > "$SANDBOX/spec.md"
+    printf 'plan body here\n' > "$SANDBOX/plan.md"
+    source "$SCRIPT"
+    run assemble_prompt "$tpl" "spec	$SANDBOX/spec.md" "plan	$SANDBOX/plan.md"
+    assert_success
+    assert_output --partial "HEAD"
+    assert_output --partial "=== SPEC: $SANDBOX/spec.md ==="
+    assert_output --partial "spec body here"
+    assert_output --partial "=== PLAN: $SANDBOX/plan.md ==="
+    assert_output --partial "plan body here"
+    refute_output --partial "{{ARTIFACTS}}"
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats -f assemble`
+Expected: FAIL — `assemble_prompt` not defined.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Insert before `main()`:
+
+```bash
+# assemble_prompt TEMPLATE "role\tpath"...  ->  full prompt on stdout
+assemble_prompt() {
+    local template="$1"; shift
+    local artifacts="" line role path
+    for line in "$@"; do
+        role="${line%%$'\t'*}"; path="${line#*$'\t'}"
+        artifacts+="=== ${role^^}: ${path} ==="$'\n'
+        artifacts+="$(cat "$path")"$'\n\n'
+    done
+    # Substitute {{ARTIFACTS}} with the assembled block (awk avoids sed escaping).
+    awk -v repl="$artifacts" '{gsub(/\{\{ARTIFACTS\}\}/, repl); print}' "$template"
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add configs/claude/prompts/spec_review.md configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): prompt template + role-labelled prompt assembly"
+```
+
+---
+
+## Task 4: Gemini seam + findings formatting
+
+**Files:**
+- Modify: `configs/claude/scripts/spec_review.sh`
+- Test: `tests/bats/spec_review.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+_fake_gemini() {  # writes a stub gemini onto PATH inside SANDBOX
+    cat > "$SANDBOX/gemini" <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null   # consume stdin
+printf '⚠️  CLARIFICATION REQUIRED: Migration\n   ├─ Location: plan vs tasks\n   ├─ The Gap: zero-downtime vs destructive\n   ├─ Recommended Direction: split into 3 tasks\n   └─ Reason Why: locking violates the constraint\n'
+STUB
+    chmod +x "$SANDBOX/gemini"
+}
+
+@test "run_gemini pipes prompt through the injectable seam" {
+    _fake_gemini
+    source "$SCRIPT"
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" run run_gemini "any prompt"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"
+}
+
+@test "format_findings tree passes structured findings through" {
+    source "$SCRIPT"
+    run format_findings "⚠️  CLARIFICATION REQUIRED: X" "tree"
+    assert_output --partial "CLARIFICATION REQUIRED: X"
+}
+
+@test "format_findings reports clean when gemini returns NO_ISSUES" {
+    source "$SCRIPT"
+    run format_findings "NO_ISSUES" "tree"
+    assert_success
+    assert_output --partial "No inconsistencies found"
+}
+
+@test "format_findings json emits a JSON array" {
+    source "$SCRIPT"
+    run format_findings "NO_ISSUES" "json"
+    assert_output --partial "[]"
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats -f gemini`
+Expected: FAIL — `run_gemini` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert before `main()`:
+
+```bash
+# run_gemini PROMPT -> raw gemini output. stdin carries the prompt body; the -p
+# instruction is short. Errors propagate (caller decides fail-open vs surface).
+run_gemini() {
+    local prompt="$1"
+    printf '%s' "$prompt" | "$SPEC_REVIEW_GEMINI" -p "Cross-reference the artifacts above per the instructions; output only the specified blocks or NO_ISSUES."
+}
+
+# format_findings RAW FORMAT -> formatted output. NO_ISSUES -> clean message.
+format_findings() {
+    local raw="$1" fmt="${2:-tree}"
+    if [[ -z "${raw//[[:space:]]/}" || "$raw" == *NO_ISSUES* ]]; then
+        if [[ "$fmt" == "json" ]]; then echo "[]"; else echo "✓ No inconsistencies found."; fi
+        return 0
+    fi
+    if [[ "$fmt" == "json" ]]; then
+        # Minimal: wrap raw blocks as a single JSON string element (tolerant).
+        printf '[%s]\n' "$(printf '%s' "$raw" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+    else
+        printf '%s\n' "$raw"
+    fi
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): injectable gemini seam + tree/json findings formatting"
+```
+
+---
+
+## Task 5: Content-hash debounce + gating
+
+**Files:**
+- Modify: `configs/claude/scripts/spec_review.sh`
+- Test: `tests/bats/spec_review.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+@test "content_hash is stable for same content and differs on change" {
+    printf 'a\n' > "$SANDBOX/x.md"; printf 'b\n' > "$SANDBOX/y.md"
+    source "$SCRIPT"
+    h1="$(content_hash "$SANDBOX/x.md" "$SANDBOX/y.md")"
+    h2="$(content_hash "$SANDBOX/x.md" "$SANDBOX/y.md")"
+    [ "$h1" = "$h2" ]
+    printf 'b2\n' > "$SANDBOX/y.md"
+    h3="$(content_hash "$SANDBOX/x.md" "$SANDBOX/y.md")"
+    [ "$h1" != "$h3" ]
+}
+
+@test "should_run_silent skips when fewer than 2 artifacts" {
+    mkdir -p "$SANDBOX/specs/001"; : > "$SANDBOX/specs/001/spec.md"
+    source "$SCRIPT"
+    SPEC_REVIEW_STATE="$SANDBOX/.spec-review" run should_run_silent "$SANDBOX"
+    assert_failure
+    assert_output --partial "fewer than 2 artifacts"
+}
+
+@test "should_run_silent runs on first change, skips on unchanged hash" {
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    source "$SCRIPT"
+    export SPEC_REVIEW_STATE="$SANDBOX/.spec-review"
+    run should_run_silent "$SANDBOX"; assert_success          # first time: changed
+    run should_run_silent "$SANDBOX"; assert_failure          # unchanged hash
+    assert_output --partial "unchanged"
+    printf 'p2\n' > "$SANDBOX/specs/001/plan.md"
+    run should_run_silent "$SANDBOX"; assert_success          # changed again
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats -f "hash\|should_run"`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert before `main()`:
+
+```bash
+# Stable combined-content hash of the given files.
+content_hash() {
+    cat "$@" 2>/dev/null | shasum | awk '{print $1}'
+}
+
+# Gating for silent/hook mode. Returns 0 (run) or 1 (skip, with reason on stdout).
+# Records the hash in $SPEC_REVIEW_STATE/.last-run only when it decides to run.
+should_run_silent() {
+    local root="${1:-.}" state="$SPEC_REVIEW_STATE"
+    local paths; paths=$(discover_artifacts "$root" | cut -f2)
+    local count; count=$(printf '%s\n' "$paths" | grep -c . || true)
+    if [[ "$count" -lt 2 ]]; then echo "skip: fewer than 2 artifacts"; return 1; fi
+    mkdir -p "$state"
+    local now prev="$state/.last-run"
+    # shellcheck disable=SC2086
+    now="$(content_hash $paths)"
+    if [[ -f "$prev" && "$(cat "$prev")" == "$now" ]]; then
+        echo "skip: unchanged"; return 1
+    fi
+    echo "$now" > "$prev"
+    return 0
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: PASS (13 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): content-hash debounce + <2-artifact gating"
+```
+
+---
+
+## Task 6: Orchestration, silent/detached mode, fail-open, main wiring
+
+**Files:**
+- Modify: `configs/claude/scripts/spec_review.sh`
+- Test: `tests/bats/spec_review.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+@test "on-demand review prints findings from the mocked gemini" {
+    _fake_gemini
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" "$SANDBOX"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"
+}
+
+@test "on-demand review on no artifacts exits 0 with nothing-to-review" {
+    run bash "$SCRIPT" "$SANDBOX"
+    assert_success
+    assert_output --partial "nothing to review"
+}
+
+@test "silent mode writes feedback file and exits 0 (inline via NO_DETACH)" {
+    _fake_gemini
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_NO_DETACH=1 \
+        SPEC_REVIEW_STATE="$SANDBOX/.spec-review" \
+        SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" --silent "$SANDBOX"
+    assert_success
+    assert [ -f "$SANDBOX/.spec-review/feedback.md" ]
+    run cat "$SANDBOX/.spec-review/feedback.md"
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"
+}
+
+@test "silent mode fails open: non-zero gemini still exits 0" {
+    printf '#!/usr/bin/env bash\nexit 3\n' > "$SANDBOX/gemini"; chmod +x "$SANDBOX/gemini"
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_NO_DETACH=1 \
+        SPEC_REVIEW_STATE="$SANDBOX/.spec-review" \
+        SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" --silent "$SANDBOX"
+    assert_success
+}
+
+@test "silent mode is a no-op on unchanged content (second run)" {
+    _fake_gemini
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    local env="SPEC_REVIEW_GEMINI=$SANDBOX/gemini SPEC_REVIEW_NO_DETACH=1 SPEC_REVIEW_STATE=$SANDBOX/.spec-review SPEC_REVIEW_TEMPLATE=$REPO_ROOT/configs/claude/prompts/spec_review.md"
+    env $env bash "$SCRIPT" --silent "$SANDBOX"
+    rm -f "$SANDBOX/.spec-review/feedback.md"
+    env $env bash "$SCRIPT" --silent "$SANDBOX"   # unchanged -> skip, no rewrite
+    assert [ ! -f "$SANDBOX/.spec-review/feedback.md" ]
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats -f "review\|silent"`
+Expected: FAIL — `review`/silent wiring not implemented.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `review()`, the silent path, and flesh out `main()`:
+
+```bash
+# review ROOT FORMAT -> discover, assemble, run gemini, format. Used on-demand.
+review() {
+    local root="${1:-.}" fmt="${2:-tree}"
+    local arts=() line
+    while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(discover_artifacts "$root")
+    if [[ "${#arts[@]}" -eq 0 ]]; then echo "spec-review: nothing to review (no artifacts found)"; return 0; fi
+    echo "[spec-review] Cross-referencing project artifacts with Gemini…"
+    local prompt raw; prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]}")"
+    raw="$(run_gemini "$prompt")"
+    format_findings "$raw" "$fmt"
+}
+
+# _silent_review_inline ROOT -> the actual review for hook mode, fail-open.
+_silent_review_inline() {
+    local root="$1" state="$SPEC_REVIEW_STATE"
+    mkdir -p "$state"
+    local arts=() line prompt raw
+    while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(discover_artifacts "$root")
+    prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]}")"
+    if ! raw="$(run_gemini "$prompt" 2>>"$state/error.log")"; then
+        return 0   # fail-open: gemini failed, never block
+    fi
+    format_findings "$raw" "tree" > "$state/feedback.md.tmp" && mv "$state/feedback.md.tmp" "$state/feedback.md"
+}
+
+run_silent() {
+    local root="${1:-.}" state="$SPEC_REVIEW_STATE"
+    local reason; if ! reason="$(should_run_silent "$root")"; then
+        return 0   # gate said skip (fewer than 2 artifacts / unchanged)
+    fi
+    mkdir -p "$state"
+    # Single-flight lock: skip if a review is already in flight.
+    if ! mkdir "$state/.lock" 2>/dev/null; then return 0; fi
+    if [[ -n "$SPEC_REVIEW_NO_DETACH" ]]; then
+        _silent_review_inline "$root"; rmdir "$state/.lock" 2>/dev/null || true
+    else
+        # Detach so the agent loop never waits on gemini; release lock when done.
+        ( _silent_review_inline "$root"; rmdir "$state/.lock" 2>/dev/null || true ) \
+            >/dev/null 2>&1 &
+        disown 2>/dev/null || true
+    fi
+    return 0
+}
+
+main() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then usage; return 0; fi
+    parse_args "$@" || return $?
+    if [[ "$SILENT" == true ]]; then run_silent "$ROOT"; return 0; fi
+    review "$ROOT" "$FORMAT"
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: PASS (18 tests). Then `shellcheck configs/claude/scripts/spec_review.sh` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): orchestration + fail-open detached silent mode with single-flight lock"
+```
+
+---
+
+## Task 7: /spec-review skill + .gitignore
+
+**Files:**
+- Create: `.skillshare/skills/spec-review/SKILL.md`
+- Modify: `.gitignore`
+- Test: `tests/bats/spec_review.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+@test "spec-review SKILL.md has valid frontmatter and points at the engine" {
+    local skill="$REPO_ROOT/.skillshare/skills/spec-review/SKILL.md"
+    assert [ -f "$skill" ]
+    run head -1 "$skill"; assert_output "---"
+    run grep -E '^name: spec-review' "$skill"; assert_success
+    run grep -E 'spec_review\.sh' "$skill"; assert_success
+}
+
+@test ".gitignore ignores the .spec-review runtime dir" {
+    run grep -E '^\.spec-review/?$' "$REPO_ROOT/.gitignore"
+    assert_success
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats -f "SKILL\|gitignore"`
+Expected: FAIL — skill + ignore entry absent.
+
+- [ ] **Step 3: Create the skill and ignore entry**
+
+`.skillshare/skills/spec-review/SKILL.md`:
+
+```markdown
+---
+name: spec-review
+description: |
+  Cross-reference a project's spec / plan / tasks artifacts for internal
+  consistency using an independent model (Gemini), and surface structured
+  remediation guidance (Location / Gap / Recommended Direction / Reason Why).
+  Analysis-only — never edits artifacts. Works with both speckit
+  (spec.md/plan.md/tasks.md) and superpowers (design + plan-with-embedded-tasks)
+  layouts. Auto-discovers artifacts, or pass explicit paths.
+---
+
+# Spec Review (Gemini cross-reference)
+
+Run an independent, analysis-only consistency check across the project's planning
+artifacts. A second model (Gemini) reviews what Claude authored — catching
+structural blind spots that self-review misses.
+
+## How to run
+
+```bash
+# Auto-discover spec/plan/tasks under the current project and review:
+~/.claude/scripts/spec_review.sh
+
+# Explicit artifacts:
+~/.claude/scripts/spec_review.sh --spec ./spec.md --plan ./plan.md --tasks ./tasks.md
+
+# Machine-readable:
+~/.claude/scripts/spec_review.sh --format json
+```
+
+Findings print as a tree of `CLARIFICATION REQUIRED` blocks, or
+`✓ No inconsistencies found.` Requires the `gemini` CLI (logged in). This skill is
+analysis-only; apply the recommendations yourself.
+```
+
+Append to `.gitignore`:
+
+```gitignore
+
+# spec-review runtime (feedback, content-hash, lock, error log)
+.spec-review/
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: PASS (20 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .skillshare/skills/spec-review/SKILL.md .gitignore tests/bats/spec_review.bats
+git commit -m "feat(spec-review): /spec-review skill + .spec-review gitignore"
+```
+
+---
+
+## Task 8: PostToolUse save hook registration
+
+**Files:**
+- Modify: `configs/claude/settings.local.json`
+- Test: `tests/bats/spec_review.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+@test "settings.local.json registers the spec_review silent save hook" {
+    local s="$REPO_ROOT/configs/claude/settings.local.json"
+    run python3 -c "import json; d=json.load(open('$s')); cmds=[h['command'] for m in d['hooks']['PostToolUse'] for h in m['hooks']]; assert any('spec_review.sh' in c and '--silent' in c for c in cmds), cmds"
+    assert_success
+}
+
+@test "settings.local.json remains valid JSON" {
+    run python3 -c "import json; json.load(open('$REPO_ROOT/configs/claude/settings.local.json'))"
+    assert_success
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats -f "hook\|JSON"`
+Expected: FAIL — hook not registered.
+
+- [ ] **Step 3: Add the hook**
+
+In `configs/claude/settings.local.json`, append a new object to the existing
+`hooks.PostToolUse` array (sibling to the version_pin entry), preserving valid JSON:
+
+```json
+{
+  "matcher": "Write|Edit",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "~/.claude/scripts/spec_review.sh --silent"
+    }
+  ]
+}
+```
+
+(The script self-gates: it discovers artifacts, skips on unchanged hash or <2
+artifacts, and detaches the gemini call — so firing on every Write/Edit is cheap
+and never blocks.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: PASS (22 tests). Then validate: `python3 -m json.tool configs/claude/settings.local.json >/dev/null && echo OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/settings.local.json tests/bats/spec_review.bats
+git commit -m "feat(spec-review): register fail-open PostToolUse save hook"
+```
+
+---
+
+## Task 9: Docs + full-suite green + lint
+
+**Files:**
+- Modify: `docs/COMMANDS.md` (if present)
+
+- [ ] **Step 1: Document the command**
+
+Add a `/spec-review` row/section to `docs/COMMANDS.md` describing: independent
+Gemini cross-reference of spec/plan/tasks; on-demand + optional save hook;
+analysis-only; speckit + superpowers; `.spec-review/feedback.md` for silent runs.
+If the repo has a command table in `CLAUDE.md`/`configs/claude/CLAUDE.md`, add a
+matching row there too.
+
+- [ ] **Step 2: Run the full suite**
+
+Run:
+```bash
+bats tests/bats/spec_review.bats
+bats tests/bats/                       # no regressions
+shellcheck configs/claude/scripts/spec_review.sh
+python3 -m json.tool configs/claude/settings.local.json >/dev/null && echo "json ok"
+```
+Expected: all green; shellcheck clean; JSON valid.
+
+- [ ] **Step 3: Markdownlint the new docs**
+
+Run: `markdownlint .skillshare/skills/spec-review/SKILL.md configs/claude/prompts/spec_review.md docs/superpowers/specs/2026-06-08-spec-review-design.md docs/superpowers/plans/2026-06-08-spec-review.md` (or the repo's configured linter; honor `.markdownlint.jsonc`). Fix violations.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/COMMANDS.md configs/claude/CLAUDE.md
+git commit -m "docs(spec-review): document /spec-review command and save hook"
+```
+
+---
+
+## Self-Review (completed during plan authoring)
+
+**Spec coverage:**
+- Engine script, front-end-agnostic → Tasks 1–6. ✓
+- Framework-agnostic discovery (speckit + superpowers, tasks-in-plan) → Task 2. ✓
+- Prompt template + Location/Gap/Direction/Reason format → Tasks 3–4. ✓
+- Injectable gemini seam (no network in tests) → Task 4. ✓
+- Content-hash debounce + <2-artifact skip → Task 5. ✓
+- Detached silent mode + single-flight lock + fail-open → Task 6. ✓
+- On-demand `/spec-review` skill → Task 7. ✓
+- `.gitignore` `.spec-review/` → Task 7. ✓
+- PostToolUse hook registration (append to existing Write|Edit block) → Task 8. ✓
+- Analysis-only (no artifact writes anywhere) → enforced across Tasks 1–6. ✓
+- Tests/lint/docs → Tasks 1–9. ✓
+
+**Type/name consistency:** Function names match the engine contract verbatim across tasks — `discover_artifacts`, `assemble_prompt`, `run_gemini`, `format_findings`, `content_hash`, `should_run_silent`, `run_silent`, `review`, `_silent_review_inline`, `main`. Env seams (`SPEC_REVIEW_GEMINI`, `SPEC_REVIEW_TEMPLATE`, `SPEC_REVIEW_STATE`, `SPEC_REVIEW_NO_DETACH`) are consistent throughout.
+
+**Note for executor:** bats sources the script (`source "$SCRIPT"`), which relies on the sourcing guard (Task 1) so `main` does not run on source. The code uses portable `while read` loops (not `mapfile`) for bash 3.2 compatibility. `disown` is guarded with `|| true`; if it is unavailable, the `( … ) &` background plus the script's immediate return still detaches the gemini call. Confirm `tests/bats/test_helper/bats-support` and `bats-assert` exist (other suites in `tests/bats/` already use them) before running.

--- a/docs/superpowers/specs/2026-06-08-spec-review-design.md
+++ b/docs/superpowers/specs/2026-06-08-spec-review-design.md
@@ -83,7 +83,9 @@ One core engine script, two thin entry points:
   - **Flags:** `--spec FILE --plan FILE --tasks FILE` (explicit) OR auto-discover;
     `--silent` (hook mode); `--format tree|json` (default `tree`).
   - **Discovery (framework-agnostic):**
-    - *speckit:* `.specify/` or `specs/<NNN>-*/{spec,plan,tasks}.md`.
+    - *speckit:* `specs/<NNN>-*/{spec,plan,tasks}.md` (or `spec.md` in cwd). Note:
+      speckit's `.specify/` dir holds templates/memory/scripts, NOT the artifacts —
+      the spec/plan/tasks live under `specs/<NNN>/`, which is what we discover.
     - *superpowers:* `docs/superpowers/specs/*-design.md` (spec) +
       `docs/superpowers/plans/*.md` (plan, **with tasks embedded** — there is no
       separate `tasks.md`). The cross-reference for superpowers is therefore
@@ -120,7 +122,7 @@ One core engine script, two thin entry points:
   owns the path logic. **Advisory and non-blocking.**
   - **Detached execution (must not stall the agent loop):** a synchronous hook that
     blocked on a multi-second `gemini` call would add that latency after every
-    artifact save. So once the cheap synchronous gates pass (path match, `<2`
+    artifact save. So once the cheap synchronous gates pass (`<2`
     artifacts, hash unchanged, lock held), the actual `gemini` review is launched
     **fully detached** — `nohup … &` with stdout → `.spec-review/feedback.md` and
     stderr → `.spec-review/error.log` — and the hook returns immediately.

--- a/docs/superpowers/specs/2026-06-08-spec-review-design.md
+++ b/docs/superpowers/specs/2026-06-08-spec-review-design.md
@@ -1,0 +1,187 @@
+# /spec-review — Gemini Cross-Reference of Project Artifacts — Design
+
+> An analysis-only Manifest skill that cross-references spec / plan / tasks
+> artifacts for consistency using the `gemini` CLI, and surfaces structured
+> remediation guidance. On-demand plus an optional fail-open save hook.
+
+**Date**: 2026-06-08
+**Status**: Approved (design) — pending implementation plan
+**Audience**: Manifest maintainers
+
+---
+
+## Problem
+
+When a feature is specified across multiple artifacts (a spec, a plan, and a task
+list), the artifacts drift: the plan promises something the tasks contradict, the
+spec defines a constraint the plan violates. Catching this by hand is tedious and
+easy to skip. We want an automated, independent cross-check that reads the
+artifacts and reports inconsistencies with a concrete remediation path.
+
+An independent **second model** (Gemini) is the valuable signal here, because the
+artifacts are usually authored by Claude — having a different model review them
+catches blind spots that Claude-reviewing-Claude would miss.
+
+## Decisions (resolved during brainstorming)
+
+| Decision | Choice |
+|----------|--------|
+| Packaging | A **new Manifest skill** (`/spec-review`), NOT a new `agi`/Antigravity CLI. Antigravity is an IDE in this repo (symlink-only config dir); there is no `agi` binary to extend. |
+| Reviewer engine | **Gemini alone** via the `gemini` CLI (`gemini -p`). Uses existing CLI auth — no Google API key, no client library, no model pinning to a dated `1.5 Flash`. |
+| Trigger | **On-demand `/spec-review`** (primary) **plus an optional Claude Code PostToolUse save hook** (advisory, debounced, fail-open). NOT a background daemon / file-watcher. |
+| Framework scope | **Framework-agnostic**: speckit (`spec.md`/`plan.md`/`tasks.md`) and superpowers (`*-design.md` + plan-with-embedded-tasks). |
+| Mutation | **Analysis-only.** Never edits artifacts (like `speckit-analyze`, `pr-review`). |
+| Name / output | Skill `/spec-review`; silent-mode findings → `.spec-review/feedback.md` (gitignored). |
+
+## Non-Goals
+
+- No `agi` CLI / sub-command framework (does not exist; out of scope for a
+  bash/Python/YAML config repo).
+- No background daemon or file-system watcher (the SkillClaw lesson: inline
+  daemons are fragile and rate-limit-prone).
+- No multi-model consensus in V1 (Gemini-only; `parallel_agent.py` is a possible
+  future engine swap, see Follow-ups).
+- No auto-editing / auto-fixing of artifacts.
+
+## Relationship to existing tooling
+
+- **`speckit-analyze`** (vendored github-spec-kit skill) already does cross-artifact
+  consistency — but it is speckit-only (`requires .specify/`), third-party/vendored
+  (editing it drifts from upstream), and Claude-driven. `/spec-review` is
+  Manifest-owned, **framework-agnostic**, and uses an **independent model**
+  (Gemini). They are complementary, not duplicative.
+- **`gemini` CLI** is already installed and authenticated; we shell out to it
+  exactly as SkillClaw shells to `claude -p`.
+
+---
+
+## Architecture
+
+One core engine script, two thin entry points:
+
+```text
+┌─ /spec-review  (SKILL.md, on-demand) ──┐
+│                                         ├─►  spec_review.sh  ─►  gemini -p <prompt>  ─►  findings
+└─ PostToolUse hook (settings.json) ──────┘     discover → assemble → invoke → parse → format
+   (auto on Write/Edit to artifact paths,
+    debounced + fail-open + --silent)
+```
+
+## Components
+
+### New
+
+- **`configs/claude/scripts/spec_review.sh`** — the engine.
+  - **Flags:** `--spec FILE --plan FILE --tasks FILE` (explicit) OR auto-discover;
+    `--silent` (hook mode); `--format tree|json` (default `tree`).
+  - **Discovery (framework-agnostic):**
+    - *speckit:* `.specify/` or `specs/<NNN>-*/{spec,plan,tasks}.md`.
+    - *superpowers:* `docs/superpowers/specs/*-design.md` (spec) +
+      `docs/superpowers/plans/*.md` (plan, **with tasks embedded** — there is no
+      separate `tasks.md`). The cross-reference for superpowers is therefore
+      **spec ↔ plan(+embedded tasks)**; for speckit it is the three-way
+      **spec ↔ plan ↔ tasks**. The assembled prompt states which shape it sees.
+  - **Engine seam:** `gemini` is invoked through one function with an injectable
+    override (`SPEC_REVIEW_GEMINI`, default `gemini`), so tests never touch the
+    network or the user's Gemini quota.
+  - **Debounce (silent/hook mode):** a per-project cooldown file
+    (`.spec-review/.last-run`); skip if it ran within `cooldown_seconds`
+    (default 60) **and** skip when fewer than 2 artifacts exist (a lone file
+    cannot be cross-referenced). Bounds `gemini` call frequency with no daemon.
+  - **Analysis-only:** reads artifacts; never writes to them.
+
+- **`configs/claude/prompts/spec_review.md`** — the distillation/critique prompt
+  template. Instructs Gemini to cross-reference the supplied artifacts and emit
+  each inconsistency in the exact `Location / The Gap / Recommended Direction /
+  Reason Why` structure, or a single `NO_ISSUES` token when consistent.
+  Version-controlled, deployed to `~/.claude/prompts/`.
+
+- **`.skillshare/skills/spec-review/SKILL.md`** — the on-demand `/spec-review`
+  entry point. Frontmatter (`name`, `description`); body instructs Claude to run
+  `spec_review.sh` (auto-discover or with explicit paths) and present the findings.
+
+- **PostToolUse hook** — registered in `configs/claude/settings.local.json` (which
+  deploys to `~/.claude/settings.json` and already contains a `hooks` block), under
+  a `PostToolUse` matcher for `Write|Edit`. The hook command runs
+  `spec_review.sh --silent`, which itself filters to artifact paths (spec/plan/tasks
+  globs) and applies debounce — so the matcher stays broad and the script owns the
+  path logic. **Advisory and non-blocking.**
+
+- **`.gitignore`** — add `.spec-review/` so silent-mode `feedback.md` and the
+  `.last-run` cooldown file are never committed.
+
+### Output format
+
+Structured tree to stdout (the agreed shape):
+
+```text
+[spec-review] Cross-referencing project artifacts with Gemini…
+
+⚠️  CLARIFICATION REQUIRED: <short title>
+   ├─ Location: <artifact A> vs <artifact B>
+   ├─ The Gap: <one-sentence description of the inconsistency>
+   ├─ Recommended Direction: <concrete remediation, may be multi-step>
+   └─ Reason Why: <why it matters / which constraint it violates>
+```
+
+- `--format json` emits the same findings as a JSON array for machine use.
+- No issues → `✓ No inconsistencies found across N artifacts.` and exit 0.
+
+## Error handling & fail-open
+
+The hard lesson from SkillClaw — **a review tool must never block or break the
+user's primary work**:
+
+- **PostToolUse hook is advisory and non-blocking.** It never rejects or delays a
+  Write/Edit. On any failure it degrades quietly.
+- **`gemini` missing / unauthenticated / non-zero exit:** silent mode logs a single
+  line and writes nothing harmful (exit 0); on-demand mode surfaces a clear,
+  actionable error (e.g. "gemini CLI not found / not logged in").
+- **Malformed Gemini output:** degrade gracefully — print the raw response under a
+  warning rather than crashing; never partial-write a corrupt `feedback.md`.
+- **No artifacts found:** `nothing to review`, exit 0.
+- **Silent mode** writes findings to `.spec-review/feedback.md` and prints one
+  summary line; `.spec-review/` is gitignored.
+
+## Testing
+
+- **bats `spec_review.bats`:**
+  - speckit-layout discovery; superpowers-layout discovery (spec + plan with
+    embedded tasks); no-artifacts case → clean exit.
+  - debounce: cooldown skip (ran < `cooldown_seconds` ago); `<2`-artifacts skip.
+  - `gemini` mocked via the `SPEC_REVIEW_GEMINI` seam (a stub script) → no network.
+  - tree formatting of a representative finding; `--format json` shape.
+  - `--silent` writes `.spec-review/feedback.md` and prints one line.
+  - malformed-Gemini-output tolerance (no crash, no corrupt feedback file).
+  - hook fail-open: non-zero gemini in `--silent` mode → exit 0.
+- **shellcheck** clean on `spec_review.sh`.
+- **markdownlint** on `SKILL.md` + `spec_review.md`; **settings.json** validates as
+  JSON.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Save hook fires `gemini` too often (cost/rate limits) | Debounce cooldown file + `<2`-artifact skip; hook is opt-in |
+| Hook blocks or breaks the user's Write/Edit | Advisory/non-blocking by construction; fail-open on every error path |
+| `gemini` not authed in headless/CI | Silent mode exits 0 with a logged note; on-demand gives a clear message |
+| Gemini returns non-structured prose | Tolerant parse: show raw under a warning, never crash |
+| Superpowers "tasks" mis-discovered as a missing file | Discovery treats plan-with-embedded-tasks as the canonical superpowers shape |
+
+## Follow-ups (not in V1)
+
+- **Pluggable engine** — swap `gemini -p` for `parallel_agent.py` multi-model
+  consensus behind the existing engine seam.
+- **`git` pre-commit hook** variant for teams that prefer commit-time over
+  save-time checks.
+- **Auto-fix mode** — offer to apply the `Recommended Direction` (kept out of V1;
+  analysis-only by design).
+
+---
+
+## Related Documents
+
+- [speckit-analyze skill](../../../.claude/skills/speckit-analyze/SKILL.md) — the
+  speckit-only cross-artifact analyzer this complements
+- [docs/SKILLCLAW.md](../../SKILLCLAW.md) — the `claude -p` / fail-open / engine-seam
+  patterns reused here

--- a/docs/superpowers/specs/2026-06-08-spec-review-design.md
+++ b/docs/superpowers/specs/2026-06-08-spec-review-design.md
@@ -38,7 +38,10 @@ catches blind spots that Claude-reviewing-Claude would miss.
 - No `agi` CLI / sub-command framework (does not exist; out of scope for a
   bash/Python/YAML config repo).
 - No background daemon or file-system watcher (the SkillClaw lesson: inline
-  daemons are fragile and rate-limit-prone).
+  daemons are fragile and rate-limit-prone). Note: the save hook's detached
+  `gemini` call is a **short-lived one-shot** process that exits when the review
+  finishes — not a persistent daemon. There is nothing to supervise, restart, or
+  health-check; if it dies, the next content change simply spawns a fresh one.
 - No multi-model consensus in V1 (Gemini-only; `parallel_agent.py` is a possible
   future engine swap, see Follow-ups).
 - No auto-editing / auto-fixing of artifacts.
@@ -71,7 +74,12 @@ One core engine script, two thin entry points:
 
 ### New
 
-- **`configs/claude/scripts/spec_review.sh`** — the engine.
+- **`configs/claude/scripts/spec_review.sh`** — the engine. **Front-end-agnostic
+  by construction:** it has no dependency on any caller, so the `/spec-review`
+  skill, the save hook, and any *future* CLI (e.g. a real `agi spec-review`) all
+  wrap this same script with zero rework. The skill is this ecosystem's unified
+  command surface and is already Antigravity-native (Antigravity inherits
+  `~/.claude/skills` via symlink), so no separate binary is invented.
   - **Flags:** `--spec FILE --plan FILE --tasks FILE` (explicit) OR auto-discover;
     `--silent` (hook mode); `--format tree|json` (default `tree`).
   - **Discovery (framework-agnostic):**
@@ -84,10 +92,14 @@ One core engine script, two thin entry points:
   - **Engine seam:** `gemini` is invoked through one function with an injectable
     override (`SPEC_REVIEW_GEMINI`, default `gemini`), so tests never touch the
     network or the user's Gemini quota.
-  - **Debounce (silent/hook mode):** a per-project cooldown file
-    (`.spec-review/.last-run`); skip if it ran within `cooldown_seconds`
-    (default 60) **and** skip when fewer than 2 artifacts exist (a lone file
-    cannot be cross-referenced). Bounds `gemini` call frequency with no daemon.
+  - **Debounce (silent/hook mode) — content-hash, not timestamp:** the gate is a
+    hash of the combined artifact contents (`cat <artifacts> | shasum`) written to
+    `.spec-review/.last-run`. Skip the run iff the hash is unchanged since last
+    time; run whenever content differs, **even seconds apart**. This avoids the
+    timestamp-cooldown race where a fast fix-up edit is suppressed and a now-stale
+    report lingers — a time window conflates "ran recently" with "nothing changed,"
+    while the hash tracks exactly what we care about. Also skip when fewer than 2
+    artifacts exist (a lone file cannot be cross-referenced). No daemon.
   - **Analysis-only:** reads artifacts; never writes to them.
 
 - **`configs/claude/prompts/spec_review.md`** — the distillation/critique prompt
@@ -104,11 +116,23 @@ One core engine script, two thin entry points:
   deploys to `~/.claude/settings.json` and already contains a `hooks` block), under
   a `PostToolUse` matcher for `Write|Edit`. The hook command runs
   `spec_review.sh --silent`, which itself filters to artifact paths (spec/plan/tasks
-  globs) and applies debounce — so the matcher stays broad and the script owns the
-  path logic. **Advisory and non-blocking.**
+  globs) and applies the hash debounce — so the matcher stays broad and the script
+  owns the path logic. **Advisory and non-blocking.**
+  - **Detached execution (must not stall the agent loop):** a synchronous hook that
+    blocked on a multi-second `gemini` call would add that latency after every
+    artifact save. So once the cheap synchronous gates pass (path match, `<2`
+    artifacts, hash unchanged, lock held), the actual `gemini` review is launched
+    **fully detached** — `nohup … &` with stdout → `.spec-review/feedback.md` and
+    stderr → `.spec-review/error.log` — and the hook returns immediately.
+  - **Lock file (overlap guard):** detaching reintroduces a concurrency race — two
+    saves in quick succession could spawn two `gemini` runs both writing
+    `feedback.md`. A lock file (`.spec-review/.lock`, acquired non-blockingly) makes
+    a new detached run a no-op while one is already in flight; combined with the
+    hash gate this bounds concurrency to one review at a time.
 
-- **`.gitignore`** — add `.spec-review/` so silent-mode `feedback.md` and the
-  `.last-run` cooldown file are never committed.
+- **`.gitignore`** — add `.spec-review/` so silent-mode runtime files
+  (`feedback.md`, the `.last-run` content hash, `.lock`, `error.log`) are never
+  committed.
 
 ### Output format
 
@@ -148,7 +172,9 @@ user's primary work**:
 - **bats `spec_review.bats`:**
   - speckit-layout discovery; superpowers-layout discovery (spec + plan with
     embedded tasks); no-artifacts case → clean exit.
-  - debounce: cooldown skip (ran < `cooldown_seconds` ago); `<2`-artifacts skip.
+  - debounce: **unchanged-hash skip** (same combined-content hash → no run);
+    **changed-hash run** (any content change → run, regardless of elapsed time);
+    `<2`-artifacts skip; lock-held → detached run becomes a no-op.
   - `gemini` mocked via the `SPEC_REVIEW_GEMINI` seam (a stub script) → no network.
   - tree formatting of a representative finding; `--format json` shape.
   - `--silent` writes `.spec-review/feedback.md` and prints one line.
@@ -162,7 +188,9 @@ user's primary work**:
 
 | Risk | Mitigation |
 |------|------------|
-| Save hook fires `gemini` too often (cost/rate limits) | Debounce cooldown file + `<2`-artifact skip; hook is opt-in |
+| Save hook fires `gemini` too often (cost/rate limits) | Content-hash debounce (runs only on real change) + `<2`-artifact skip + single-flight lock; hook is opt-in |
+| Hook blocks the agent loop on a slow `gemini` call | `gemini` runs fully detached (`nohup … &`); hook returns immediately |
+| Stale report after a fast fix-up edit | Hash debounce (not timestamp) — a content change always re-runs |
 | Hook blocks or breaks the user's Write/Edit | Advisory/non-blocking by construction; fail-open on every error path |
 | `gemini` not authed in headless/CI | Silent mode exits 0 with a logged note; on-demand gives a clear message |
 | Gemini returns non-structured prose | Tolerant parse: show raw under a warning, never crash |

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -27,3 +27,34 @@ teardown() {
     run bash "$SCRIPT" --bogus
     assert_failure
 }
+
+@test "discover_artifacts finds speckit spec/plan/tasks in a specs dir" {
+    mkdir -p "$SANDBOX/specs/001-feature"
+    : > "$SANDBOX/specs/001-feature/spec.md"
+    : > "$SANDBOX/specs/001-feature/plan.md"
+    : > "$SANDBOX/specs/001-feature/tasks.md"
+    source "$SCRIPT"
+    run discover_artifacts "$SANDBOX"
+    assert_success
+    assert_output --partial "spec	$SANDBOX/specs/001-feature/spec.md"
+    assert_output --partial "plan	$SANDBOX/specs/001-feature/plan.md"
+    assert_output --partial "tasks	$SANDBOX/specs/001-feature/tasks.md"
+}
+
+@test "discover_artifacts finds superpowers design+plan (tasks embedded in plan)" {
+    mkdir -p "$SANDBOX/docs/superpowers/specs" "$SANDBOX/docs/superpowers/plans"
+    : > "$SANDBOX/docs/superpowers/specs/2026-06-08-thing-design.md"
+    : > "$SANDBOX/docs/superpowers/plans/2026-06-08-thing.md"
+    source "$SCRIPT"
+    run discover_artifacts "$SANDBOX"
+    assert_success
+    assert_output --partial "spec	$SANDBOX/docs/superpowers/specs/2026-06-08-thing-design.md"
+    assert_output --partial "plan	$SANDBOX/docs/superpowers/plans/2026-06-08-thing.md"
+    refute_output --partial "tasks	"
+}
+
+@test "discover_artifacts prints nothing when no artifacts exist" {
+    source "$SCRIPT"
+    run discover_artifacts "$SANDBOX"
+    assert_output ""
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -79,3 +79,39 @@ TAIL
     assert_output --partial "TAIL"
     refute_output --partial "{{ARTIFACTS}}"
 }
+
+_fake_gemini() {  # writes a stub gemini onto PATH inside SANDBOX
+    cat > "$SANDBOX/gemini" <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null   # consume stdin
+printf '⚠️  CLARIFICATION REQUIRED: Migration\n   ├─ Location: plan vs tasks\n   ├─ The Gap: zero-downtime vs destructive\n   ├─ Recommended Direction: split into 3 tasks\n   └─ Reason Why: locking violates the constraint\n'
+STUB
+    chmod +x "$SANDBOX/gemini"
+}
+
+@test "run_gemini pipes prompt through the injectable seam" {
+    _fake_gemini
+    source "$SCRIPT"
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" run run_gemini "any prompt"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"
+}
+
+@test "format_findings tree passes structured findings through" {
+    source "$SCRIPT"
+    run format_findings "⚠️  CLARIFICATION REQUIRED: X" "tree"
+    assert_output --partial "CLARIFICATION REQUIRED: X"
+}
+
+@test "format_findings reports clean when gemini returns NO_ISSUES" {
+    source "$SCRIPT"
+    run format_findings "NO_ISSUES" "tree"
+    assert_success
+    assert_output --partial "No inconsistencies found"
+}
+
+@test "format_findings json emits a JSON array" {
+    source "$SCRIPT"
+    run format_findings "NO_ISSUES" "json"
+    assert_output --partial "[]"
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -76,5 +76,6 @@ TAIL
     assert_output --partial "spec body here"
     assert_output --partial "=== PLAN: $SANDBOX/plan.md ==="
     assert_output --partial "plan body here"
+    assert_output --partial "TAIL"
     refute_output --partial "{{ARTIFACTS}}"
 }

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -228,3 +228,16 @@ STUB
     assert [ -f "$SANDBOX/.spec-review/feedback.md" ]   # ran despite the stale lock
     assert [ ! -d "$SANDBOX/.spec-review/.lock" ]        # lock released after run
 }
+
+@test "spec-review SKILL.md has valid frontmatter and points at the engine" {
+    local skill="$REPO_ROOT/.skillshare/skills/spec-review/SKILL.md"
+    assert [ -f "$skill" ]
+    run head -1 "$skill"; assert_output "---"
+    run grep -E '^name: spec-review' "$skill"; assert_success
+    run grep -E 'spec_review\.sh' "$skill"; assert_success
+}
+
+@test ".gitignore ignores the .spec-review runtime dir" {
+    run grep -E '^\.spec-review/?$' "$REPO_ROOT/.gitignore"
+    assert_success
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -115,3 +115,11 @@ STUB
     run format_findings "NO_ISSUES" "json"
     assert_output --partial "[]"
 }
+
+@test "format_findings json wraps real findings as valid JSON (incl. special chars)" {
+    source "$SCRIPT"
+    run format_findings 'CLARIFICATION: a & b \slash "quote"' "json"
+    assert_success
+    # the python3-wrapped branch must produce JSON that parses and round-trips
+    echo "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert isinstance(d,list) and "CLARIFICATION" in d[0]'
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -58,3 +58,23 @@ teardown() {
     run discover_artifacts "$SANDBOX"
     assert_output ""
 }
+
+@test "assemble_prompt embeds template and role-labelled artifact contents" {
+    local tpl="$SANDBOX/tpl.md"; printf 'HEAD
+{{ARTIFACTS}}
+TAIL
+' > "$tpl"
+    printf 'spec body here
+' > "$SANDBOX/spec.md"
+    printf 'plan body here
+' > "$SANDBOX/plan.md"
+    source "$SCRIPT"
+    run assemble_prompt "$tpl" "spec	$SANDBOX/spec.md" "plan	$SANDBOX/plan.md"
+    assert_success
+    assert_output --partial "HEAD"
+    assert_output --partial "=== SPEC: $SANDBOX/spec.md ==="
+    assert_output --partial "spec body here"
+    assert_output --partial "=== PLAN: $SANDBOX/plan.md ==="
+    assert_output --partial "plan body here"
+    refute_output --partial "{{ARTIFACTS}}"
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+# Tests for configs/claude/scripts/spec_review.sh
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+SCRIPT="$REPO_ROOT/configs/claude/scripts/spec_review.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    SANDBOX=$(mktemp -d "$BATS_TMPDIR/spec_review.XXXXXX")
+}
+
+teardown() {
+    [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+@test "spec_review.sh is executable and prints usage on --help" {
+    run bash "$SCRIPT" --help
+    assert_success
+    assert_output --partial "spec-review"
+    assert_output --partial "--silent"
+}
+
+@test "spec_review.sh rejects an unknown flag" {
+    run bash "$SCRIPT" --bogus
+    assert_failure
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -123,3 +123,35 @@ STUB
     # the python3-wrapped branch must produce JSON that parses and round-trips
     echo "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert isinstance(d,list) and "CLARIFICATION" in d[0]'
 }
+
+@test "content_hash is stable for same content and differs on change" {
+    printf 'a\n' > "$SANDBOX/x.md"; printf 'b\n' > "$SANDBOX/y.md"
+    source "$SCRIPT"
+    h1="$(content_hash "$SANDBOX/x.md" "$SANDBOX/y.md")"
+    h2="$(content_hash "$SANDBOX/x.md" "$SANDBOX/y.md")"
+    [ "$h1" = "$h2" ]
+    printf 'b2\n' > "$SANDBOX/y.md"
+    h3="$(content_hash "$SANDBOX/x.md" "$SANDBOX/y.md")"
+    [ "$h1" != "$h3" ]
+}
+
+@test "should_run_silent skips when fewer than 2 artifacts" {
+    mkdir -p "$SANDBOX/specs/001"; : > "$SANDBOX/specs/001/spec.md"
+    source "$SCRIPT"
+    SPEC_REVIEW_STATE="$SANDBOX/.spec-review" run should_run_silent "$SANDBOX"
+    assert_failure
+    assert_output --partial "fewer than 2 artifacts"
+}
+
+@test "should_run_silent runs on first change, skips on unchanged hash" {
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    source "$SCRIPT"
+    export SPEC_REVIEW_STATE="$SANDBOX/.spec-review"
+    run should_run_silent "$SANDBOX"; assert_success          # first time: changed
+    run should_run_silent "$SANDBOX"; assert_failure          # unchanged hash
+    assert_output --partial "unchanged"
+    printf 'p2\n' > "$SANDBOX/specs/001/plan.md"
+    run should_run_silent "$SANDBOX"; assert_success          # changed again
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -155,3 +155,59 @@ STUB
     printf 'p2\n' > "$SANDBOX/specs/001/plan.md"
     run should_run_silent "$SANDBOX"; assert_success          # changed again
 }
+
+@test "on-demand review prints findings from the mocked gemini" {
+    _fake_gemini
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" "$SANDBOX"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"
+}
+
+@test "on-demand review on no artifacts exits 0 with nothing-to-review" {
+    run bash "$SCRIPT" "$SANDBOX"
+    assert_success
+    assert_output --partial "nothing to review"
+}
+
+@test "silent mode writes feedback file and exits 0 (inline via NO_DETACH)" {
+    _fake_gemini
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_NO_DETACH=1 \
+        SPEC_REVIEW_STATE="$SANDBOX/.spec-review" \
+        SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" --silent "$SANDBOX"
+    assert_success
+    assert [ -f "$SANDBOX/.spec-review/feedback.md" ]
+    run cat "$SANDBOX/.spec-review/feedback.md"
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"
+}
+
+@test "silent mode fails open: non-zero gemini still exits 0" {
+    printf '#!/usr/bin/env bash\nexit 3\n' > "$SANDBOX/gemini"; chmod +x "$SANDBOX/gemini"
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_NO_DETACH=1 \
+        SPEC_REVIEW_STATE="$SANDBOX/.spec-review" \
+        SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" --silent "$SANDBOX"
+    assert_success
+}
+
+@test "silent mode is a no-op on unchanged content (second run)" {
+    _fake_gemini
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    local env="SPEC_REVIEW_GEMINI=$SANDBOX/gemini SPEC_REVIEW_NO_DETACH=1 SPEC_REVIEW_STATE=$SANDBOX/.spec-review SPEC_REVIEW_TEMPLATE=$REPO_ROOT/configs/claude/prompts/spec_review.md"
+    env $env bash "$SCRIPT" --silent "$SANDBOX"
+    rm -f "$SANDBOX/.spec-review/feedback.md"
+    env $env bash "$SCRIPT" --silent "$SANDBOX"   # unchanged -> skip, no rewrite
+    assert [ ! -f "$SANDBOX/.spec-review/feedback.md" ]
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -241,3 +241,20 @@ STUB
     run grep -E '^\.spec-review/?$' "$REPO_ROOT/.gitignore"
     assert_success
 }
+
+@test "settings.local.json registers the spec_review silent save hook" {
+    local s="$REPO_ROOT/configs/claude/settings.local.json"
+    run python3 -c "import json; d=json.load(open('$s')); cmds=[h['command'] for m in d['hooks']['PostToolUse'] for h in m['hooks']]; assert any('spec_review.sh' in c and '--silent' in c for c in cmds), cmds"
+    assert_success
+}
+
+@test "settings.local.json remains valid JSON" {
+    run python3 -c "import json; json.load(open('$REPO_ROOT/configs/claude/settings.local.json'))"
+    assert_success
+}
+
+@test "settings.local.json still has the pre-existing version_pin hook" {
+    local s="$REPO_ROOT/configs/claude/settings.local.json"
+    run python3 -c "import json; d=json.load(open('$s')); cmds=[h['command'] for m in d['hooks']['PostToolUse'] for h in m['hooks']]; assert any('version_pin' in c for c in cmds), cmds"
+    assert_success
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -258,3 +258,27 @@ STUB
     run python3 -c "import json; d=json.load(open('$s')); cmds=[h['command'] for m in d['hooks']['PostToolUse'] for h in m['hooks']]; assert any('version_pin' in c for c in cmds), cmds"
     assert_success
 }
+
+@test "explicit --spec/--plan flags are used instead of auto-discovery" {
+    _fake_gemini
+    printf 's\n' > "$SANDBOX/myspec.md"
+    printf 'p\n' > "$SANDBOX/myplan.md"
+    # ROOT has no discoverable layout; only the explicit flags point at artifacts
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" --spec "$SANDBOX/myspec.md" --plan "$SANDBOX/myplan.md" "$SANDBOX"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"
+}
+
+@test "clean message includes the artifact count" {
+    # gemini stub that reports no issues
+    printf '#!/usr/bin/env bash\ncat >/dev/null\nprintf NO_ISSUES\n' > "$SANDBOX/gemini"
+    chmod +x "$SANDBOX/gemini"
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" "$SANDBOX"
+    assert_success
+    assert_output --partial "No inconsistencies found across 2 artifacts"
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -211,3 +211,20 @@ STUB
     env $env bash "$SCRIPT" --silent "$SANDBOX"   # unchanged -> skip, no rewrite
     assert [ ! -f "$SANDBOX/.spec-review/feedback.md" ]
 }
+
+@test "silent mode self-heals a stale lock (older than 10 min)" {
+    _fake_gemini
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    mkdir -p "$SANDBOX/.spec-review/.lock"
+    # age the stale lock 20 minutes into the past
+    touch -t "$(date -v-20M +%Y%m%d%H%M 2>/dev/null || date -d '20 min ago' +%Y%m%d%H%M)" "$SANDBOX/.spec-review/.lock"
+    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_NO_DETACH=1 \
+        SPEC_REVIEW_STATE="$SANDBOX/.spec-review" \
+        SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" --silent "$SANDBOX"
+    assert_success
+    assert [ -f "$SANDBOX/.spec-review/feedback.md" ]   # ran despite the stale lock
+    assert [ ! -d "$SANDBOX/.spec-review/.lock" ]        # lock released after run
+}


### PR DESCRIPTION
## Summary

Adds `/spec-review` — an **analysis-only** skill + reusable `spec_review.sh` engine that cross-references a project's spec / plan / tasks artifacts for internal consistency using an **independent model (Gemini)**, surfacing structured remediation (`Location / Gap / Recommended Direction / Reason Why`). Having a different model review Claude-authored artifacts catches structural blind spots that self-review misses.

- **Engine** (`configs/claude/scripts/spec_review.sh`) — front-end-agnostic: discovers artifacts (speckit `specs/<NNN>/` and superpowers `*-design.md` + plan-with-embedded-tasks), assembles a prompt, and shells `gemini -p` via an injectable seam (`SPEC_REVIEW_GEMINI`) using your existing CLI auth — no API key. Honors explicit `--spec/--plan/--tasks` or auto-discovers; `--format tree|json`.
- **On-demand** — `/spec-review` skill (already Antigravity-native via the symlinked skills dir).
- **Save hook** — a fail-open PostToolUse hook runs `spec_review.sh --silent`: **content-hash debounce** (runs on real content change, not a timestamp window), single-flight lock with **stale-lock self-heal**, and a **fully detached** `gemini` call so the agent loop never stalls. Findings land in `.spec-review/feedback.md` (gitignored).
- **Analysis-only** — never edits artifacts.

### Notes on scope
No `agi`/Antigravity CLI was built — Antigravity is an IDE here (symlink-only config), so there is no binary to extend. The engine is deliberately front-end-agnostic, so a real `agi spec-review` could wrap it in three lines later. This complements (not duplicates) the vendored `speckit-analyze`, which is speckit-only and Claude-driven.

Design: `docs/superpowers/specs/2026-06-08-spec-review-design.md`. Built spec → plan → subagent-driven TDD (9 tasks); four review rounds, all findings fixed.

## Test Plan

- [x] `bats tests/bats/spec_review.bats` — **27 passed** (gemini stubbed via the seam; network-free)
- [x] `bats tests/bats/` — **215 passed, 0 failures** (no regressions)
- [x] `shellcheck configs/claude/scripts/spec_review.sh` — clean
- [x] `settings.local.json` valid JSON; markdownlint clean over CI-gated globs
- [x] Verified: fail-open (non-zero gemini → exit 0), detached non-blocking, space-safe path hashing, stale-lock self-heal, explicit-flags path
- [ ] Manual smoke: run `~/.claude/scripts/spec_review.sh` over a real spec/plan pair with the `gemini` CLI logged in; confirm structured findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)