### PR TITLE
spec-review: switch reviewer from Gemini to agy (Antigravity)

### DIFF
--- a/.skillshare/skills/spec-review/SKILL.md
+++ b/.skillshare/skills/spec-review/SKILL.md
@@ -2,17 +2,17 @@
 name: spec-review
 description: |
   Cross-reference a project's spec / plan / tasks artifacts for internal
-  consistency using an independent model (Gemini), and surface structured
+  consistency using an independent model (Antigravity / `agy`), and surface structured
   remediation guidance (Location / Gap / Recommended Direction / Reason Why).
   Analysis-only — never edits artifacts. Works with both speckit
   (spec.md/plan.md/tasks.md) and superpowers (design + plan-with-embedded-tasks)
   layouts. Auto-discovers artifacts, or pass explicit paths.
 ---
 
-# Spec Review (Gemini cross-reference)
+# Spec Review (Antigravity cross-reference)
 
 Run an independent, analysis-only consistency check across the project's planning
-artifacts. A second model (Gemini) reviews what Claude authored — catching
+artifacts. A second model (Antigravity / `agy`) reviews what Claude authored — catching
 structural blind spots that self-review misses.
 
 ## How to run
@@ -29,5 +29,5 @@ structural blind spots that self-review misses.
 ```
 
 Findings print as a tree of `CLARIFICATION REQUIRED` blocks, or
-`✓ No inconsistencies found.` Requires the `gemini` CLI (logged in). This skill is
+`✓ No inconsistencies found.` Requires the `agy` CLI (logged in). This skill is
 analysis-only; apply the recommendations yourself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ The following slash commands are available in Claude Code:
 | `sync-skills` | Sync .skillshare/skills/ to all home targets (daily skill dev workflow) | NO |
 | `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run default) | NO |
 | `/pass-cli` | Retrieve credentials from Proton Pass vaults via `pass-cli` agent CLI | NO |
-| `/spec-review` | Independent Gemini cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; engine: `~/.claude/scripts/spec_review.sh` (`--spec/--plan/--tasks/--silent/--format`) | NO |
+| `/spec-review` | Independent Antigravity (agy) cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; engine: `~/.claude/scripts/spec_review.sh` (`--spec/--plan/--tasks/--silent/--format`) | NO |
 
 ## Testing Changes
 

--- a/configs/claude/CLAUDE.md
+++ b/configs/claude/CLAUDE.md
@@ -156,7 +156,7 @@ These integrate with the parallel agent orchestration framework.
 | `/branch-clean` | Prune merged/gone/stale branches safely (dry-run, local-only) | CONDITIONAL |
 | `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run default) | NO |
 | `/pass-cli` | Retrieve credentials from Proton Pass (auth is the user's step; PAT never stored) | NO |
-| `/spec-review` | Independent Gemini cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; engine: `~/.claude/scripts/spec_review.sh` (`--spec/--plan/--tasks/--silent/--format`) | NO |
+| `/spec-review` | Independent Antigravity (agy) cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; engine: `~/.claude/scripts/spec_review.sh` (`--spec/--plan/--tasks/--silent/--format`) | NO |
 
 ### Command Usage
 

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # spec_review.sh — cross-reference spec/plan/tasks artifacts for consistency via
-# the gemini CLI. Analysis-only: never edits artifacts. Front-end-agnostic — the
+# an independent reviewer CLI (default: agy / Antigravity). Analysis-only: never
+# edits artifacts. Reviewer is the injectable SPEC_REVIEW_CLI seam. Front-end-agnostic — the
 # /spec-review skill, the save hook, and any future CLI all wrap this script.
 #
 # Usage: spec_review.sh [--spec F] [--plan F] [--tasks F] [--silent] [--format tree|json] [ROOT]
@@ -17,7 +18,7 @@ SPEC=""; PLAN=""; TASKS=""; SILENT=false; FORMAT="tree"; ROOT="."
 err() { echo "spec-review: $*" >&2; }
 usage() {
     cat <<'EOF'
-spec-review — cross-reference spec/plan/tasks for consistency (Gemini, analysis-only)
+spec-review — cross-reference spec/plan/tasks for consistency (Antigravity/agy, analysis-only)
 
 Usage: spec_review.sh [--spec F] [--plan F] [--tasks F] [--silent] [--format tree|json] [ROOT]
 
@@ -166,13 +167,13 @@ resolve_artifacts() {
     discover_artifacts "$root"
 }
 
-# review ROOT FORMAT -> resolve, assemble, run gemini, format. Used on-demand.
+# review ROOT FORMAT -> resolve, assemble, run reviewer, format. Used on-demand.
 review() {
     local root="${1:-.}" fmt="${2:-tree}"
     local arts=() line
     while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(resolve_artifacts "$root")
     if [[ "${#arts[@]}" -eq 0 ]]; then echo "spec-review: nothing to review (no artifacts found)"; return 0; fi
-    echo "[spec-review] Cross-referencing project artifacts with Gemini…"
+    echo "[spec-review] Cross-referencing project artifacts with Antigravity (agy)…"
     local prompt raw; prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]}")"
     raw="$(run_reviewer "$prompt")"
     format_findings "$raw" "$fmt" "${#arts[@]}"
@@ -187,12 +188,12 @@ _silent_review_inline() {
     [[ "${#arts[@]}" -eq 0 ]] && return 0   # defensive: nothing to review (set -u safe)
     prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]}")"
     if ! raw="$(run_reviewer "$prompt" 2>>"$state/error.log")"; then
-        return 0   # fail-open: gemini failed, never block
+        return 0   # fail-open: reviewer failed, never block
     fi
     format_findings "$raw" "tree" > "$state/feedback.md.tmp" && mv "$state/feedback.md.tmp" "$state/feedback.md"
 }
 
-# Silent/hook entry: gate, single-flight lock, detach the gemini call.
+# Silent/hook entry: gate, single-flight lock, detach the reviewer call.
 run_silent() {
     local root="${1:-.}" state="$SPEC_REVIEW_STATE"
     if ! should_run_silent "$root" >/dev/null; then
@@ -211,7 +212,7 @@ run_silent() {
     if [[ -n "$SPEC_REVIEW_NO_DETACH" ]]; then
         _silent_review_inline "$root" || true; rmdir "$state/.lock" 2>/dev/null || true
     else
-        # Detach so the agent loop never waits on gemini; release lock when done.
+        # Detach so the agent loop never waits on the reviewer; release lock when done.
         ( _silent_review_inline "$root" || true; rmdir "$state/.lock" 2>/dev/null || true ) >/dev/null 2>&1 &
         disown 2>/dev/null || true
     fi

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SPEC_REVIEW_GEMINI="${SPEC_REVIEW_GEMINI:-gemini}"
+SPEC_REVIEW_CLI="${SPEC_REVIEW_CLI:-agy}"
 SPEC_REVIEW_TEMPLATE="${SPEC_REVIEW_TEMPLATE:-${SCRIPT_DIR}/../prompts/spec_review.md}"
 SPEC_REVIEW_STATE="${SPEC_REVIEW_STATE:-.spec-review}"
 SPEC_REVIEW_NO_DETACH="${SPEC_REVIEW_NO_DETACH:-}"
@@ -99,11 +99,11 @@ assemble_prompt() {
     return "$rc"
 }
 
-# run_gemini PROMPT -> raw gemini output. stdin carries the prompt body; the -p
+# run_reviewer PROMPT -> raw reviewer output. stdin carries the prompt body; the -p
 # instruction is short. Errors propagate (caller decides fail-open vs surface).
-run_gemini() {
+run_reviewer() {
     local prompt="$1"
-    printf '%s' "$prompt" | "$SPEC_REVIEW_GEMINI" -p "Cross-reference the artifacts above per the instructions; output only the specified blocks or NO_ISSUES."
+    printf '%s' "$prompt" | "$SPEC_REVIEW_CLI" -p "Cross-reference the artifacts above per the instructions; output only the specified blocks or NO_ISSUES."
 }
 
 # format_findings RAW FORMAT [COUNT] -> formatted output. NO_ISSUES -> clean
@@ -174,7 +174,7 @@ review() {
     if [[ "${#arts[@]}" -eq 0 ]]; then echo "spec-review: nothing to review (no artifacts found)"; return 0; fi
     echo "[spec-review] Cross-referencing project artifacts with Gemini…"
     local prompt raw; prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]}")"
-    raw="$(run_gemini "$prompt")"
+    raw="$(run_reviewer "$prompt")"
     format_findings "$raw" "$fmt" "${#arts[@]}"
 }
 
@@ -186,7 +186,7 @@ _silent_review_inline() {
     while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(discover_artifacts "$root")
     [[ "${#arts[@]}" -eq 0 ]] && return 0   # defensive: nothing to review (set -u safe)
     prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]}")"
-    if ! raw="$(run_gemini "$prompt" 2>>"$state/error.log")"; then
+    if ! raw="$(run_reviewer "$prompt" 2>>"$state/error.log")"; then
         return 0   # fail-open: gemini failed, never block
     fi
     format_findings "$raw" "tree" > "$state/feedback.md.tmp" && mv "$state/feedback.md.tmp" "$state/feedback.md"

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -47,7 +47,7 @@ Manifest ships with 19 slash commands and 1 CLI tool (34 skills total, 1 auto-tr
 | `/branch-clean` | Prune merged/gone/stale branches safely (dry-run by default, local-only) | CONDITIONAL (--apply) |
 | `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default); requires SkillClaw enabled | NEVER |
 | `/pass-cli` | Retrieve credentials from Proton Pass vaults via `pass-cli` agent CLI | NEVER |
-| `/spec-review` | Independent Gemini cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; works with speckit and superpowers layouts; silent-mode findings land in `.spec-review/feedback.md` | NO |
+| `/spec-review` | Independent Antigravity (agy) cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; works with speckit and superpowers layouts; silent-mode findings land in `.spec-review/feedback.md` | NO |
 
 **CLI tool** (installed to `~/.local/bin/`):
 

--- a/docs/superpowers/plans/2026-06-09-spec-review-agy-reviewer.md
+++ b/docs/superpowers/plans/2026-06-09-spec-review-agy-reviewer.md
@@ -1,0 +1,278 @@
+# spec-review → agy Reviewer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch the `/spec-review` engine's reviewer from `gemini` to `agy` (the Antigravity CLI), via a clean rename of the injectable seam — keeping the skill, save hook, debounce, detach, lock, and fail-open untouched.
+
+**Architecture:** Pure reviewer swap inside the existing, deployed spec-review system. Rename the seam `SPEC_REVIEW_GEMINI` → `SPEC_REVIEW_CLI` (default `gemini` → `agy`) and `run_gemini` → `run_reviewer` in `spec_review.sh`; update the bats suite's stub + injections in lock-step (the tests invoke these names directly, so script + tests must change together to stay green); update the four doc references. `agy -p` was verified to read stdin and print headless exactly like `gemini -p`, so the invocation body is unchanged.
+
+**Tech Stack:** Bash (3.2-safe), bats (bats-support/bats-assert), Markdown.
+
+---
+
+## File Structure
+
+**Modify:**
+- `configs/claude/scripts/spec_review.sh` — rename seam + function (6 references)
+- `tests/bats/spec_review.bats` — rename stub/injections/test name (16 references) + 1 new "default reviewer is agy" test
+- `.skillshare/skills/spec-review/SKILL.md` — Gemini → Antigravity/`agy` (4 spots)
+- `docs/COMMANDS.md`, `CLAUDE.md`, `configs/claude/CLAUDE.md` — `/spec-review` row: "Gemini" → "Antigravity (`agy`)"
+
+No new files. No behavior change beyond which CLI is invoked.
+
+---
+
+## Task 1: Coordinated reviewer rename (script + tests), default → agy
+
+**Files:**
+- Modify: `configs/claude/scripts/spec_review.sh`
+- Modify: `tests/bats/spec_review.bats`
+
+This is one atomic task: the bats suite calls `run_gemini` and injects `SPEC_REVIEW_GEMINI`, so renaming only the script would red the suite. Script + tests change together.
+
+- [ ] **Step 1: Edit `configs/claude/scripts/spec_review.sh` — the 6 references**
+
+Apply these exact replacements:
+
+Line ~10:
+```bash
+SPEC_REVIEW_CLI="${SPEC_REVIEW_CLI:-agy}"
+```
+(was `SPEC_REVIEW_GEMINI="${SPEC_REVIEW_GEMINI:-gemini}"`)
+
+Lines ~102-107 (comment + function + body):
+```bash
+# run_reviewer PROMPT -> raw reviewer output. stdin carries the prompt body; the -p
+# instruction is short. Errors propagate (caller decides fail-open vs surface).
+run_reviewer() {
+    local prompt="$1"
+    printf '%s' "$prompt" | "$SPEC_REVIEW_CLI" -p "Cross-reference the artifacts above per the instructions; output only the specified blocks or NO_ISSUES."
+}
+```
+(was `run_gemini` / `$SPEC_REVIEW_GEMINI`)
+
+Line ~177 (in `review()`):
+```bash
+    raw="$(run_reviewer "$prompt")"
+```
+
+Line ~189 (in `_silent_review_inline()`):
+```bash
+    if ! raw="$(run_reviewer "$prompt" 2>>"$state/error.log")"; then
+```
+
+Verify none remain:
+```bash
+grep -nE 'SPEC_REVIEW_GEMINI|run_gemini' configs/claude/scripts/spec_review.sh
+```
+Expected: no output.
+
+- [ ] **Step 2: Rename identifiers in `tests/bats/spec_review.bats`**
+
+Run (BSD/macOS sed):
+```bash
+sed -i '' \
+  -e 's/SPEC_REVIEW_GEMINI/SPEC_REVIEW_CLI/g' \
+  -e 's/run_gemini/run_reviewer/g' \
+  -e 's/_fake_gemini/_fake_reviewer/g' \
+  -e 's#\$SANDBOX/gemini#$SANDBOX/agy#g' \
+  tests/bats/spec_review.bats
+```
+This renames the seam injections, the function calls, the stub helper, and the stub's file path (`$SANDBOX/gemini` → `$SANDBOX/agy`).
+
+- [ ] **Step 3: Fix the residual `gemini` mentions the sed didn't catch (comment + stub heredoc)**
+
+The `_fake_reviewer` helper still has a comment and an internal stub naming "gemini". Replace the helper definition so it's clean. Open `tests/bats/spec_review.bats`, find the `_fake_reviewer()` helper (near line 83) and ensure it reads exactly:
+
+```bash
+_fake_reviewer() {  # writes a stub reviewer CLI named 'agy' into SANDBOX
+    cat > "$SANDBOX/agy" <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null   # consume stdin
+printf '⚠️  CLARIFICATION REQUIRED: Migration\n   ├─ Location: plan vs tasks\n   ├─ The Gap: zero-downtime vs destructive\n   ├─ Recommended Direction: split into 3 tasks\n   └─ Reason Why: locking violates the constraint\n'
+STUB
+    chmod +x "$SANDBOX/agy"
+}
+```
+
+Confirm no `gemini` remains:
+```bash
+grep -niE 'gemini' tests/bats/spec_review.bats
+```
+Expected: no output.
+
+- [ ] **Step 4: Run the suite — confirm it stays green**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: all existing tests PASS (27), zero failures. (The rename is behavior-preserving; the stub just has a new name.)
+
+Run: `shellcheck configs/claude/scripts/spec_review.sh`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): rename reviewer seam to SPEC_REVIEW_CLI, default to agy"
+```
+
+---
+
+## Task 2: Assert the default reviewer is `agy`
+
+**Files:**
+- Modify: `tests/bats/spec_review.bats`
+
+- [ ] **Step 1: Append the failing test**
+
+Add to `tests/bats/spec_review.bats`:
+
+```bash
+@test "default reviewer is agy when SPEC_REVIEW_CLI is unset" {
+    # Put a stub named 'agy' on PATH; do NOT set SPEC_REVIEW_CLI.
+    _fake_reviewer                      # creates $SANDBOX/agy
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    PATH="$SANDBOX:$PATH" \
+        SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" "$SANDBOX"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"
+}
+```
+
+- [ ] **Step 2: Run it — confirm it passes**
+
+Run: `bats tests/bats/spec_review.bats -f "default reviewer is agy"`
+Expected: PASS (the script's default `SPEC_REVIEW_CLI` is now `agy`, which resolves to the stub on PATH). If it FAILS with the stub not found, the default isn't `agy` — fix Task 1 Step 1.
+
+- [ ] **Step 3: Run the full file**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: 28 tests pass, zero failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/bats/spec_review.bats
+git commit -m "test(spec-review): assert default reviewer is agy"
+```
+
+---
+
+## Task 3: Update docs (skill + command tables)
+
+**Files:**
+- Modify: `.skillshare/skills/spec-review/SKILL.md`
+- Modify: `docs/COMMANDS.md`
+- Modify: `CLAUDE.md`
+- Modify: `configs/claude/CLAUDE.md`
+
+- [ ] **Step 1: `.skillshare/skills/spec-review/SKILL.md` — 4 replacements**
+
+- Line ~5: `consistency using an independent model (Gemini), and surface structured` → `consistency using an independent model (Antigravity / `agy`), and surface structured`
+- Line ~12 heading: `# Spec Review (Gemini cross-reference)` → `# Spec Review (Antigravity cross-reference)`
+- Line ~15: `artifacts. A second model (Gemini) reviews what Claude authored — catching` → `artifacts. A second model (Antigravity / `agy`) reviews what Claude authored — catching`
+- Line ~32: `` `✓ No inconsistencies found.` Requires the `gemini` CLI (logged in). This skill is `` → `` `✓ No inconsistencies found.` Requires the `agy` CLI (logged in). This skill is ``
+
+Confirm: `grep -niE 'gemini' .skillshare/skills/spec-review/SKILL.md` → no output.
+
+- [ ] **Step 2: The three `/spec-review` command-table rows**
+
+In each of `docs/COMMANDS.md`, `CLAUDE.md`, `configs/claude/CLAUDE.md`, replace `Independent Gemini cross-reference` with `Independent Antigravity (agy) cross-reference` in the `/spec-review` row.
+
+Exact edit (same string in all three):
+- Find: `| `/spec-review` | Independent Gemini cross-reference of spec/plan/tasks`
+- Replace `Independent Gemini cross-reference` → `Independent Antigravity (agy) cross-reference`
+
+- [ ] **Step 3: Verify no stray Gemini refs remain in spec-review surfaces**
+
+Run:
+```bash
+grep -rniE 'gemini' .skillshare/skills/spec-review/ docs/COMMANDS.md \
+  | grep -i 'spec-review\|spec_review\|cross-referenc' || echo "clean"
+grep -niE 'spec-review.*gemini|gemini.*spec-review' CLAUDE.md configs/claude/CLAUDE.md || echo "tables clean"
+```
+Expected: `clean` / `tables clean`.
+
+- [ ] **Step 4: Markdownlint the CI-gated docs**
+
+Run: `npx --yes markdownlint-cli2 "CLAUDE.md" "docs/COMMANDS.md"`
+Expected: 0 errors. (`configs/claude/CLAUDE.md` and the skill SKILL.md are not in the CI glob set — `AGENTS.md CLAUDE.md README.md docs/*.md` — but keep their edits clean anyway.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .skillshare/skills/spec-review/SKILL.md docs/COMMANDS.md CLAUDE.md configs/claude/CLAUDE.md
+git commit -m "docs(spec-review): reviewer is now Antigravity (agy), not Gemini"
+```
+
+---
+
+## Task 4: Full verification + real-`agy` headless smoke
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Grep guard — zero `gemini` / old-seam references anywhere in the spec-review surface**
+
+Run:
+```bash
+grep -rnE 'SPEC_REVIEW_GEMINI|run_gemini|_fake_gemini' \
+  configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats && echo "FOUND (bad)" || echo "no old identifiers ✓"
+```
+Expected: `no old identifiers ✓`.
+
+- [ ] **Step 2: Full suite + lint**
+
+Run:
+```bash
+bats tests/bats/spec_review.bats          # 28 pass
+bats tests/bats/                          # no regressions
+shellcheck configs/claude/scripts/spec_review.sh
+```
+Expected: all green; shellcheck clean.
+
+- [ ] **Step 3: Real-`agy` headless smoke (verification item #1 from the spec)**
+
+Confirm the actual `agy` CLI works through the engine in non-interactive mode without hanging on a tool-permission prompt (the review is pure text analysis). Bounded so a hang can't stall:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+mkdir -p /tmp/agysmoke/specs/001
+printf '# Spec\nUse a zero-downtime migration.\n' > /tmp/agysmoke/specs/001/spec.md
+printf '# Plan\nRun a destructive migration that locks tables.\n' > /tmp/agysmoke/specs/001/plan.md
+( SPEC_REVIEW_TEMPLATE="$PWD/configs/claude/prompts/spec_review.md" \
+    timeout_guard=300 bash configs/claude/scripts/spec_review.sh /tmp/agysmoke ) &
+PID=$!; ( sleep 300; kill -9 $PID 2>/dev/null ) & W=$!
+wait $PID; ec=$?; kill $W 2>/dev/null
+echo "exit=$ec"
+rm -rf /tmp/agysmoke
+```
+Expected: exit 0, and either structured `CLARIFICATION REQUIRED` findings (it should catch the zero-downtime vs destructive contradiction) or `✓ No inconsistencies found.` — and it must RETURN (no hang). If it hangs, note it: the detached silent path is unaffected (fail-open), but on-demand would need an explicit `--print-timeout`; capture that as a follow-up rather than blocking.
+
+- [ ] **Step 4: Commit (if any verification tweak was needed; otherwise skip)**
+
+```bash
+git add -A && git commit -m "chore(spec-review): verify agy reviewer end-to-end" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review (completed during plan authoring)
+
+**Spec coverage:**
+- Rename seam `SPEC_REVIEW_GEMINI` → `SPEC_REVIEW_CLI` (default agy) + `run_gemini` → `run_reviewer` → Task 1. ✓
+- bats stub/injection rename in lock-step → Task 1. ✓
+- "default reviewer is agy" test → Task 2. ✓
+- Docs (SKILL.md + 3 tables) → Task 3. ✓
+- Enforcement unchanged (hook/skill) — nothing to do; noted. ✓
+- Verification item #1 (headless no-hang) → Task 4 Step 3. ✓
+- Verification item #2 (5m timeout fine) — covered by the bounded smoke; no code change. ✓
+- grep guard / no lingering gemini → Tasks 1–4. ✓
+
+**Placeholder scan:** none — every edit shows exact before/after strings or exact sed/grep commands.
+
+**Type/name consistency:** the new names `SPEC_REVIEW_CLI`, `run_reviewer`, `_fake_reviewer`, and stub file `agy` are used identically across Tasks 1, 2, 4.
+
+**Note for executor:** `sed -i ''` is BSD/macOS syntax (this repo runs on macOS). On GNU/Linux use `sed -i` (no `''`). After Task 1's sed, re-read the `_fake_reviewer` helper to confirm Step 3's explicit form took (the sed renames identifiers/paths but Step 3 ensures the comment + stub filename are clean).

--- a/docs/superpowers/plans/2026-06-09-spec-review-agy-reviewer.md
+++ b/docs/superpowers/plans/2026-06-09-spec-review-agy-reviewer.md
@@ -18,7 +18,8 @@
 - `.skillshare/skills/spec-review/SKILL.md` — Gemini → Antigravity/`agy` (4 spots)
 - `docs/COMMANDS.md`, `CLAUDE.md`, `configs/claude/CLAUDE.md` — `/spec-review` row: "Gemini" → "Antigravity (`agy`)"
 
-No new files. No behavior change beyond which CLI is invoked.
+No new runtime files or engine components (this design + plan doc aside). No
+behavior change beyond which CLI is invoked.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-09-spec-review-agy-reviewer-design.md
+++ b/docs/superpowers/specs/2026-06-09-spec-review-agy-reviewer-design.md
@@ -1,0 +1,125 @@
+# spec-review: switch reviewer from Gemini to agy (Antigravity) — Design
+
+> Point the existing `/spec-review` engine at the `agy` (Antigravity) CLI instead
+> of `gemini`, so spec/plan/tasks artifacts are reviewed by Antigravity — on
+> demand and via the already-deployed save hook. A reviewer swap, not a new
+> subsystem.
+
+**Date**: 2026-06-09
+**Status**: Approved (design) — pending implementation plan
+**Audience**: Manifest maintainers
+
+---
+
+## Problem
+
+The `/spec-review` system (skill + `spec_review.sh` engine + fail-open PostToolUse
+save hook, all shipped and deployed) currently runs its independent review through
+the `gemini` CLI via an injectable seam (`SPEC_REVIEW_GEMINI`). The maintainer
+wants **Antigravity (`agy`)** to be the model that reviews specs, enforced through
+the existing skill + hook.
+
+`agy` (`~/.local/bin/agy`, v1.0.7) was verified to behave exactly like
+`gemini -p` / `claude -p`: it reads the piped prompt on stdin, runs headless with
+`-p/--print`, returns the response, and exits 0 (authenticated, no permission
+hang). So this is a **drop-in reviewer swap**.
+
+## Decision
+
+**Replace `gemini` with `agy` as the single spec reviewer.** The skill, hook,
+debounce, detach, lock, fail-open, and output formats are all model-agnostic and
+stay exactly as they are. To keep the seam honest, rename it to be reviewer-
+agnostic rather than gemini-specific, so a future swap is a one-line change.
+
+## Non-Goals
+
+- No multi-model / cross-model review (single reviewer = agy; "both gemini and
+  agy" was considered and declined).
+- No new skill, hook, or config file — enforcement already exists.
+- No change to discovery, prompt template, debounce, lock, or fail-open behavior.
+
+---
+
+## Change surface
+
+All within the existing spec-review system.
+
+- **`configs/claude/scripts/spec_review.sh`**
+  - Rename the seam `SPEC_REVIEW_GEMINI` → `SPEC_REVIEW_CLI`, default `gemini` →
+    **`agy`** (`SPEC_REVIEW_CLI="${SPEC_REVIEW_CLI:-agy}"`).
+  - Rename `run_gemini` → `run_reviewer`; the body is unchanged:
+    `printf '%s' "$prompt" | "$SPEC_REVIEW_CLI" -p "<instruction>"` (verified: agy
+    reads stdin, prints, exits 0). The instruction text is already model-agnostic.
+  - Update the two call sites (`review()` and `_silent_review_inline()`).
+
+- **`tests/bats/spec_review.bats`**
+  - Rename the `_fake_gemini` stub helper → `_fake_reviewer` and every
+    `SPEC_REVIEW_GEMINI=` injection → `SPEC_REVIEW_CLI=`. The stub is model-
+    agnostic (it just prints a structured finding), so all assertions hold; the
+    network-free seam is preserved.
+  - Add one test asserting the **default reviewer is `agy`** (e.g. the script,
+    with no `SPEC_REVIEW_CLI` set, invokes a stub named `agy` placed on PATH).
+
+- **Docs**
+  - `.skillshare/skills/spec-review/SKILL.md` — description "independent model
+    (Gemini)" → "independent model (Antigravity / `agy`)".
+  - The `/spec-review` rows in `docs/COMMANDS.md`, `CLAUDE.md`, and
+    `configs/claude/CLAUDE.md` — replace "Gemini" with "Antigravity (`agy`)".
+
+## Enforcement ("ensure it's followed") — already in place
+
+No new wiring needed:
+- The **deployed PostToolUse hook** runs `spec_review.sh --silent` on every
+  Write/Edit to spec/plan/tasks — after this swap it reviews via `agy`.
+- The **`/spec-review` skill** is the on-demand path.
+
+The change reaches the live environment the usual way: PR → merge → `./bootstrap.sh
+--skip-install --skip-auth` redeploy (the engine script + skill + docs).
+
+## Unchanged (model-agnostic)
+
+Content-hash debounce, detached execution, single-flight + stale-lock self-heal,
+fail-open, `--format tree|json`, discovery (speckit + superpowers), and the prompt
+template.
+
+## Verification items (carried into the plan)
+
+1. **Headless hook mode:** confirm `agy -p` in the **detached, no-TTY** silent
+   path doesn't stall on a tool-permission prompt. The review is pure text
+   analysis (the artifacts are piped into the prompt), so agy shouldn't invoke
+   tools — but a guarded bats/integration check should confirm it returns and the
+   fail-open path still holds if it doesn't.
+2. **Timeout:** `agy` default `--print-timeout` is 5m; fine for the detached
+   silent path (nothing waits on it) and acceptable on demand. No flag needed in
+   V1; revisit only if runs hang.
+
+## Testing
+
+- **bats `spec_review.bats`:** all existing tests pass after the rename (seam +
+  stub renamed); the new "default reviewer is `agy`" test; fail-open and detached
+  behavior unchanged.
+- **shellcheck** clean on `spec_review.sh`.
+- **grep guard:** no remaining `SPEC_REVIEW_GEMINI` / `run_gemini` / `_fake_gemini`
+  references in scripts, tests, or docs.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| `agy` stalls on a permission prompt in headless hook mode | Review prompt is pure text (no tool use); guarded test; fail-open already swallows a non-zero/timeout in silent mode |
+| Lingering `gemini` references after rename | grep guard in the test suite + final review |
+| Operators expect the old `SPEC_REVIEW_GEMINI` env var | It's an internal test/override seam, not user-facing; documented in the script header comment under the new name |
+
+## Follow-ups (not in V1)
+
+- Configurable reviewer (`gemini | agy | both`) if cross-model review is wanted
+  later — the renamed seam makes this a small addition.
+- A `--reviewer` flag / `skillclaw.yml`-style config if per-run selection is
+  needed.
+
+---
+
+## Related Documents
+
+- [spec-review design](2026-06-08-spec-review-design.md) — the system this swaps the reviewer in
+- [docs/SKILLCLAW.md](../../SKILLCLAW.md)

--- a/docs/superpowers/specs/2026-06-09-spec-review-agy-reviewer-design.md
+++ b/docs/superpowers/specs/2026-06-09-spec-review-agy-reviewer-design.md
@@ -6,7 +6,8 @@
 > subsystem.
 
 **Date**: 2026-06-09
-**Status**: Approved (design) — pending implementation plan
+**Status**: Approved — implementation plan and change landed (see
+`docs/superpowers/plans/2026-06-09-spec-review-agy-reviewer.md`)
 **Audience**: Manifest maintainers
 
 ---

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -282,3 +282,16 @@ STUB
     assert_success
     assert_output --partial "No inconsistencies found across 2 artifacts"
 }
+
+@test "default reviewer is agy when SPEC_REVIEW_CLI is unset" {
+    # Put a stub named 'agy' on PATH; do NOT set SPEC_REVIEW_CLI.
+    _fake_reviewer                      # creates $SANDBOX/agy
+    mkdir -p "$SANDBOX/specs/001"
+    printf 's\n' > "$SANDBOX/specs/001/spec.md"
+    printf 'p\n' > "$SANDBOX/specs/001/plan.md"
+    PATH="$SANDBOX:$PATH" \
+        SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" "$SANDBOX"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"
+}

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -80,19 +80,19 @@ TAIL
     refute_output --partial "{{ARTIFACTS}}"
 }
 
-_fake_gemini() {  # writes a stub gemini onto PATH inside SANDBOX
-    cat > "$SANDBOX/gemini" <<'STUB'
+_fake_reviewer() {  # writes a stub reviewer CLI named 'agy' into SANDBOX
+    cat > "$SANDBOX/agy" <<'STUB'
 #!/usr/bin/env bash
 cat >/dev/null   # consume stdin
 printf '⚠️  CLARIFICATION REQUIRED: Migration\n   ├─ Location: plan vs tasks\n   ├─ The Gap: zero-downtime vs destructive\n   ├─ Recommended Direction: split into 3 tasks\n   └─ Reason Why: locking violates the constraint\n'
 STUB
-    chmod +x "$SANDBOX/gemini"
+    chmod +x "$SANDBOX/agy"
 }
 
-@test "run_gemini pipes prompt through the injectable seam" {
-    _fake_gemini
+@test "run_reviewer pipes prompt through the injectable seam" {
+    _fake_reviewer
     source "$SCRIPT"
-    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" run run_gemini "any prompt"
+    SPEC_REVIEW_CLI="$SANDBOX/agy" run run_reviewer "any prompt"
     assert_success
     assert_output --partial "CLARIFICATION REQUIRED: Migration"
 }
@@ -103,7 +103,7 @@ STUB
     assert_output --partial "CLARIFICATION REQUIRED: X"
 }
 
-@test "format_findings reports clean when gemini returns NO_ISSUES" {
+@test "format_findings reports clean when reviewer returns NO_ISSUES" {
     source "$SCRIPT"
     run format_findings "NO_ISSUES" "tree"
     assert_success
@@ -156,12 +156,12 @@ STUB
     run should_run_silent "$SANDBOX"; assert_success          # changed again
 }
 
-@test "on-demand review prints findings from the mocked gemini" {
-    _fake_gemini
+@test "on-demand review prints findings from the mocked reviewer" {
+    _fake_reviewer
     mkdir -p "$SANDBOX/specs/001"
     printf 's\n' > "$SANDBOX/specs/001/spec.md"
     printf 'p\n' > "$SANDBOX/specs/001/plan.md"
-    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+    SPEC_REVIEW_CLI="$SANDBOX/agy" SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
         run bash "$SCRIPT" "$SANDBOX"
     assert_success
     assert_output --partial "CLARIFICATION REQUIRED: Migration"
@@ -174,11 +174,11 @@ STUB
 }
 
 @test "silent mode writes feedback file and exits 0 (inline via NO_DETACH)" {
-    _fake_gemini
+    _fake_reviewer
     mkdir -p "$SANDBOX/specs/001"
     printf 's\n' > "$SANDBOX/specs/001/spec.md"
     printf 'p\n' > "$SANDBOX/specs/001/plan.md"
-    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_NO_DETACH=1 \
+    SPEC_REVIEW_CLI="$SANDBOX/agy" SPEC_REVIEW_NO_DETACH=1 \
         SPEC_REVIEW_STATE="$SANDBOX/.spec-review" \
         SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
         run bash "$SCRIPT" --silent "$SANDBOX"
@@ -188,12 +188,12 @@ STUB
     assert_output --partial "CLARIFICATION REQUIRED: Migration"
 }
 
-@test "silent mode fails open: non-zero gemini still exits 0" {
-    printf '#!/usr/bin/env bash\nexit 3\n' > "$SANDBOX/gemini"; chmod +x "$SANDBOX/gemini"
+@test "silent mode fails open: non-zero reviewer still exits 0" {
+    printf '#!/usr/bin/env bash\nexit 3\n' > "$SANDBOX/agy"; chmod +x "$SANDBOX/agy"
     mkdir -p "$SANDBOX/specs/001"
     printf 's\n' > "$SANDBOX/specs/001/spec.md"
     printf 'p\n' > "$SANDBOX/specs/001/plan.md"
-    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_NO_DETACH=1 \
+    SPEC_REVIEW_CLI="$SANDBOX/agy" SPEC_REVIEW_NO_DETACH=1 \
         SPEC_REVIEW_STATE="$SANDBOX/.spec-review" \
         SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
         run bash "$SCRIPT" --silent "$SANDBOX"
@@ -201,11 +201,11 @@ STUB
 }
 
 @test "silent mode is a no-op on unchanged content (second run)" {
-    _fake_gemini
+    _fake_reviewer
     mkdir -p "$SANDBOX/specs/001"
     printf 's\n' > "$SANDBOX/specs/001/spec.md"
     printf 'p\n' > "$SANDBOX/specs/001/plan.md"
-    local env="SPEC_REVIEW_GEMINI=$SANDBOX/gemini SPEC_REVIEW_NO_DETACH=1 SPEC_REVIEW_STATE=$SANDBOX/.spec-review SPEC_REVIEW_TEMPLATE=$REPO_ROOT/configs/claude/prompts/spec_review.md"
+    local env="SPEC_REVIEW_CLI=$SANDBOX/agy SPEC_REVIEW_NO_DETACH=1 SPEC_REVIEW_STATE=$SANDBOX/.spec-review SPEC_REVIEW_TEMPLATE=$REPO_ROOT/configs/claude/prompts/spec_review.md"
     env $env bash "$SCRIPT" --silent "$SANDBOX"
     rm -f "$SANDBOX/.spec-review/feedback.md"
     env $env bash "$SCRIPT" --silent "$SANDBOX"   # unchanged -> skip, no rewrite
@@ -213,14 +213,14 @@ STUB
 }
 
 @test "silent mode self-heals a stale lock (older than 10 min)" {
-    _fake_gemini
+    _fake_reviewer
     mkdir -p "$SANDBOX/specs/001"
     printf 's\n' > "$SANDBOX/specs/001/spec.md"
     printf 'p\n' > "$SANDBOX/specs/001/plan.md"
     mkdir -p "$SANDBOX/.spec-review/.lock"
     # age the stale lock 20 minutes into the past
     touch -t "$(date -v-20M +%Y%m%d%H%M 2>/dev/null || date -d '20 min ago' +%Y%m%d%H%M)" "$SANDBOX/.spec-review/.lock"
-    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_NO_DETACH=1 \
+    SPEC_REVIEW_CLI="$SANDBOX/agy" SPEC_REVIEW_NO_DETACH=1 \
         SPEC_REVIEW_STATE="$SANDBOX/.spec-review" \
         SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
         run bash "$SCRIPT" --silent "$SANDBOX"
@@ -260,24 +260,24 @@ STUB
 }
 
 @test "explicit --spec/--plan flags are used instead of auto-discovery" {
-    _fake_gemini
+    _fake_reviewer
     printf 's\n' > "$SANDBOX/myspec.md"
     printf 'p\n' > "$SANDBOX/myplan.md"
     # ROOT has no discoverable layout; only the explicit flags point at artifacts
-    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+    SPEC_REVIEW_CLI="$SANDBOX/agy" SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
         run bash "$SCRIPT" --spec "$SANDBOX/myspec.md" --plan "$SANDBOX/myplan.md" "$SANDBOX"
     assert_success
     assert_output --partial "CLARIFICATION REQUIRED: Migration"
 }
 
 @test "clean message includes the artifact count" {
-    # gemini stub that reports no issues
-    printf '#!/usr/bin/env bash\ncat >/dev/null\nprintf NO_ISSUES\n' > "$SANDBOX/gemini"
-    chmod +x "$SANDBOX/gemini"
+    # reviewer stub that reports no issues
+    printf '#!/usr/bin/env bash\ncat >/dev/null\nprintf NO_ISSUES\n' > "$SANDBOX/agy"
+    chmod +x "$SANDBOX/agy"
     mkdir -p "$SANDBOX/specs/001"
     printf 's\n' > "$SANDBOX/specs/001/spec.md"
     printf 'p\n' > "$SANDBOX/specs/001/plan.md"
-    SPEC_REVIEW_GEMINI="$SANDBOX/gemini" SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+    SPEC_REVIEW_CLI="$SANDBOX/agy" SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
         run bash "$SCRIPT" "$SANDBOX"
     assert_success
     assert_output --partial "No inconsistencies found across 2 artifacts"


### PR DESCRIPTION
## Summary

Switches the `/spec-review` engine's reviewer from `gemini` to **`agy`** (the Antigravity CLI). A behavior-preserving reviewer swap inside the existing, deployed spec-review system — the skill, fail-open PostToolUse save hook, content-hash debounce, detached execution, single-flight lock, and output formats are all model-agnostic and untouched.

- **Engine** (`configs/claude/scripts/spec_review.sh`): rename the injectable seam `SPEC_REVIEW_GEMINI` → `SPEC_REVIEW_CLI` (default `gemini` → **`agy`**) and `run_gemini` → `run_reviewer`. The invocation body is identical (`printf '%s' "$prompt" | "$SPEC_REVIEW_CLI" -p "<same instruction>"`) — `agy -p` was verified to read stdin and print headless exactly like `gemini -p`. User-visible strings (banner, `--help`) now name Antigravity (agy).
- **Tests** (`tests/bats/spec_review.bats`): stub/injections renamed in lock-step; new test asserts the default reviewer is `agy` (stub on PATH, seam unset) — a genuine falsifier.
- **Docs**: `spec-review` SKILL.md + the three `/spec-review` command tables (COMMANDS.md, CLAUDE.md, configs/claude/CLAUDE.md) now say Antigravity (agy).
- **Enforcement unchanged**: the already-deployed save hook auto-reviews spec/plan/tasks on Write/Edit — after this swap, via `agy`.

Design/plan: `docs/superpowers/specs/2026-06-09-spec-review-agy-reviewer-design.md`. Built spec → plan → subagent-driven TDD (4 tasks); final whole-branch review returned READY TO MERGE with no findings.

## Test Plan

- [x] `bats tests/bats/spec_review.bats` — **28 passed** (incl. default-agy test; network-free via stub)
- [x] `bats tests/bats/` — **217 passed, 0 failures**
- [x] `shellcheck` clean; markdownlint clean over CI globs
- [x] Grep guard: zero `gemini`/old-seam references in engine, tests, or skill
- [x] **Real-`agy` end-to-end smoke**: ran the actual engine over a contrived spec/plan contradiction — `agy` correctly flagged zero-downtime vs destructive migration in the structured format, exit 0, headless, no permission-prompt hang
- [ ] Post-merge: redeploy via `./bootstrap.sh --skip-install --skip-auth` so the live engine + skill + docs pick up the swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)