### PR TITLE
feat(skillclaw): promote audit log + live status/ETA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes are documented here in reverse chronological order.
 
 ## [Unreleased]
 
+### Added
+- **SkillClaw promote audit log + live status/ETA** — new `skillclaw_audit.py`
+  writes an append-only `~/.skillclaw/promote.log` (JSONL history, self-trimmed to
+  ~50 runs) and a live `status.json` snapshot. `skillclaw_promote.sh --status`
+  reports where a run is and a rough ETA; the evolve stage prints per-chunk
+  progress. Fail-open: audit I/O never blocks a promote run.
+
 ## [2026-05]
 
 ### Added

--- a/configs/claude/scripts/skillclaw_audit.py
+++ b/configs/claude/scripts/skillclaw_audit.py
@@ -73,6 +73,86 @@ def _write_atomic(path: Path, data: str) -> None:
             pass
 
 
+def _read_status() -> dict:
+    try:
+        return json.loads(_status_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def _fresh_status(run_id: str) -> dict:
+    now = _now_iso()
+    return {
+        "run_id": run_id,
+        "started_at": now,
+        "updated_at": now,
+        "state": RUNNING,
+        "stage": "-",
+        "evolve": None,
+        "totals": {"ingested": None, "candidates": None, "dropped": None},
+        "pr_url": None,
+    }
+
+
+def _apply_event(status: dict, stage: str, event: str, fields: dict) -> dict:
+    status["updated_at"] = _now_iso()
+    if stage and stage != "-":
+        status["stage"] = stage
+    if event == "run_start":
+        cfg = status.setdefault("config", {})
+        for k in ("window_days", "token_budget", "apply"):
+            if k in fields:
+                cfg[k] = fields[k]
+    elif event == "stage_start" and stage == "evolve":
+        status["evolve"] = {"chunk": 0, "total": fields.get("chunks", 0),
+                            "elapsed_s": 0, "eta_s": None, "eta_label": "estimating…"}
+    elif event == "stage_end" and "ingested" in fields:
+        status["totals"]["ingested"] = fields["ingested"]
+    elif event == "chunk_done":
+        done, total = fields.get("i", 0), fields.get("total", 0)
+        elapsed = fields.get("elapsed_s", 0)
+        eta_s, label = compute_eta(done, total, elapsed)
+        status["evolve"] = {"chunk": done, "total": total, "elapsed_s": elapsed,
+                            "eta_s": eta_s, "eta_label": label}
+    elif event == "candidates":
+        new = fields.get("new") or []
+        changed = fields.get("changed") or []
+        dropped = fields.get("dropped") or []
+        status["totals"]["candidates"] = len(new) + len(changed)
+        status["totals"]["dropped"] = len(dropped)
+    elif event == "pr_opened":
+        status["pr_url"] = fields.get("url")
+    elif event == "run_end":
+        status["state"] = fields.get("state", DONE)
+        status["stage"] = "-"
+        status["total_seconds"] = fields.get("total_seconds")
+    elif event == "run_error":
+        status["state"] = FAILED
+        status["error_stage"] = stage
+        status["message"] = fields.get("message")
+    return status
+
+
+def log(run_id, stage, event, **fields):
+    """Append one JSONL audit line and update the live status snapshot. Fail-open."""
+    try:
+        _ensure_storage()
+        line = {"ts": _now_iso(), "run_id": run_id, "stage": stage, "event": event}
+        line.update(fields)
+        with _log_path().open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(line) + "\n")
+        try:
+            os.chmod(_log_path(), 0o600)
+        except OSError:
+            pass
+        current = _read_status()
+        if event == "run_start" or current.get("run_id") != run_id:
+            current = _fresh_status(run_id)
+        _write_atomic(_status_path(), json.dumps(_apply_event(current, stage, event, fields), indent=2))
+    except Exception:  # noqa: BLE001 - fail-open: never raise into the pipeline
+        return
+
+
 def compute_eta(chunks_done, chunks_total, elapsed_s):
     """Return (eta_s|None, label).
 

--- a/configs/claude/scripts/skillclaw_audit.py
+++ b/configs/claude/scripts/skillclaw_audit.py
@@ -182,6 +182,8 @@ def _fmt_secs(s):
         s = int(round(float(s)))
     except (TypeError, ValueError):
         return "?"
+    if s < 0:
+        return "?"
     return "%dm%02ds" % (s // 60, s % 60) if s >= 60 else "%ds" % s
 
 
@@ -209,15 +211,17 @@ def render_status():
             return "run %s · stale (no live process)" % short
         if state == FAILED:
             return "last run: failed · stage %s" % st.get("error_stage", "?")
-        tot = st.get("totals", {})
-        parts = ["last run: done"]
-        if tot.get("candidates") is not None:
-            parts.append("%s candidates" % tot["candidates"])
-        if st.get("pr_url"):
-            parts.append("PR %s" % st["pr_url"])
-        if st.get("total_seconds") is not None:
-            parts.append(_fmt_secs(st["total_seconds"]))
-        return " · ".join(parts)
+        if state == DONE:
+            tot = st.get("totals", {})
+            parts = ["last run: done"]
+            if tot.get("candidates") is not None:
+                parts.append("%s candidates" % tot["candidates"])
+            if st.get("pr_url"):
+                parts.append("PR %s" % st["pr_url"])
+            if st.get("total_seconds") is not None:
+                parts.append(_fmt_secs(st["total_seconds"]))
+            return " · ".join(parts)
+        return "no recent run"
     except Exception:  # noqa: BLE001 - fail-open
         return "no recent run"
 

--- a/configs/claude/scripts/skillclaw_audit.py
+++ b/configs/claude/scripts/skillclaw_audit.py
@@ -94,6 +94,7 @@ def _fresh_status(run_id: str) -> dict:
     }
 
 
+# Mutates `status` in place and returns it (caller passes a dict it does not retain).
 def _apply_event(status: dict, stage: str, event: str, fields: dict) -> dict:
     status["updated_at"] = _now_iso()
     if stage and stage != "-":
@@ -139,6 +140,8 @@ def log(run_id, stage, event, **fields):
         _ensure_storage()
         line = {"ts": _now_iso(), "run_id": run_id, "stage": stage, "event": event}
         line.update(fields)
+        # promote.log is the authoritative record; status.json is best-effort and
+        # may lag the log by one event if the process dies between the two writes.
         with _log_path().open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(line) + "\n")
         try:

--- a/configs/claude/scripts/skillclaw_audit.py
+++ b/configs/claude/scripts/skillclaw_audit.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""SkillClaw promote audit log + live status/ETA engine.
+
+Single source of truth for two artifacts under ~/.skillclaw/:
+  - promote.log : append-only JSONL audit history (one event per line)
+  - status.json : overwritten snapshot of the current/last run + rough ETA
+
+Fail-open by construction: every public function swallows I/O errors and returns
+cleanly, so audit logging can never abort or delay a promote run.
+
+CLI (always invoked as `python3 "${SCRIPT_DIR}/skillclaw_audit.py" <cmd>`):
+    log <run_id> <stage> <event> [key=value ...]
+    status
+    trim [--max-runs N]
+
+Env overrides (tests): SKILLCLAW_AUDIT_DIR (default ~/.skillclaw).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_HOME = "~/.skillclaw"
+MAX_RUNS = 50
+RUNNING, DONE, FAILED, STALE = "running", "done", "failed", "stale"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _audit_dir() -> Path:
+    return Path(os.environ.get("SKILLCLAW_AUDIT_DIR", DEFAULT_HOME)).expanduser()
+
+
+def _log_path() -> Path:
+    return _audit_dir() / "promote.log"
+
+
+def _status_path() -> Path:
+    return _audit_dir() / "status.json"
+
+
+def _ensure_storage() -> Path:
+    """mkdir -p ~/.skillclaw (700) so a fresh install never silently logs nothing."""
+    d = _audit_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:
+        pass
+    return d
+
+
+def _write_atomic(path: Path, data: str) -> None:
+    """Write via a .tmp sibling + os.replace so concurrent reads never see a torn file."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(data, encoding="utf-8")
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+
+
+def compute_eta(chunks_done, chunks_total, elapsed_s):
+    """Return (eta_s|None, label).
+
+    `estimating…` until >=2 chunks are done and inputs are sane; otherwise a
+    linear projection. Guards prevent negative/div-by-zero ETAs from corrupt or
+    out-of-order status.
+    """
+    try:
+        if chunks_done < 2 or chunks_total <= chunks_done or elapsed_s <= 0:
+            return (None, "estimating…")
+        eta_s = (chunks_total - chunks_done) * (elapsed_s / chunks_done)
+        return (eta_s, "~%dm left (est)" % max(1, round(eta_s / 60)))
+    except (TypeError, ValueError):
+        return (None, "estimating…")

--- a/configs/claude/scripts/skillclaw_audit.py
+++ b/configs/claude/scripts/skillclaw_audit.py
@@ -156,6 +156,72 @@ def log(run_id, stage, event, **fields):
         return
 
 
+def _pid_from_run_id(run_id):
+    try:
+        return int(str(run_id).rsplit("-", 1)[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def _pid_alive(pid):
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True   # exists but owned by another user
+    except OSError:
+        return False
+    return True
+
+
+def _fmt_secs(s):
+    try:
+        s = int(round(float(s)))
+    except (TypeError, ValueError):
+        return "?"
+    return "%dm%02ds" % (s // 60, s % 60) if s >= 60 else "%ds" % s
+
+
+def render_status():
+    """One-glance human summary for --status. Fail-open -> 'no recent run'."""
+    try:
+        st = _read_status()
+        if not st:
+            return "no recent run"
+        state = st.get("state")
+        run_id = st.get("run_id", "?")
+        short = str(run_id).split("-")[0][:13]
+        if state == RUNNING and not _pid_alive(_pid_from_run_id(run_id)):
+            state = STALE
+        if state == RUNNING:
+            ev = st.get("evolve") or {}
+            stage = st.get("stage", "?")
+            if stage == "evolve" and ev.get("total"):
+                return ("run %s · evolve · chunk %s/%s · %s elapsed · %s"
+                        % (short, ev.get("chunk"), ev.get("total"),
+                           _fmt_secs(ev.get("elapsed_s")),
+                           ev.get("eta_label", "estimating…")))
+            return "run %s · %s · running" % (short, stage)
+        if state == STALE:
+            return "run %s · stale (no live process)" % short
+        if state == FAILED:
+            return "last run: failed · stage %s" % st.get("error_stage", "?")
+        tot = st.get("totals", {})
+        parts = ["last run: done"]
+        if tot.get("candidates") is not None:
+            parts.append("%s candidates" % tot["candidates"])
+        if st.get("pr_url"):
+            parts.append("PR %s" % st["pr_url"])
+        if st.get("total_seconds") is not None:
+            parts.append(_fmt_secs(st["total_seconds"]))
+        return " · ".join(parts)
+    except Exception:  # noqa: BLE001 - fail-open
+        return "no recent run"
+
+
 def compute_eta(chunks_done, chunks_total, elapsed_s):
     """Return (eta_s|None, label).
 

--- a/configs/claude/scripts/skillclaw_audit.py
+++ b/configs/claude/scripts/skillclaw_audit.py
@@ -56,14 +56,21 @@ def _ensure_storage() -> Path:
 
 
 def _write_atomic(path: Path, data: str) -> None:
-    """Write via a .tmp sibling + os.replace so concurrent reads never see a torn file."""
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(data, encoding="utf-8")
+    """Write via a unique .tmp sibling + os.replace so concurrent readers never
+    see a torn file and two writers never collide on the same tmp name."""
+    tmp = path.parent / ("%s.%d.tmp" % (path.name, os.getpid()))
     try:
-        os.chmod(tmp, 0o600)
-    except OSError:
-        pass
-    os.replace(tmp, path)
+        tmp.write_text(data, encoding="utf-8")
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
 
 
 def compute_eta(chunks_done, chunks_total, elapsed_s):
@@ -77,6 +84,8 @@ def compute_eta(chunks_done, chunks_total, elapsed_s):
         if chunks_done < 2 or chunks_total <= chunks_done or elapsed_s <= 0:
             return (None, "estimating…")
         eta_s = (chunks_total - chunks_done) * (elapsed_s / chunks_done)
+        # Deliberately minute-granular and rough: any sub-minute ETA rounds up to
+        # "~1m left (est)" — the label is an explicit estimate, not a countdown.
         return (eta_s, "~%dm left (est)" % max(1, round(eta_s / 60)))
     except (TypeError, ValueError):
         return (None, "estimating…")

--- a/configs/claude/scripts/skillclaw_audit.py
+++ b/configs/claude/scripts/skillclaw_audit.py
@@ -226,6 +226,35 @@ def render_status():
         return "no recent run"
 
 
+def trim(max_runs=MAX_RUNS):
+    """Keep only events for the most recent max_runs run_ids. Atomic. Fail-open."""
+    try:
+        path = _log_path()
+        if not path.exists():
+            return
+        lines = path.read_text(encoding="utf-8").splitlines()
+        order, seen = [], set()
+        for ln in lines:
+            try:
+                rid = json.loads(ln).get("run_id")
+            except ValueError:
+                continue
+            if rid not in seen:
+                seen.add(rid)
+                order.append(rid)
+        keep = set(order[-max_runs:])
+        kept = []
+        for ln in lines:
+            try:
+                if json.loads(ln).get("run_id") in keep:
+                    kept.append(ln)
+            except ValueError:
+                continue
+        _write_atomic(path, "\n".join(kept) + ("\n" if kept else ""))
+    except Exception:  # noqa: BLE001 - fail-open
+        return
+
+
 def compute_eta(chunks_done, chunks_total, elapsed_s):
     """Return (eta_s|None, label).
 

--- a/configs/claude/scripts/skillclaw_audit.py
+++ b/configs/claude/scripts/skillclaw_audit.py
@@ -255,6 +255,43 @@ def trim(max_runs=MAX_RUNS):
         return
 
 
+def _parse_kv(pairs):
+    """Parse `key=value` argv pairs; JSON-decode each value, else keep the string."""
+    out = {}
+    for p in pairs:
+        if "=" not in p:
+            continue
+        k, v = p.split("=", 1)
+        try:
+            out[k] = json.loads(v)
+        except ValueError:
+            out[k] = v
+    return out
+
+
+def main(argv):
+    if not argv or argv[0] == "status":
+        print(render_status())
+        return 0
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "trim":
+        mx = MAX_RUNS
+        if "--max-runs" in rest:
+            i = rest.index("--max-runs")
+            try:
+                mx = int(rest[i + 1])
+            except (IndexError, ValueError):
+                mx = MAX_RUNS
+        trim(mx)
+        return 0
+    if cmd == "log":
+        if len(rest) < 3:
+            return 0  # fail-open: a malformed call never errors the pipeline
+        log(rest[0], rest[1], rest[2], **_parse_kv(rest[3:]))
+        return 0
+    return 0  # unknown subcommand: fail-open
+
+
 def compute_eta(chunks_done, chunks_total, elapsed_s):
     """Return (eta_s|None, label).
 
@@ -271,3 +308,7 @@ def compute_eta(chunks_done, chunks_total, elapsed_s):
         return (eta_s, "~%dm left (est)" % max(1, round(eta_s / 60)))
     except (TypeError, ValueError):
         return (None, "estimating…")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/configs/claude/scripts/skillclaw_evolve.py
+++ b/configs/claude/scripts/skillclaw_evolve.py
@@ -143,13 +143,14 @@ def evolve(sessions_dir, evolved_dir, template_path, *,
     sessions = load_sessions(sessions_dir)
     template = Path(template_path).expanduser().read_text(encoding="utf-8")
     library = _library_names(committed_dir if committed_dir is not None else evolved_dir)
-    if not sessions:
-        return {"candidates": 0, "chunks": 0, "written": []}
-
     chunks = chunk_sessions(sessions, token_budget)
+    # Emit stage_start before the empty-sessions short-circuit so --status reflects
+    # that evolve ran (and skipped) rather than showing a stale prior stage.
     audit_mod = audit if audit is not None else (_load_audit() if run_id else None)
     if audit_mod and run_id:
         audit_mod.log(run_id, "evolve", "stage_start", chunks=len(chunks))
+    if not sessions:
+        return {"candidates": 0, "chunks": 0, "written": []}
 
     mapped: list[dict] = []
     start = time.monotonic()

--- a/configs/claude/scripts/skillclaw_evolve.py
+++ b/configs/claude/scripts/skillclaw_evolve.py
@@ -16,10 +16,25 @@ import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 DEFAULT_TOKEN_BUDGET = 100_000
 _SKILL_RE = re.compile(r"~~~skill name=(?P<name>[^\n]+)\n(?P<body>.*?)~~~", re.DOTALL)
+
+
+def _load_audit():
+    """Import the audit logger lazily; return None if unavailable (fail-open)."""
+    try:
+        import skillclaw_audit
+        return skillclaw_audit
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _fmt_elapsed(s: float) -> str:
+    s = int(round(s))
+    return "%dm%02ds" % (s // 60, s % 60) if s >= 60 else "%ds" % s
 
 
 def estimate_tokens(text: str) -> int:
@@ -117,7 +132,8 @@ def _library_names(skills_dir: Path) -> list[str]:
 
 
 def evolve(sessions_dir, evolved_dir, template_path, *,
-           committed_dir=None, token_budget=DEFAULT_TOKEN_BUDGET, runner=subprocess_runner) -> dict:
+           committed_dir=None, token_budget=DEFAULT_TOKEN_BUDGET, runner=subprocess_runner,
+           run_id=None, audit=None) -> dict:
     """Map-reduce sessions into SKILL.md candidates. Returns a summary dict.
 
     The prompt's "existing library" is the committed library (committed_dir) so
@@ -131,10 +147,22 @@ def evolve(sessions_dir, evolved_dir, template_path, *,
         return {"candidates": 0, "chunks": 0, "written": []}
 
     chunks = chunk_sessions(sessions, token_budget)
+    audit_mod = audit if audit is not None else (_load_audit() if run_id else None)
+    if audit_mod and run_id:
+        audit_mod.log(run_id, "evolve", "stage_start", chunks=len(chunks))
+
     mapped: list[dict] = []
-    for chunk in chunks:
+    start = time.monotonic()
+    for idx, chunk in enumerate(chunks, 1):
         out = runner(build_prompt(template, chunk, library))
         mapped.extend(parse_candidates(out))
+        if audit_mod and run_id:
+            elapsed = time.monotonic() - start
+            audit_mod.log(run_id, "evolve", "chunk_done", i=idx, total=len(chunks),
+                          chunk_seconds=round(elapsed, 1), elapsed_s=round(elapsed, 1))
+            _, label = audit_mod.compute_eta(idx, len(chunks), elapsed)
+            print("[skillclaw] evolve · chunk %d/%d · %s · %s"
+                  % (idx, len(chunks), _fmt_elapsed(elapsed), label), file=sys.stderr)
 
     # reduce: dedupe by name (last write wins); a single chunk skips a 2nd call
     if len(chunks) > 1 and mapped:
@@ -155,10 +183,13 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--committed-dir",
                     help="committed skill library shown to the model (avoids re-proposals)")
     ap.add_argument("--token-budget", type=int, default=DEFAULT_TOKEN_BUDGET)
+    ap.add_argument("--run-id", default=None,
+                    help="audit run id; enables per-chunk status logging")
     args = ap.parse_args(argv)
     try:
         summary = evolve(args.sessions_dir, args.evolved_dir, args.template,
-                         committed_dir=args.committed_dir, token_budget=args.token_budget)
+                         committed_dir=args.committed_dir, token_budget=args.token_budget,
+                         run_id=args.run_id)
     except (RuntimeError, FileNotFoundError) as e:
         print(f"skillclaw_evolve: {e}", file=sys.stderr)
         return 1

--- a/configs/claude/scripts/skillclaw_evolve.py
+++ b/configs/claude/scripts/skillclaw_evolve.py
@@ -153,13 +153,16 @@ def evolve(sessions_dir, evolved_dir, template_path, *,
 
     mapped: list[dict] = []
     start = time.monotonic()
+    prev_elapsed = 0.0
     for idx, chunk in enumerate(chunks, 1):
         out = runner(build_prompt(template, chunk, library))
         mapped.extend(parse_candidates(out))
         if audit_mod and run_id:
             elapsed = time.monotonic() - start
+            chunk_seconds = round(elapsed - prev_elapsed, 1)
+            prev_elapsed = elapsed
             audit_mod.log(run_id, "evolve", "chunk_done", i=idx, total=len(chunks),
-                          chunk_seconds=round(elapsed, 1), elapsed_s=round(elapsed, 1))
+                          chunk_seconds=chunk_seconds, elapsed_s=round(elapsed, 1))
             _, label = audit_mod.compute_eta(idx, len(chunks), elapsed)
             print("[skillclaw] evolve · chunk %d/%d · %s · %s"
                   % (idx, len(chunks), _fmt_elapsed(elapsed), label), file=sys.stderr)

--- a/configs/claude/scripts/skillclaw_promote.sh
+++ b/configs/claude/scripts/skillclaw_promote.sh
@@ -116,7 +116,7 @@ fi
 
 # 4. Classify + validate. A crash here (empty/non-JSON output) must fail loudly,
 # not abort cryptically under `set -e`, so guard the capture explicitly.
-CUR_STAGE="classify"; echo "▸ classify…"
+CUR_STAGE="classify"; _t0=$SECONDS; echo "▸ classify…"
 audit log "$run_id" classify stage_start
 classify_args=("$EVOLVED" "$COMMITTED" --rejected-dir "$REJECTED")
 [[ -n "$SKILL" ]] && classify_args+=(--skill "$SKILL")
@@ -149,6 +149,7 @@ new_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys
 changed_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("promote",[]) if c.get("status")=="CHANGED"]))')"
 dropped_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("dropped",[])]))')"
 audit log "$run_id" classify candidates new="$new_json" changed="$changed_json" dropped="$dropped_json"
+audit log "$run_id" classify stage_end seconds=$((SECONDS - _t0))
 
 if [[ -z "$promote_names" ]]; then
     echo "Nothing to promote."
@@ -166,7 +167,7 @@ if [[ "$APPLY" != true ]]; then
 fi
 
 # 5. Stage a branch with one commit per skill, then open a PR.
-CUR_STAGE="promote"; echo "▸ promote…"
+CUR_STAGE="promote"; _t0=$SECONDS; echo "▸ promote…"
 audit log "$run_id" promote stage_start
 count="$(echo "$promote_names" | wc -w | tr -d ' ')"
 if [[ ! -d "$COMMITTED" ]]; then
@@ -193,6 +194,7 @@ pr_url="$("$GITOPS" pr-create --base "$PR_BASE" --head "$branch" \
     --label needs-review --label follow-up)"
 
 audit log "$run_id" promote pr_opened url="$pr_url"
+audit log "$run_id" promote stage_end seconds=$((SECONDS - _t0))
 echo "Opened review PR: $pr_url"
 RUN_DONE=true
 audit log "$run_id" "-" run_end state=done total_seconds=$SECONDS

--- a/configs/claude/scripts/skillclaw_promote.sh
+++ b/configs/claude/scripts/skillclaw_promote.sh
@@ -40,6 +40,11 @@ audit() { python3 "$AUDIT" "$@" >/dev/null 2>&1 || true; }
 BRANCH_PREFIX="skillclaw/evolve-"
 PR_BASE="main"
 
+# Pipeline defaults — kept here so the audit log records the values the run
+# actually used (ingest's --window-days and evolve's --token-budget), not zeros.
+WINDOW_DAYS="${SKILLCLAW_WINDOW_DAYS:-30}"
+TOKEN_BUDGET="${SKILLCLAW_TOKEN_BUDGET:-100000}"
+
 APPLY=false; SKILL=""; DO_EVOLVE=true; FORCE_NEW=false
 
 err() { echo "skillclaw-promote: $*" >&2; }
@@ -67,7 +72,7 @@ finalize() {
     fi
 }
 trap finalize EXIT
-audit log "$run_id" "-" run_start window_days=0 token_budget=0 apply="$APPLY"
+audit log "$run_id" "-" run_start window_days="$WINDOW_DAYS" token_budget="$TOKEN_BUDGET" apply="$APPLY"
 
 # 0. Idempotency (Option A): one open evolve PR at a time.
 open_pr() {
@@ -91,7 +96,8 @@ if [[ "$DO_EVOLVE" == true ]]; then
     CUR_STAGE="ingest"; _t0=$SECONDS
     echo "▸ ingest…"
     audit log "$run_id" ingest stage_start
-    python3 "$INGEST" "$TRANSCRIPTS" "$SESSIONS" --state "$STATE" >/dev/null 2>&1 \
+    python3 "$INGEST" "$TRANSCRIPTS" "$SESSIONS" --state "$STATE" \
+        --window-days "$WINDOW_DAYS" >/dev/null 2>&1 \
         || err "ingest returned non-zero (continuing)"
     audit log "$run_id" ingest stage_end seconds=$((SECONDS - _t0))
 fi
@@ -110,7 +116,8 @@ if [[ "$DO_EVOLVE" == true ]]; then
     CUR_STAGE="evolve"
     echo "▸ evolve…"
     python3 "$EVOLVE" "$SESSIONS" "$EVOLVED" --template "$TEMPLATE" \
-        --committed-dir "$COMMITTED" --run-id "$run_id" >/dev/null \
+        --committed-dir "$COMMITTED" --token-budget "$TOKEN_BUDGET" \
+        --run-id "$run_id" >/dev/null \
         || err "evolve returned non-zero (continuing)"
 fi
 
@@ -144,10 +151,12 @@ fi
 
 promote_names="$(echo "$classify_json" | python3 -c 'import json,sys; print(" ".join(c["name"] for c in json.load(sys.stdin).get("promote", [])))')"
 
-# Structured candidate record (names only — never session content).
+# Structured candidate record (names only for promoted; dropped also carries its
+# schema-validation reason — never session content). The reason aids debugging and
+# matches the design doc's dropped-candidate schema ({name, reason}).
 new_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("promote",[]) if c.get("status")=="NEW"]))')"
 changed_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("promote",[]) if c.get("status")=="CHANGED"]))')"
-dropped_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("dropped",[])]))')"
+dropped_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([{"name": c["name"], "reason": c.get("reason", "")} for c in d.get("dropped",[])]))')"
 audit log "$run_id" classify candidates new="$new_json" changed="$changed_json" dropped="$dropped_json"
 audit log "$run_id" classify stage_end seconds=$((SECONDS - _t0))
 

--- a/configs/claude/scripts/skillclaw_promote.sh
+++ b/configs/claude/scripts/skillclaw_promote.sh
@@ -31,6 +31,12 @@ REJECTED="${SKILLCLAW_REJECTED:-$HOME/.skillclaw/skills/rejected}"
 # lives in ~/.claude/scripts, so locate the repo via MANIFEST_ROOT (exported by
 # bootstrap into the shell profile); fall back to repo-relative when run in-tree.
 COMMITTED="${SKILLCLAW_COMMITTED:-${MANIFEST_ROOT:-${SCRIPT_DIR}/../../..}/.skillshare/skills}"
+
+AUDIT="${SCRIPT_DIR}/skillclaw_audit.py"
+# Shared audit storage; evolve.py reads SKILLCLAW_AUDIT_DIR too (default ~/.skillclaw).
+export SKILLCLAW_AUDIT_DIR="${SKILLCLAW_AUDIT_DIR:-$HOME/.skillclaw}"
+audit() { python3 "$AUDIT" "$@" >/dev/null 2>&1 || true; }
+
 BRANCH_PREFIX="skillclaw/evolve-"
 PR_BASE="main"
 
@@ -41,6 +47,7 @@ usage_error() { err "$*"; exit 2; }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --status) python3 "$AUDIT" status; exit 0 ;;
         --apply) APPLY=true; shift ;;
         --skill) [[ $# -ge 2 ]] || usage_error "--skill needs a name"; SKILL="$2"; shift 2 ;;
         --no-evolve) DO_EVOLVE=false; shift ;;
@@ -49,6 +56,18 @@ while [[ $# -gt 0 ]]; do
         *) usage_error "unexpected argument: $1" ;;
     esac
 done
+
+run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+RUN_DONE=false
+CUR_STAGE="startup"
+finalize() {
+    local ec=$?
+    if [[ "$RUN_DONE" != true ]]; then
+        audit log "$run_id" "$CUR_STAGE" run_error message="exit ${ec}"
+    fi
+}
+trap finalize EXIT
+audit log "$run_id" "-" run_start window_days=0 token_budget=0 apply="$APPLY"
 
 # 0. Idempotency (Option A): one open evolve PR at a time.
 open_pr() {
@@ -69,25 +88,36 @@ fi
 
 # 1. Ingest transcripts → sessions (passive; no proxy).
 if [[ "$DO_EVOLVE" == true ]]; then
+    CUR_STAGE="ingest"; _t0=$SECONDS
+    echo "▸ ingest…"
+    audit log "$run_id" ingest stage_start
     python3 "$INGEST" "$TRANSCRIPTS" "$SESSIONS" --state "$STATE" >/dev/null 2>&1 \
         || err "ingest returned non-zero (continuing)"
+    audit log "$run_id" ingest stage_end seconds=$((SECONDS - _t0))
 fi
 
 # 2. Scrub captured sessions (best-effort; never blocks).
 if [[ -d "$SESSIONS" ]]; then
+    CUR_STAGE="scrub"; _t0=$SECONDS
+    echo "▸ scrub…"
+    audit log "$run_id" scrub stage_start
     python3 "${SCRIPT_DIR}/skillclaw_scrub.py" "$SESSIONS" >/dev/null 2>&1 || true
+    audit log "$run_id" scrub stage_end seconds=$((SECONDS - _t0))
 fi
 
-# 3. Evolve (skip with --no-evolve). Suppress its stdout summary (kept clean like
-# ingest); errors still surface on stderr and are reported below.
+# 3. Evolve (skip with --no-evolve). evolve.py logs its own stage_start/chunk_done.
 if [[ "$DO_EVOLVE" == true ]]; then
+    CUR_STAGE="evolve"
+    echo "▸ evolve…"
     python3 "$EVOLVE" "$SESSIONS" "$EVOLVED" --template "$TEMPLATE" \
-        --committed-dir "$COMMITTED" >/dev/null \
+        --committed-dir "$COMMITTED" --run-id "$run_id" >/dev/null \
         || err "evolve returned non-zero (continuing)"
 fi
 
 # 4. Classify + validate. A crash here (empty/non-JSON output) must fail loudly,
 # not abort cryptically under `set -e`, so guard the capture explicitly.
+CUR_STAGE="classify"; echo "▸ classify…"
+audit log "$run_id" classify stage_start
 classify_args=("$EVOLVED" "$COMMITTED" --rejected-dir "$REJECTED")
 [[ -n "$SKILL" ]] && classify_args+=(--skill "$SKILL")
 classify_json="$(python3 "${SCRIPT_DIR}/skillclaw_promote.py" "${classify_args[@]}")" \
@@ -114,18 +144,30 @@ fi
 
 promote_names="$(echo "$classify_json" | python3 -c 'import json,sys; print(" ".join(c["name"] for c in json.load(sys.stdin).get("promote", [])))')"
 
+# Structured candidate record (names only — never session content).
+new_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("promote",[]) if c.get("status")=="NEW"]))')"
+changed_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("promote",[]) if c.get("status")=="CHANGED"]))')"
+dropped_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("dropped",[])]))')"
+audit log "$run_id" classify candidates new="$new_json" changed="$changed_json" dropped="$dropped_json"
+
 if [[ -z "$promote_names" ]]; then
     echo "Nothing to promote."
+    RUN_DONE=true
+    audit log "$run_id" "-" run_end state=done total_seconds=$SECONDS
     exit 0
 fi
 
 if [[ "$APPLY" != true ]]; then
     echo ""
     echo "Dry run — re-run with --apply to open a review PR."
+    RUN_DONE=true
+    audit log "$run_id" "-" run_end state=done total_seconds=$SECONDS
     exit 0
 fi
 
 # 5. Stage a branch with one commit per skill, then open a PR.
+CUR_STAGE="promote"; echo "▸ promote…"
+audit log "$run_id" promote stage_start
 count="$(echo "$promote_names" | wc -w | tr -d ' ')"
 if [[ ! -d "$COMMITTED" ]]; then
     err "committed skills dir not found: $COMMITTED"
@@ -150,4 +192,8 @@ pr_url="$("$GITOPS" pr-create --base "$PR_BASE" --head "$branch" \
     --title "SkillClaw: evolve ${count} skill(s)" --body "$body" \
     --label needs-review --label follow-up)"
 
+audit log "$run_id" promote pr_opened url="$pr_url"
 echo "Opened review PR: $pr_url"
+RUN_DONE=true
+audit log "$run_id" "-" run_end state=done total_seconds=$SECONDS
+audit trim

--- a/docs/SKILLCLAW.md
+++ b/docs/SKILLCLAW.md
@@ -73,6 +73,33 @@ exists, `--apply` aborts with a message. Review or merge it first, or pass
 
 `/skill-evolve` is the Claude Code skill entry point for this flow.
 
+## Audit log + live status
+
+Each `skillclaw_promote` run writes two best-effort artifacts under `~/.skillclaw/`
+(fail-open — audit I/O never aborts or delays a run):
+
+- **`promote.log`** — append-only JSONL audit history (one event per line:
+  `run_start`, `stage_start`/`stage_end`, `chunk_done`, `candidates`, `pr_opened`,
+  `run_end`/`run_error`). Self-trims to the most recent ~50 runs.
+- **`status.json`** — overwritten snapshot of the current/last run plus a rough,
+  explicitly-labeled ETA (only the evolve stage predicts, and only once ≥2 chunks
+  complete; before that it shows `estimating…`).
+
+During a run the evolve stage prints a live per-chunk line to stderr, e.g.
+`[skillclaw] evolve · chunk 4/12 · 1m00s · ~2m left (est)`.
+
+Query the latest run at any time:
+
+```bash
+skillclaw_promote.sh --status
+# run 20260609T2305 · evolve · chunk 4/12 · 1m00s elapsed · ~2m left (est)
+# last run: done · 3 candidates · PR https://…/pull/7 · 4m12s
+# no recent run
+```
+
+The log records counts, names, timings, and URLs only — never session content
+(evolve inputs are already scrubbed upstream).
+
 ## Security
 
 - Storage `~/.skillclaw/` and its subdirectories (`sessions/`, `skills/`) are

--- a/docs/superpowers/plans/2026-06-09-skillclaw-promote-audit-log.md
+++ b/docs/superpowers/plans/2026-06-09-skillclaw-promote-audit-log.md
@@ -1,0 +1,1156 @@
+# SkillClaw Promote — Audit Log + Live Status/ETA Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `skillclaw_promote` a durable JSONL audit history plus a live, queryable run-status snapshot with a rough ETA, without ever blocking the promote pipeline.
+
+**Architecture:** A new `skillclaw_audit.py` module is the single source of truth for two files under `~/.skillclaw/`: an append-only `promote.log` (JSONL audit history) and an overwritten `status.json` (live snapshot + ETA). The shell orchestrator (`skillclaw_promote.sh`) writes run/stage events through its CLI; the Python evolver (`skillclaw_evolve.py`) writes per-chunk progress through its importable API. All audit calls are fail-open — any I/O error is swallowed so a promote run completes regardless.
+
+**Tech Stack:** Python 3 (stdlib only: `json`, `os`, `datetime`, `pathlib`), Bash (`set -euo pipefail`), pytest, bats, shellcheck.
+
+---
+
+## Source Spec
+
+`docs/superpowers/specs/2026-06-09-skillclaw-promote-audit-log-design.md` (Approved; reviewed by `agy` — 7 findings incorporated).
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `configs/claude/scripts/skillclaw_audit.py` | Logger + status/ETA engine. Owns both file formats, atomic writes, fail-open wrappers, CLI (`log`/`status`/`trim`). | **Create** |
+| `configs/claude/scripts/skillclaw_evolve.py` | Add `--run-id`; emit `stage_start`/`chunk_done` per chunk + a live stderr progress line. | **Modify** |
+| `configs/claude/scripts/skillclaw_promote.sh` | Mint `run_id`; log run/stage events + candidates + `pr_opened`; `--status` flag; finalization trap; `trim` once. | **Modify** |
+| `tests/python/test_skillclaw_audit.py` | Unit tests for `compute_eta`, `log`, status reset, `render_status` (incl. stale), `trim` (atomic), fail-open, storage init. | **Create** |
+| `tests/python/test_skillclaw_evolve.py` | Extend: chunk events update `status.json` with correct `chunk`/`total`. | **Modify** |
+| `tests/bats/skillclaw_promote.bats` | Extend: `run_id` in log, `--status` render, stage events, trap-on-interrupt, unwritable-path-still-exits-0. | **Modify** |
+| `docs/SKILLCLAW.md`, `CHANGELOG.md` | Document the audit log, `--status`, and live progress. | **Modify** |
+
+### Conventions to follow (verified in-repo)
+
+- Python CLI scripts: `from __future__ import annotations`, `def main(argv: list[str]) -> int`, `raise SystemExit(main(sys.argv[1:]))`, errors to stderr.
+- pytest files start with `sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/claude/scripts"))` then import the module.
+- Scripts are invoked as `python3 "${SCRIPT_DIR}/skillclaw_*.py"` — never bare on `PATH`.
+- Atomic file writes use a `.tmp` sibling + `os.replace()`.
+- Storage dir `~/.skillclaw/` is `chmod 700`; files are `chmod 600`.
+- `run_id` format: `<UTC>-<pid>`, e.g. `20260609T230501Z-4821` (the timestamp has no `-`, so `rsplit("-", 1)` recovers the pid).
+- Tests redirect storage via the `SKILLCLAW_AUDIT_DIR` env var (default `~/.skillclaw`).
+
+---
+
+## Task 1: Audit module skeleton — storage helpers + `compute_eta`
+
+**Files:**
+- Create: `configs/claude/scripts/skillclaw_audit.py`
+- Test: `tests/python/test_skillclaw_audit.py`
+
+`compute_eta` is a pure function — start here so the storage scaffolding (dir resolution, atomic write) lands with a trivially testable unit.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/python/test_skillclaw_audit.py`:
+
+```python
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/claude/scripts"))
+import skillclaw_audit as audit  # noqa: E402
+
+
+def test_compute_eta_estimating_until_two_chunks():
+    assert audit.compute_eta(0, 12, 0)[1] == "estimating…"
+    assert audit.compute_eta(1, 12, 14.2)[1] == "estimating…"
+
+
+def test_compute_eta_guards_bad_inputs():
+    # total <= done, and non-positive elapsed -> estimating, never negative/div0
+    assert audit.compute_eta(5, 5, 60)[0] is None
+    assert audit.compute_eta(6, 5, 60)[0] is None
+    assert audit.compute_eta(3, 12, 0)[0] is None
+    assert audit.compute_eta(3, 12, -1)[0] is None
+
+
+def test_compute_eta_linear_projection():
+    # (12-4) * (60/4) = 120s -> ~2m
+    eta_s, label = audit.compute_eta(4, 12, 60)
+    assert eta_s == 120
+    assert label == "~2m left (est)"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_audit.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'skillclaw_audit'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `configs/claude/scripts/skillclaw_audit.py`:
+
+```python
+#!/usr/bin/env python3
+"""SkillClaw promote audit log + live status/ETA engine.
+
+Single source of truth for two artifacts under ~/.skillclaw/:
+  - promote.log : append-only JSONL audit history (one event per line)
+  - status.json : overwritten snapshot of the current/last run + rough ETA
+
+Fail-open by construction: every public function swallows I/O errors and returns
+cleanly, so audit logging can never abort or delay a promote run.
+
+CLI (always invoked as `python3 "${SCRIPT_DIR}/skillclaw_audit.py" <cmd>`):
+    log <run_id> <stage> <event> [key=value ...]
+    status
+    trim [--max-runs N]
+
+Env overrides (tests): SKILLCLAW_AUDIT_DIR (default ~/.skillclaw).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_HOME = "~/.skillclaw"
+MAX_RUNS = 50
+RUNNING, DONE, FAILED, STALE = "running", "done", "failed", "stale"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _audit_dir() -> Path:
+    return Path(os.environ.get("SKILLCLAW_AUDIT_DIR", DEFAULT_HOME)).expanduser()
+
+
+def _log_path() -> Path:
+    return _audit_dir() / "promote.log"
+
+
+def _status_path() -> Path:
+    return _audit_dir() / "status.json"
+
+
+def _ensure_storage() -> Path:
+    """mkdir -p ~/.skillclaw (700) so a fresh install never silently logs nothing."""
+    d = _audit_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:
+        pass
+    return d
+
+
+def _write_atomic(path: Path, data: str) -> None:
+    """Write via a .tmp sibling + os.replace so concurrent reads never see a torn file."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(data, encoding="utf-8")
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+
+
+def compute_eta(chunks_done, chunks_total, elapsed_s):
+    """Return (eta_s|None, label).
+
+    `estimating…` until >=2 chunks are done and inputs are sane; otherwise a
+    linear projection. Guards prevent negative/div-by-zero ETAs from corrupt or
+    out-of-order status.
+    """
+    try:
+        if chunks_done < 2 or chunks_total <= chunks_done or elapsed_s <= 0:
+            return (None, "estimating…")
+        eta_s = (chunks_total - chunks_done) * (elapsed_s / chunks_done)
+        return (eta_s, "~%dm left (est)" % max(1, round(eta_s / 60)))
+    except (TypeError, ValueError):
+        return (None, "estimating…")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_audit.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_audit.py tests/python/test_skillclaw_audit.py
+git commit -m "feat(skillclaw): audit module skeleton + compute_eta"
+```
+
+---
+
+## Task 2: `log()` — append JSONL + update live `status.json` (no state bleed)
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_audit.py`
+- Test: `tests/python/test_skillclaw_audit.py`
+
+`log()` appends one audit line and folds the event into the live snapshot. A `run_start` — or any event whose `run_id` differs from the one in `status.json` — initializes a fresh snapshot instead of merging, so a new run never inherits the prior run's `pr_url`/metrics.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_skillclaw_audit.py`:
+
+```python
+import json
+
+
+def _read(p):
+    return json.loads(Path(p).read_text())
+
+
+def test_log_appends_jsonl_and_updates_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    audit.log("20260609T230501Z-4821", "-", "run_start",
+              window_days=30, token_budget=100000, apply=True)
+    log_lines = (tmp_path / "promote.log").read_text().splitlines()
+    assert len(log_lines) == 1
+    first = json.loads(log_lines[0])
+    assert first["event"] == "run_start" and first["window_days"] == 30
+    status = _read(tmp_path / "status.json")
+    assert status["run_id"] == "20260609T230501Z-4821"
+    assert status["state"] == "running"
+
+
+def test_chunk_done_event_records_eta(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "evolve", "stage_start", chunks=12)
+    audit.log(rid, "evolve", "chunk_done", i=4, total=12, chunk_seconds=15.0, elapsed_s=60)
+    status = _read(tmp_path / "status.json")
+    assert status["stage"] == "evolve"
+    assert status["evolve"]["chunk"] == 4 and status["evolve"]["total"] == 12
+    assert status["evolve"]["eta_s"] == 120
+    assert status["evolve"]["eta_label"] == "~2m left (est)"
+
+
+def test_new_run_id_resets_snapshot_no_state_bleed(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    audit.log("20260609T230501Z-1111", "promote", "pr_opened", url="https://x/pull/9")
+    audit.log("20260609T235959Z-2222", "-", "run_start")  # different run_id
+    status = _read(tmp_path / "status.json")
+    assert status["run_id"] == "20260609T235959Z-2222"
+    assert status["pr_url"] is None          # prior run's PR must not bleed in
+    assert status["state"] == "running"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_audit.py -k "log or chunk or state_bleed" -v`
+Expected: FAIL with `AttributeError: module 'skillclaw_audit' has no attribute 'log'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `configs/claude/scripts/skillclaw_audit.py` (after `compute_eta`):
+
+```python
+def _read_status() -> dict:
+    try:
+        return json.loads(_status_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def _fresh_status(run_id: str) -> dict:
+    now = _now_iso()
+    return {
+        "run_id": run_id,
+        "started_at": now,
+        "updated_at": now,
+        "state": RUNNING,
+        "stage": "-",
+        "evolve": None,
+        "totals": {"ingested": None, "candidates": None, "dropped": None},
+        "pr_url": None,
+    }
+
+
+def _apply_event(status: dict, stage: str, event: str, fields: dict) -> dict:
+    status["updated_at"] = _now_iso()
+    if stage and stage != "-":
+        status["stage"] = stage
+    if event == "run_start":
+        cfg = status.setdefault("config", {})
+        for k in ("window_days", "token_budget", "apply"):
+            if k in fields:
+                cfg[k] = fields[k]
+    elif event == "stage_start" and stage == "evolve":
+        status["evolve"] = {"chunk": 0, "total": fields.get("chunks", 0),
+                            "elapsed_s": 0, "eta_s": None, "eta_label": "estimating…"}
+    elif event == "stage_end" and "ingested" in fields:
+        status["totals"]["ingested"] = fields["ingested"]
+    elif event == "chunk_done":
+        done, total = fields.get("i", 0), fields.get("total", 0)
+        elapsed = fields.get("elapsed_s", 0)
+        eta_s, label = compute_eta(done, total, elapsed)
+        status["evolve"] = {"chunk": done, "total": total, "elapsed_s": elapsed,
+                            "eta_s": eta_s, "eta_label": label}
+    elif event == "candidates":
+        new = fields.get("new") or []
+        changed = fields.get("changed") or []
+        dropped = fields.get("dropped") or []
+        status["totals"]["candidates"] = len(new) + len(changed)
+        status["totals"]["dropped"] = len(dropped)
+    elif event == "pr_opened":
+        status["pr_url"] = fields.get("url")
+    elif event == "run_end":
+        status["state"] = fields.get("state", DONE)
+        status["stage"] = "-"
+        status["total_seconds"] = fields.get("total_seconds")
+    elif event == "run_error":
+        status["state"] = FAILED
+        status["error_stage"] = stage
+        status["message"] = fields.get("message")
+    return status
+
+
+def log(run_id, stage, event, **fields):
+    """Append one JSONL audit line and update the live status snapshot. Fail-open."""
+    try:
+        _ensure_storage()
+        line = {"ts": _now_iso(), "run_id": run_id, "stage": stage, "event": event}
+        line.update(fields)
+        with _log_path().open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(line) + "\n")
+        try:
+            os.chmod(_log_path(), 0o600)
+        except OSError:
+            pass
+        current = _read_status()
+        if event == "run_start" or current.get("run_id") != run_id:
+            current = _fresh_status(run_id)
+        _write_atomic(_status_path(), json.dumps(_apply_event(current, stage, event, fields), indent=2))
+    except Exception:  # noqa: BLE001 - fail-open: never raise into the pipeline
+        return
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_audit.py -v`
+Expected: PASS (all Task 1 + Task 2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_audit.py tests/python/test_skillclaw_audit.py
+git commit -m "feat(skillclaw): audit log() with no-state-bleed status snapshot"
+```
+
+---
+
+## Task 3: `render_status()` — one-glance summary + stale-pid detection
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_audit.py`
+- Test: `tests/python/test_skillclaw_audit.py`
+
+`render_status()` produces the human line for `--status`. If `state=="running"` but the pid embedded in `run_id` is no longer alive, it reports `stale` — a SIGKILL'd run that skipped the finalization trap must never show as a phantom running run.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_skillclaw_audit.py`:
+
+```python
+def test_render_status_no_recent_run(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    assert audit.render_status() == "no recent run"
+
+
+def test_render_status_running_evolve(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    monkeypatch.setattr(audit, "_pid_alive", lambda pid: True)
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "evolve", "stage_start", chunks=12)
+    audit.log(rid, "evolve", "chunk_done", i=4, total=12, chunk_seconds=15.0, elapsed_s=60)
+    out = audit.render_status()
+    assert "evolve" in out and "chunk 4/12" in out and "~2m left (est)" in out
+
+
+def test_render_status_stale_when_pid_dead(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    monkeypatch.setattr(audit, "_pid_alive", lambda pid: False)
+    audit.log("20260609T230501Z-4821", "-", "run_start")
+    assert "stale" in audit.render_status()
+
+
+def test_render_status_done_summary(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "classify", "candidates", new=["a", "b", "c"], changed=[], dropped=[])
+    audit.log(rid, "promote", "pr_opened", url="https://x/pull/7")
+    audit.log(rid, "-", "run_end", state="done", total_seconds=252.4)
+    out = audit.render_status()
+    assert "done" in out and "3 candidates" in out and "PR https://x/pull/7" in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_audit.py -k render -v`
+Expected: FAIL with `AttributeError: module 'skillclaw_audit' has no attribute 'render_status'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `configs/claude/scripts/skillclaw_audit.py` (after `log`):
+
+```python
+def _pid_from_run_id(run_id):
+    try:
+        return int(str(run_id).rsplit("-", 1)[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def _pid_alive(pid):
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True   # exists but owned by another user
+    except OSError:
+        return False
+    return True
+
+
+def _fmt_secs(s):
+    try:
+        s = int(round(float(s)))
+    except (TypeError, ValueError):
+        return "?"
+    return "%dm%02ds" % (s // 60, s % 60) if s >= 60 else "%ds" % s
+
+
+def render_status():
+    """One-glance human summary for --status. Fail-open -> 'no recent run'."""
+    try:
+        st = _read_status()
+        if not st:
+            return "no recent run"
+        state = st.get("state")
+        run_id = st.get("run_id", "?")
+        short = str(run_id).split("-")[0][:13]
+        if state == RUNNING and not _pid_alive(_pid_from_run_id(run_id)):
+            state = STALE
+        if state == RUNNING:
+            ev = st.get("evolve") or {}
+            stage = st.get("stage", "?")
+            if stage == "evolve" and ev.get("total"):
+                return ("run %s · evolve · chunk %s/%s · %s elapsed · %s"
+                        % (short, ev.get("chunk"), ev.get("total"),
+                           _fmt_secs(ev.get("elapsed_s")),
+                           ev.get("eta_label", "estimating…")))
+            return "run %s · %s · running" % (short, stage)
+        if state == STALE:
+            return "run %s · stale (no live process)" % short
+        if state == FAILED:
+            return "last run: failed · stage %s" % st.get("error_stage", "?")
+        tot = st.get("totals", {})
+        parts = ["last run: done"]
+        if tot.get("candidates") is not None:
+            parts.append("%s candidates" % tot["candidates"])
+        if st.get("pr_url"):
+            parts.append("PR %s" % st["pr_url"])
+        if st.get("total_seconds") is not None:
+            parts.append(_fmt_secs(st["total_seconds"]))
+        return " · ".join(parts)
+    except Exception:  # noqa: BLE001 - fail-open
+        return "no recent run"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_audit.py -v`
+Expected: PASS (all tests through Task 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_audit.py tests/python/test_skillclaw_audit.py
+git commit -m "feat(skillclaw): render_status with stale-pid detection"
+```
+
+---
+
+## Task 4: `trim()` — atomic retention to the last ~50 runs
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_audit.py`
+- Test: `tests/python/test_skillclaw_audit.py`
+
+`trim()` rewrites `promote.log` keeping only events for the most recent `max_runs` `run_id`s, written atomically so an interrupt mid-trim leaves the original intact.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_skillclaw_audit.py`:
+
+```python
+def test_trim_keeps_only_recent_run_ids(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    for i in range(5):
+        audit.log("run-%d" % i, "-", "run_start")
+    audit.trim(max_runs=2)
+    rids = {json.loads(ln)["run_id"]
+            for ln in (tmp_path / "promote.log").read_text().splitlines()}
+    assert rids == {"run-3", "run-4"}
+
+
+def test_trim_is_atomic_on_failure(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    for i in range(3):
+        audit.log("run-%d" % i, "-", "run_start")
+    original = (tmp_path / "promote.log").read_text()
+
+    def boom(*a, **k):
+        raise OSError("simulated mid-trim crash")
+
+    monkeypatch.setattr(audit.os, "replace", boom)
+    audit.trim(max_runs=1)  # fail-open: swallows the error
+    assert (tmp_path / "promote.log").read_text() == original  # untouched
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_audit.py -k trim -v`
+Expected: FAIL with `AttributeError: module 'skillclaw_audit' has no attribute 'trim'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `configs/claude/scripts/skillclaw_audit.py` (after `render_status`):
+
+```python
+def trim(max_runs=MAX_RUNS):
+    """Keep only events for the most recent max_runs run_ids. Atomic. Fail-open."""
+    try:
+        path = _log_path()
+        if not path.exists():
+            return
+        lines = path.read_text(encoding="utf-8").splitlines()
+        order, seen = [], set()
+        for ln in lines:
+            try:
+                rid = json.loads(ln).get("run_id")
+            except ValueError:
+                continue
+            if rid not in seen:
+                seen.add(rid)
+                order.append(rid)
+        keep = set(order[-max_runs:])
+        kept = []
+        for ln in lines:
+            try:
+                if json.loads(ln).get("run_id") in keep:
+                    kept.append(ln)
+            except ValueError:
+                continue
+        _write_atomic(path, "\n".join(kept) + ("\n" if kept else ""))
+    except Exception:  # noqa: BLE001 - fail-open
+        return
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/python/test_skillclaw_audit.py -v`
+Expected: PASS (all tests through Task 4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_audit.py tests/python/test_skillclaw_audit.py
+git commit -m "feat(skillclaw): atomic trim() retention to last 50 runs"
+```
+
+---
+
+## Task 5: Fail-open hardening + storage auto-init + CLI entry
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_audit.py`
+- Test: `tests/python/test_skillclaw_audit.py`
+
+Add the CLI (`log`/`status`/`trim` with `key=value` field parsing — shell's only interface) and prove the two cross-cutting guarantees: an unwritable audit dir never raises, and storage auto-inits on a fresh machine.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_skillclaw_audit.py`:
+
+```python
+def test_fail_open_on_unwritable_dir(tmp_path, monkeypatch):
+    # Point the audit dir *inside* a regular file so mkdir raises NotADirectoryError.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir")
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(blocker / "sub"))
+    audit.log("run-x", "-", "run_start")          # must not raise
+    assert audit.render_status() == "no recent run"
+
+
+def test_storage_auto_inits_when_absent(tmp_path, monkeypatch):
+    target = tmp_path / "fresh" / "nested"        # does not exist yet
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(target))
+    audit.log("run-1", "-", "run_start")
+    assert (target / "promote.log").exists()
+    assert (target / "status.json").exists()
+
+
+def test_cli_log_parses_key_value_and_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rc = audit.main(["log", "run-1", "classify", "candidates",
+                     'new=["a","b"]', "dropped=[]", "changed=[]"])
+    assert rc == 0
+    status = json.loads((tmp_path / "status.json").read_text())
+    assert status["totals"]["candidates"] == 2
+
+
+def test_cli_status_and_trim(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    assert audit.main(["status"]) == 0
+    assert capsys.readouterr().out.strip() == "no recent run"
+    assert audit.main(["trim", "--max-runs", "10"]) == 0   # no log yet -> no-op, rc 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_audit.py -k "fail_open or auto_inits or cli" -v`
+Expected: FAIL with `AttributeError: module 'skillclaw_audit' has no attribute 'main'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `configs/claude/scripts/skillclaw_audit.py` (after `trim`, before any `__main__` guard):
+
+```python
+def _parse_kv(pairs):
+    """Parse `key=value` argv pairs; JSON-decode each value, else keep the string."""
+    out = {}
+    for p in pairs:
+        if "=" not in p:
+            continue
+        k, v = p.split("=", 1)
+        try:
+            out[k] = json.loads(v)
+        except ValueError:
+            out[k] = v
+    return out
+
+
+def main(argv):
+    if not argv or argv[0] == "status":
+        print(render_status())
+        return 0
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "trim":
+        mx = MAX_RUNS
+        if "--max-runs" in rest:
+            i = rest.index("--max-runs")
+            try:
+                mx = int(rest[i + 1])
+            except (IndexError, ValueError):
+                mx = MAX_RUNS
+        trim(mx)
+        return 0
+    if cmd == "log":
+        if len(rest) < 3:
+            return 0  # fail-open: a malformed call never errors the pipeline
+        log(rest[0], rest[1], rest[2], **_parse_kv(rest[3:]))
+        return 0
+    return 0  # unknown subcommand: fail-open
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run the full module suite**
+
+Run: `pytest tests/python/test_skillclaw_audit.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Make the script executable and commit**
+
+```bash
+chmod +x configs/claude/scripts/skillclaw_audit.py
+git add configs/claude/scripts/skillclaw_audit.py tests/python/test_skillclaw_audit.py
+git commit -m "feat(skillclaw): audit CLI (log/status/trim) + fail-open hardening"
+```
+
+---
+
+## Task 6: Wire `skillclaw_evolve.py` — per-chunk events + live stderr line
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_evolve.py`
+- Test: `tests/python/test_skillclaw_evolve.py`
+
+The evolver owns all of evolve's audit events: `stage_start` (with chunk count), one `chunk_done` per chunk (carrying cumulative `elapsed_s` so ETA is stateless), and a live stderr progress line. Audit is imported lazily and only when a `run_id` is supplied, so existing callers and tests are untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_skillclaw_evolve.py`:
+
+```python
+def test_evolve_emits_chunk_events_to_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path / "audit"))
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    big = "x" * 160_000  # ~40k tokens each -> 2 sessions force >=2 chunks at budget 50k
+    for i in range(2):
+        (sessions_dir / f"s{i}.json").write_text(json.dumps(
+            {"session_id": f"s{i}", "turns": [
+                {"role": "user", "blocks": [{"kind": "text", "text": big}]}]}))
+    template = tmp_path / "tpl.md"
+    template.write_text("{{LIBRARY}}{{SESSIONS}}")
+    evolved = tmp_path / "evolved"
+    out = "~~~skill name=dup\n---\nname: dup\ndescription: d\n---\n# Dup\nstep\n~~~\n"
+
+    ev.evolve(sessions_dir, evolved, template, token_budget=50_000,
+              runner=lambda p: out, run_id="20260609T230501Z-4821")
+
+    log_lines = (tmp_path / "audit" / "promote.log").read_text().splitlines()
+    events = [json.loads(ln)["event"] for ln in log_lines]
+    assert "stage_start" in events
+    assert events.count("chunk_done") >= 2
+    status = json.loads((tmp_path / "audit" / "status.json").read_text())
+    assert status["evolve"]["total"] >= 2
+    assert status["evolve"]["chunk"] == status["evolve"]["total"]  # last chunk recorded
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/python/test_skillclaw_evolve.py -k chunk_events -v`
+Expected: FAIL — `evolve()` rejects the unexpected `run_id` keyword (`TypeError`).
+
+- [ ] **Step 3: Write the implementation**
+
+In `configs/claude/scripts/skillclaw_evolve.py`, add `import sys` is already present and add `import time` near the top imports (after `import subprocess`):
+
+```python
+import subprocess
+import sys
+import time
+```
+
+Add a lazy loader and a small formatter after the imports / constants (e.g. after `_SKILL_RE`):
+
+```python
+def _load_audit():
+    """Import the audit logger lazily; return None if unavailable (fail-open)."""
+    try:
+        import skillclaw_audit
+        return skillclaw_audit
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _fmt_elapsed(s: float) -> str:
+    s = int(round(s))
+    return "%dm%02ds" % (s // 60, s % 60) if s >= 60 else "%ds" % s
+```
+
+Change the `evolve` signature to accept `run_id` and an injectable `audit` module:
+
+```python
+def evolve(sessions_dir, evolved_dir, template_path, *,
+           committed_dir=None, token_budget=DEFAULT_TOKEN_BUDGET, runner=subprocess_runner,
+           run_id=None, audit=None) -> dict:
+```
+
+Replace the map loop (the `chunks = chunk_sessions(...)` block through `mapped.extend(parse_candidates(out))`) with:
+
+```python
+    chunks = chunk_sessions(sessions, token_budget)
+    audit_mod = audit if audit is not None else (_load_audit() if run_id else None)
+    if audit_mod and run_id:
+        audit_mod.log(run_id, "evolve", "stage_start", chunks=len(chunks))
+
+    mapped: list[dict] = []
+    start = time.monotonic()
+    for idx, chunk in enumerate(chunks, 1):
+        out = runner(build_prompt(template, chunk, library))
+        mapped.extend(parse_candidates(out))
+        if audit_mod and run_id:
+            elapsed = time.monotonic() - start
+            _, label = audit_mod.compute_eta(idx, len(chunks), elapsed)
+            audit_mod.log(run_id, "evolve", "chunk_done", i=idx, total=len(chunks),
+                          chunk_seconds=round(elapsed, 1), elapsed_s=round(elapsed, 1))
+            print("[skillclaw] evolve · chunk %d/%d · %s · %s"
+                  % (idx, len(chunks), _fmt_elapsed(elapsed), label), file=sys.stderr)
+```
+
+Wire the new arg through `main`. In the `argparse` block add:
+
+```python
+    ap.add_argument("--run-id", default=None,
+                    help="audit run id; enables per-chunk status logging")
+```
+
+and pass it in the `evolve(...)` call inside `main`:
+
+```python
+        summary = evolve(args.sessions_dir, args.evolved_dir, args.template,
+                         committed_dir=args.committed_dir, token_budget=args.token_budget,
+                         run_id=args.run_id)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/python/test_skillclaw_evolve.py -v`
+Expected: PASS (existing tests unaffected — they pass no `run_id`, so audit stays off — plus the new chunk-events test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_evolve.py tests/python/test_skillclaw_evolve.py
+git commit -m "feat(skillclaw): evolve emits per-chunk audit events + live ETA line"
+```
+
+---
+
+## Task 7: Wire `skillclaw_promote.sh` — run/stage events, `--status`, trap, trim
+
+**Files:**
+- Modify: `configs/claude/scripts/skillclaw_promote.sh`
+- Test: `tests/bats/skillclaw_promote.bats`
+
+The orchestrator mints the `run_id`, logs run/stage events through the audit CLI, exposes `--status`, installs a finalization trap so a crash/Ctrl-C records `run_error` + a `failed` status, and trims once per run. Every audit call is best-effort (`|| true`).
+
+- [ ] **Step 1: Write the failing bats tests**
+
+First, in `tests/bats/skillclaw_promote.bats`, extend `setup()` to redirect audit storage into the sandbox. Add these two lines just before the final `: > "$SKILLCLAW_PROMOTE_LOG"`:
+
+```bash
+    export SKILLCLAW_AUDIT_DIR="$SANDBOX/skillclaw"
+    mkdir -p "$SKILLCLAW_AUDIT_DIR"
+```
+
+Then append these tests to the file:
+
+```bash
+@test "promote mints a run_id and records it in promote.log" {
+    run bash "$SCRIPT" --no-evolve
+    assert_success
+    run grep -c '"event": "run_start"' "$SKILLCLAW_AUDIT_DIR/promote.log"
+    assert_output "1"
+    run grep -Eq '"run_id": "[0-9]{8}T[0-9]{6}Z-[0-9]+"' "$SKILLCLAW_AUDIT_DIR/promote.log"
+    assert_success
+}
+
+@test "--status renders from a seeded status.json" {
+    cat > "$SKILLCLAW_AUDIT_DIR/status.json" << 'EOF'
+{"run_id":"20260609T230501Z-4821","state":"done","stage":"-",
+ "totals":{"ingested":12,"candidates":3,"dropped":0},
+ "pr_url":"https://example.test/pr/7","total_seconds":252}
+EOF
+    run bash "$SCRIPT" --status
+    assert_success
+    assert_output --partial "done"
+    assert_output --partial "3 candidates"
+    assert_output --partial "PR https://example.test/pr/7"
+}
+
+@test "stage transitions are logged as stage_start events" {
+    run bash "$SCRIPT" --no-evolve
+    assert_success
+    run grep -c '"event": "stage_start"' "$SKILLCLAW_AUDIT_DIR/promote.log"
+    [ "$output" -ge 1 ]
+}
+
+@test "finalization trap records run_error + failed status on mid-run interrupt" {
+    # Make `git switch` fail so --apply dies after run_start/stages -> trap fires.
+    cat > "$MOCK_BIN/git" << 'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  rev-parse) echo "abc1234" ;;
+  switch) echo "boom" >&2; exit 1 ;;
+  *) : ;;
+esac
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/git"
+    export SKILLCLAW_OPEN_PR=""
+    run bash "$SCRIPT" --apply --no-evolve
+    assert_failure
+    run grep -c '"event": "run_error"' "$SKILLCLAW_AUDIT_DIR/promote.log"
+    [ "$output" -ge 1 ]
+    run grep -q '"state": "failed"' "$SKILLCLAW_AUDIT_DIR/status.json"
+    assert_success
+}
+
+@test "unwritable audit path does not abort the run" {
+    # Point the audit dir inside a regular file -> every audit call fails open.
+    printf 'x' > "$SANDBOX/blocker"
+    export SKILLCLAW_AUDIT_DIR="$SANDBOX/blocker/sub"
+    run bash "$SCRIPT" --no-evolve
+    assert_success
+}
+```
+
+- [ ] **Step 2: Run the bats suite to verify the new tests fail**
+
+Run: `bats tests/bats/skillclaw_promote.bats`
+Expected: the 5 new tests FAIL (no `run_id`/`--status`/audit logging yet); the original tests still pass.
+
+- [ ] **Step 3: Implement the shell changes**
+
+In `configs/claude/scripts/skillclaw_promote.sh`:
+
+(a) After the existing path/env block (just after the `REJECTED=...` / `COMMITTED=...` lines, around line 33), add the audit wiring:
+
+```bash
+AUDIT="${SCRIPT_DIR}/skillclaw_audit.py"
+# Shared audit storage; evolve.py reads SKILLCLAW_AUDIT_DIR too (default ~/.skillclaw).
+export SKILLCLAW_AUDIT_DIR="${SKILLCLAW_AUDIT_DIR:-$HOME/.skillclaw}"
+audit() { python3 "$AUDIT" "$@" >/dev/null 2>&1 || true; }
+```
+
+(b) Handle `--status` as the first thing in the arg loop (add a new case before `--apply`):
+
+```bash
+        --status) python3 "$AUDIT" status; exit 0 ;;
+```
+
+(c) After argument parsing completes (after the `done` of the `while` loop at line 51) and before the idempotency check, mint the run id, install the trap, and log `run_start`:
+
+```bash
+run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+RUN_DONE=false
+CUR_STAGE="startup"
+finalize() {
+    local ec=$?
+    if [[ "$RUN_DONE" != true ]]; then
+        audit log "$run_id" "$CUR_STAGE" run_error message="exit ${ec}"
+    fi
+}
+trap finalize EXIT
+audit log "$run_id" "-" run_start window_days=0 token_budget=0 apply="$APPLY"
+```
+
+(d) Wrap each pipeline stage with `CUR_STAGE` + `stage_start`/`stage_end`. Replace the ingest block (lines 70-74) with:
+
+```bash
+# 1. Ingest transcripts → sessions (passive; no proxy).
+if [[ "$DO_EVOLVE" == true ]]; then
+    CUR_STAGE="ingest"; _t0=$SECONDS
+    echo "▸ ingest…"
+    audit log "$run_id" ingest stage_start
+    python3 "$INGEST" "$TRANSCRIPTS" "$SESSIONS" --state "$STATE" >/dev/null 2>&1 \
+        || err "ingest returned non-zero (continuing)"
+    audit log "$run_id" ingest stage_end seconds=$((SECONDS - _t0))
+fi
+```
+
+Replace the scrub block (lines 76-79) with:
+
+```bash
+# 2. Scrub captured sessions (best-effort; never blocks).
+if [[ -d "$SESSIONS" ]]; then
+    CUR_STAGE="scrub"; _t0=$SECONDS
+    echo "▸ scrub…"
+    audit log "$run_id" scrub stage_start
+    python3 "${SCRIPT_DIR}/skillclaw_scrub.py" "$SESSIONS" >/dev/null 2>&1 || true
+    audit log "$run_id" scrub stage_end seconds=$((SECONDS - _t0))
+fi
+```
+
+Replace the evolve block (lines 81-87) with (passing `--run-id`; evolve owns its own stage events):
+
+```bash
+# 3. Evolve (skip with --no-evolve). evolve.py logs its own stage_start/chunk_done.
+if [[ "$DO_EVOLVE" == true ]]; then
+    CUR_STAGE="evolve"
+    echo "▸ evolve…"
+    python3 "$EVOLVE" "$SESSIONS" "$EVOLVED" --template "$TEMPLATE" \
+        --committed-dir "$COMMITTED" --run-id "$run_id" >/dev/null \
+        || err "evolve returned non-zero (continuing)"
+fi
+```
+
+Set the stage before classify. Immediately before the `classify_args=(...)` line (line 91), add:
+
+```bash
+CUR_STAGE="classify"; echo "▸ classify…"
+audit log "$run_id" classify stage_start
+```
+
+(e) Log the `candidates` event after the diff table is computed. Immediately after the `promote_names=...` line (line 115), add:
+
+```bash
+# Structured candidate record (names only — never session content).
+new_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("promote",[]) if c.get("status")=="NEW"]))')"
+changed_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("promote",[]) if c.get("status")=="CHANGED"]))')"
+dropped_json="$(echo "$classify_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps([c["name"] for c in d.get("dropped",[])]))')"
+audit log "$run_id" classify candidates new="$new_json" changed="$changed_json" dropped="$dropped_json"
+```
+
+(f) Finalize on the two early non-error exits. Replace the "Nothing to promote." block (lines 117-120) with:
+
+```bash
+if [[ -z "$promote_names" ]]; then
+    echo "Nothing to promote."
+    RUN_DONE=true
+    audit log "$run_id" "-" run_end state=done total_seconds=$SECONDS
+    exit 0
+fi
+```
+
+Replace the dry-run block (lines 122-126) with:
+
+```bash
+if [[ "$APPLY" != true ]]; then
+    echo ""
+    echo "Dry run — re-run with --apply to open a review PR."
+    RUN_DONE=true
+    audit log "$run_id" "-" run_end state=done total_seconds=$SECONDS
+    exit 0
+fi
+```
+
+(g) Set the promote stage and log `pr_opened` + final `run_end`. Immediately before the `count=...` line (line 129) add:
+
+```bash
+CUR_STAGE="promote"; echo "▸ promote…"
+audit log "$run_id" promote stage_start
+```
+
+Replace the final two lines (lines 153-154, `echo "Opened review PR: $pr_url"`) with:
+
+```bash
+audit log "$run_id" promote pr_opened url="$pr_url"
+echo "Opened review PR: $pr_url"
+RUN_DONE=true
+audit log "$run_id" "-" run_end state=done total_seconds=$SECONDS
+audit trim
+```
+
+- [ ] **Step 4: Run the bats suite to verify it passes**
+
+Run: `bats tests/bats/skillclaw_promote.bats`
+Expected: PASS (all original + 5 new tests).
+
+- [ ] **Step 5: shellcheck the script**
+
+Run: `shellcheck configs/claude/scripts/skillclaw_promote.sh`
+Expected: clean (no warnings). The `_t0`/`CUR_STAGE`/`run_id` vars are used; `audit()` is a real function.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add configs/claude/scripts/skillclaw_promote.sh tests/bats/skillclaw_promote.bats
+git commit -m "feat(skillclaw): promote.sh audit events, --status, finalization trap"
+```
+
+---
+
+## Task 8: Documentation + full-suite verification
+
+**Files:**
+- Modify: `docs/SKILLCLAW.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Document the audit log in `docs/SKILLCLAW.md`**
+
+Insert a new section immediately before `## Security` (currently line 76):
+
+```markdown
+## Audit log + live status
+
+Each `skillclaw_promote` run writes two best-effort artifacts under `~/.skillclaw/`
+(fail-open — audit I/O never aborts or delays a run):
+
+- **`promote.log`** — append-only JSONL audit history (one event per line:
+  `run_start`, `stage_start`/`stage_end`, `chunk_done`, `candidates`, `pr_opened`,
+  `run_end`/`run_error`). Self-trims to the most recent ~50 runs.
+- **`status.json`** — overwritten snapshot of the current/last run plus a rough,
+  explicitly-labeled ETA (only the evolve stage predicts, and only once ≥2 chunks
+  complete; before that it shows `estimating…`).
+
+During a run the evolve stage prints a live per-chunk line to stderr, e.g.
+`[skillclaw] evolve · chunk 4/12 · 1m00s · ~2m left (est)`.
+
+Query the latest run at any time:
+
+```bash
+skillclaw_promote.sh --status
+# run 20260609T2305 · evolve · chunk 4/12 · 1m00s elapsed · ~2m left (est)
+# last run: done · 3 candidates · PR https://…/pull/7 · 4m12s
+# no recent run
+```
+
+The log records counts, names, timings, and URLs only — never session content
+(evolve inputs are already scrubbed upstream).
+```
+
+- [ ] **Step 2: Add a CHANGELOG entry**
+
+Under the `## [Unreleased]` heading in `CHANGELOG.md`, add:
+
+```markdown
+## [Unreleased]
+
+### Added
+- **SkillClaw promote audit log + live status/ETA** — new `skillclaw_audit.py`
+  writes an append-only `~/.skillclaw/promote.log` (JSONL history, self-trimmed to
+  ~50 runs) and a live `status.json` snapshot. `skillclaw_promote.sh --status`
+  reports where a run is and a rough ETA; the evolve stage prints per-chunk
+  progress. Fail-open: audit I/O never blocks a promote run.
+```
+
+- [ ] **Step 3: Run the full affected suite**
+
+Run:
+
+```bash
+pytest tests/python/test_skillclaw_audit.py tests/python/test_skillclaw_evolve.py -v
+bats tests/bats/skillclaw_promote.bats
+shellcheck configs/claude/scripts/skillclaw_promote.sh
+```
+
+Expected: all green; shellcheck clean.
+
+- [ ] **Step 4: Verify the audit log + status.json are valid JSON end-to-end**
+
+Run (uses a throwaway audit dir so it never touches the real `~/.skillclaw`):
+
+```bash
+SKILLCLAW_AUDIT_DIR=$(mktemp -d) python3 - <<'PY'
+import os, json, subprocess, sys
+sys.path.insert(0, "configs/claude/scripts")
+import skillclaw_audit as a
+rid = "20260609T230501Z-4821"
+a.log(rid, "-", "run_start", window_days=30, token_budget=100000, apply=True)
+a.log(rid, "evolve", "stage_start", chunks=3)
+a.log(rid, "evolve", "chunk_done", i=2, total=3, chunk_seconds=10.0, elapsed_s=20.0)
+a.log(rid, "-", "run_end", state="done", total_seconds=42.0)
+d = os.environ["SKILLCLAW_AUDIT_DIR"]
+for ln in open(f"{d}/promote.log"):
+    json.loads(ln)                      # raises if any line is invalid JSON
+json.load(open(f"{d}/status.json"))     # raises if status is invalid JSON
+print("OK:", a.render_status())
+PY
+```
+
+Expected: `OK: last run: done · ... · 42s` and no JSON errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/SKILLCLAW.md CHANGELOG.md
+git commit -m "docs(skillclaw): document promote audit log + --status"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** two artifacts (Tasks 2/4), `--status` both surfaces (Tasks 5/7), ETA-always-progress-once-measurable (Tasks 1/2/6), retention ~50 (Task 4), fail-open (Tasks 2-5,7), stale-pid liveness (Task 3), finalization trap (Task 7), no-state-bleed reset (Task 2), atomic trim & status writes (Tasks 1/4), storage auto-init (Task 5), `${SCRIPT_DIR}`-relative invocation (Task 7), cumulative `elapsed_s` for stateless ETA (Task 6), secrets posture = names/counts only (Tasks 7/8). All design decisions and all 7 `agy` findings are mapped to tasks.
+- **Type consistency:** `compute_eta(chunks_done, chunks_total, elapsed_s)`, `log(run_id, stage, event, **fields)`, `render_status()`, `trim(max_runs=50)`, and `evolve(..., run_id=None, audit=None)` are referenced identically across every task and test.
+- **Non-goals respected:** no `--history`, no external metrics/OTel, no change to pipeline behavior — observability only.

--- a/docs/superpowers/specs/2026-06-09-skillclaw-promote-audit-log-design.md
+++ b/docs/superpowers/specs/2026-06-09-skillclaw-promote-audit-log-design.md
@@ -1,0 +1,204 @@
+# SkillClaw Promote — Audit Log + Live Status/ETA — Design
+
+> A structured, persistent audit record for `skillclaw_promote` runs, plus live
+> run status and a rough "time remaining" estimate — surfaced both in the
+> terminal and via an on-demand `--status` query.
+
+**Date**: 2026-06-09
+**Status**: Approved (design) — pending implementation plan
+**Audience**: Manifest maintainers
+
+---
+
+## Problem
+
+`skillclaw_promote` runs the proxy-free SkillClaw pipeline (ingest → scrub →
+evolve → classify → promote). Today it has **no persistent run/audit log** — only
+ephemeral stdout and the git/PR provenance of whatever it promotes. The pipeline
+is long-running: the **evolve** stage is a map-reduce where each chunk is one
+`claude -p` call (seconds to tens of seconds), and `promote.sh` suppresses all
+sub-stage output (`>/dev/null`), so during a multi-minute evolve the operator
+sees a silent terminal with no sense of progress or how much longer it will take.
+
+We want: (1) a durable, structured **audit record** of each run, and (2) live
+**status + a rough ETA** that answers "where is it / how much longer," both as it
+runs and on demand.
+
+## Decisions (resolved during brainstorming)
+
+| Decision | Choice |
+|----------|--------|
+| Artifact structure | **Two artifacts** — append-only `promote.log` (JSONL audit history) + overwritten `status.json` (live current-run snapshot). `--status` is an O(1) read, not a tail-scan. |
+| Status surface | **Both** — live progress lines in the terminal during the run, **and** a queryable `skillclaw_promote.sh --status` reading `status.json`. |
+| ETA model | **Progress always + rough ETA once measurable.** Show stage + chunk i/N + elapsed always; once ≥2 chunks complete, also show `~Nm left (est)`. Before that, `estimating…`. |
+| Retention | `promote.log` self-trims to the most recent **~50 runs**. |
+| Query surface | `--status` only (no `--history` in V1). |
+| Failure posture | **Fail-open** — audit logging never aborts or delays a promote run. |
+
+## Non-Goals
+
+- No external log shipping / metrics backend (local files only).
+- No precise/guaranteed ETA — `claude -p` per-chunk time is variable; the ETA is
+  an explicitly-labeled estimate.
+- No `--history` browser of past runs (the JSONL is greppable; a viewer is a
+  future add).
+- No change to what the pipeline *does* — this is observability only.
+
+---
+
+## Architecture
+
+```text
+skillclaw_promote.sh ──┐  stage transitions (ingest/scrub/evolve/classify/promote),
+                       │  final summary, --status query, mints run_id
+                       ├──►  skillclaw_audit.py  ──►  ~/.skillclaw/promote.log  (append-only JSONL: audit history)
+skillclaw_evolve.py  ──┘  per-chunk: i/N + seconds        │              ~/.skillclaw/status.json   (overwritten: live snapshot + ETA)
+```
+
+`skillclaw_audit.py` is the single source of truth for both file formats; both
+the shell orchestrator and the Python evolver write through it.
+
+## Components
+
+### New
+
+- **`configs/claude/scripts/skillclaw_audit.py`** — the logger + status engine.
+  - `log(run_id, stage, event, **fields)` — append one JSONL line to
+    `~/.skillclaw/promote.log` **and** merge the live `~/.skillclaw/status.json`.
+  - `compute_eta(chunks_done, chunks_total, elapsed_s) -> (eta_s|None, label)` —
+    `i<2 → (None, "estimating…")`; `i≥2 → ((total-i)*elapsed/i, "~Nm left (est)")`.
+  - `render_status() -> str` — human one-glance summary for `--status`
+    (running / done / failed / none).
+  - `trim(max_runs=50)` — keep only events for the most recent `max_runs`
+    `run_id`s in `promote.log`.
+  - **Fail-open:** every public function wraps its I/O so an error (unwritable
+    dir, full disk, malformed merge) is swallowed and returns cleanly — it can
+    never raise into the pipeline.
+  - CLI entry so the shell can call it: `skillclaw_audit.py log …`,
+    `skillclaw_audit.py status`, `skillclaw_audit.py trim`.
+  - Files created `chmod 600` under `~/.skillclaw/` (already `700`).
+
+### Modified
+
+- **`configs/claude/scripts/skillclaw_promote.sh`**
+  - Mint a `run_id` at start (UTC timestamp + short pid suffix, e.g.
+    `20260609T230501Z-4821`).
+  - Log `run_start` (config: window_days, token_budget, apply?), `stage_start` /
+    `stage_end` for each stage with counts + seconds, `candidates`
+    (NEW/CHANGED/DROPPED names + reasons), `pr_opened` (url), and `run_end`
+    (state, total_seconds) — or `run_error` (stage, message) on failure.
+  - Print a short progress line at each stage transition
+    (`▸ evolve (12 chunks)…`).
+  - Pass `run_id` to `skillclaw_evolve.py`.
+  - New **`--status`** flag → `skillclaw_audit.py status` and exit 0.
+  - Call `skillclaw_audit.py trim` once per run.
+
+- **`configs/claude/scripts/skillclaw_evolve.py`**
+  - Accept `--run-id` (and audit path override for tests).
+  - In the existing map-reduce loop, after each chunk completes, record the
+    chunk's wall-clock seconds and call the audit logger with a `chunk_done`
+    event (`i`, `total`, `chunk_seconds`); the logger updates `status.json`
+    (stage=evolve, chunk i/N, elapsed, eta) and the evolver prints one live
+    progress line to stderr: `[skillclaw] evolve · chunk 4/12 · 1m00s · ~2m left (est)`.
+  - Time is real wall-clock (`time.monotonic()`); the evolver already has the
+    chunk list, so `total` is known up front.
+
+## Artifact schemas
+
+### `~/.skillclaw/promote.log` (append-only JSONL — audit record)
+
+One event per line: `{"ts": <iso8601>, "run_id": <id>, "stage": <name>, "event": <name>, ...fields}`.
+Event sequence per run:
+
+```jsonc
+{"ts":"…","run_id":"…","stage":"-","event":"run_start","window_days":30,"token_budget":100000,"apply":true}
+{"ts":"…","run_id":"…","stage":"ingest","event":"stage_start"}
+{"ts":"…","run_id":"…","stage":"ingest","event":"stage_end","ingested":12,"skipped":459,"seconds":3.1}
+{"ts":"…","run_id":"…","stage":"evolve","event":"stage_start","chunks":12}
+{"ts":"…","run_id":"…","stage":"evolve","event":"chunk_done","i":1,"total":12,"chunk_seconds":14.2}
+…
+{"ts":"…","run_id":"…","stage":"classify","event":"candidates","new":["a"],"changed":["b"],"dropped":[{"name":"c","reason":"…"}]}
+{"ts":"…","run_id":"…","stage":"promote","event":"pr_opened","url":"https://…/pull/NNN"}
+{"ts":"…","run_id":"…","stage":"-","event":"run_end","state":"done","total_seconds":252.4}
+```
+
+Errors emit `{"event":"run_error","stage":<where>,"message":<short>}`.
+
+### `~/.skillclaw/status.json` (overwritten — live snapshot)
+
+```jsonc
+{
+  "run_id": "20260609T230501Z-4821",
+  "started_at": "…", "updated_at": "…",
+  "state": "running",                       // running | done | failed
+  "stage": "evolve",
+  // eta_s = (total-chunk) * (elapsed_s / chunk) = (12-4) * (60/4) = 120
+  "evolve": {"chunk": 4, "total": 12, "elapsed_s": 60, "eta_s": 120, "eta_label": "~2m left (est)"},
+  "totals": {"ingested": 12, "candidates": null, "dropped": null},
+  "pr_url": null
+}
+```
+
+## Live UX + `--status`
+
+- **Terminal (live):** per-chunk stderr line from evolve + a short stage line from
+  promote. The existing `>/dev/null` on raw sub-stage output stays; only these
+  structured lines surface.
+- **`skillclaw_promote.sh --status`:** prints a one-glance summary, e.g.
+  `run 20260609T2305 · evolve · chunk 4/12 · 1m00s elapsed · ~2m left (est)`, or
+  `last run: done · 3 candidates · PR #NNN · 4m12s`, or `no recent run`.
+
+## Error handling & fail-open
+
+Audit logging is observability, never load-bearing. Every `skillclaw_audit.py`
+call (from shell or Python) is best-effort: on any error it logs nothing and
+returns success to the caller, so a promote run completes even if the log/status
+files can't be written. This mirrors the SkillClaw pipeline's existing fail-open
+posture (ingest/scrub/evolve already `|| err`/`|| true`).
+
+## Retention
+
+On each run, `skillclaw_audit.py trim` rewrites `promote.log` keeping only events
+whose `run_id` is among the most recent ~50. Bounds the file to a few hundred KB
+while preserving a meaningful history. `status.json` is a single snapshot
+(constant size).
+
+## Testing
+
+- **pytest `test_skillclaw_audit.py`:** `log()` appends a JSONL line and merges
+  `status.json`; `compute_eta` (`i<2 → estimating…`; `i≥2 → (total-i)*elapsed/i`);
+  `render_status` (running / done / none); `trim` keeps only the last N run_ids;
+  **fail-open** (unwritable path → returns cleanly, no raise, pipeline-safe).
+- **pytest `test_skillclaw_evolve.py` (extend):** with the injectable runner + a
+  temp audit dir, the map-reduce loop emits one `chunk_done` per chunk and
+  `status.json` reflects the correct `chunk`/`total`.
+- **bats `skillclaw_promote.bats` (extend):** `run_id` minted and present in
+  `promote.log`; `--status` renders from a seeded `status.json`; stage events are
+  logged; an **unwritable audit path does not abort** the run (exit 0).
+- **shellcheck** clean; `promote.log` lines and `status.json` are valid JSON.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Audit failure breaks a promote run | Fail-open by construction; bats asserts an unwritable path still exits 0 |
+| ETA misleads on high per-chunk variance | Labeled `(est)`; suppressed (`estimating…`) until ≥2 chunks; only evolve predicts |
+| Log grows unbounded | `trim` to last ~50 runs each run |
+| Concurrent reads of `status.json` mid-write | Write to `status.json.tmp` then atomic `mv` (same pattern as spec-review feedback) |
+| Secrets leaking into the log | Log records counts/names/timings/URLs only — never session content; evolve inputs are already scrubbed upstream |
+
+## Follow-ups (not in V1)
+
+- `--history` view (one-line summary per recent run from `promote.log`).
+- Per-stage ETA for ingest on very large transcript sets (currently treated as
+  fast/fixed).
+- Optional metrics/OTel export.
+
+---
+
+## Related Documents
+
+- [docs/SKILLCLAW.md](../../SKILLCLAW.md) — the proxy-free pipeline this instruments
+- [2026-06-08 SkillClaw proxy-free evolve design](2026-06-08-skillclaw-proxy-free-evolve-design.md)
+- [spec-review design](2026-06-08-spec-review-design.md) — shares the atomic
+  `.tmp`+`mv` write and fail-open patterns reused here

--- a/docs/superpowers/specs/2026-06-09-skillclaw-promote-audit-log-design.md
+++ b/docs/superpowers/specs/2026-06-09-skillclaw-promote-audit-log-design.md
@@ -7,6 +7,11 @@
 **Date**: 2026-06-09
 **Status**: Approved (design) — pending implementation plan
 **Audience**: Manifest maintainers
+**Reviewed by**: `agy` (Antigravity CLI) independent design review — 7 findings
+(4 important, 3 minor) verified and incorporated: stateless ETA via cumulative
+`elapsed_s`, stale-`running` finalization (trap + pid-liveness), per-run status
+reset (no state bleed), atomic `trim`, `compute_eta` bounds guards, storage
+auto-init, and `${SCRIPT_DIR}`-relative invocation.
 
 ---
 
@@ -64,19 +69,34 @@ the shell orchestrator and the Python evolver write through it.
 
 - **`configs/claude/scripts/skillclaw_audit.py`** — the logger + status engine.
   - `log(run_id, stage, event, **fields)` — append one JSONL line to
-    `~/.skillclaw/promote.log` **and** merge the live `~/.skillclaw/status.json`.
+    `~/.skillclaw/promote.log` **and** update `~/.skillclaw/status.json`. A
+    `run_start` event — or any event whose `run_id` differs from the one currently
+    in `status.json` — **initializes a fresh status structure instead of merging**,
+    so a new run can never inherit the prior run's `pr_url`, totals, or evolve
+    metrics (no state bleed). All other events merge into the current run's snapshot.
   - `compute_eta(chunks_done, chunks_total, elapsed_s) -> (eta_s|None, label)` —
-    `i<2 → (None, "estimating…")`; `i≥2 → ((total-i)*elapsed/i, "~Nm left (est)")`.
+    returns `(None, "estimating…")` when inputs are insufficient or invalid
+    (`chunks_done < 2`, `chunks_total <= chunks_done`, or any non-positive), else
+    `((total-done)*elapsed/done, "~Nm left (est)")`. The guards prevent
+    negative/div-by-zero ETAs from corrupt or out-of-order status.
   - `render_status() -> str` — human one-glance summary for `--status`
-    (running / done / failed / none).
+    (running / done / failed / none). **Liveness:** if `state=="running"` but the
+    pid embedded in `run_id` is no longer alive, render as `stale` — a crash or
+    Ctrl-C that skipped finalization must never show as a phantom running run.
   - `trim(max_runs=50)` — keep only events for the most recent `max_runs`
-    `run_id`s in `promote.log`.
+    `run_id`s in `promote.log`. **Atomic:** writes filtered lines to
+    `promote.log.tmp` then `os.replace()` over `promote.log`, so an interrupt or
+    full disk during trim can't corrupt or lose the audit history.
+  - **Storage init:** ensures `~/.skillclaw/` exists (`mkdir -p` + `chmod 700`)
+    before writing, so a fresh install with no dir doesn't silently log nothing.
   - **Fail-open:** every public function wraps its I/O so an error (unwritable
-    dir, full disk, malformed merge) is swallowed and returns cleanly — it can
+    dir, full disk, malformed status) is swallowed and returns cleanly — it can
     never raise into the pipeline.
-  - CLI entry so the shell can call it: `skillclaw_audit.py log …`,
-    `skillclaw_audit.py status`, `skillclaw_audit.py trim`.
-  - Files created `chmod 600` under `~/.skillclaw/` (already `700`).
+  - CLI entry, **always invoked as `python3 "${SCRIPT_DIR}/skillclaw_audit.py"
+    <cmd>`** from promote.sh (matching the repo's `${SCRIPT_DIR}/skillclaw_*.py`
+    convention — never bare on `PATH`): `log …`, `status`, `trim`.
+  - `status.json` and `promote.log` written `chmod 600`; `status.json` via `.tmp`
+    + atomic rename (safe concurrent reads under `~/.skillclaw/`, already `700`).
 
 ### Modified
 
@@ -92,16 +112,24 @@ the shell orchestrator and the Python evolver write through it.
   - Pass `run_id` to `skillclaw_evolve.py`.
   - New **`--status`** flag → `skillclaw_audit.py status` and exit 0.
   - Call `skillclaw_audit.py trim` once per run.
+  - **Finalization trap:** install a `trap` on `EXIT`/`INT`/`TERM` that, if the run
+    hasn't already logged `run_end`, logs `run_error` (stage = wherever it died)
+    and finalizes `status.json` to `failed` — so a crash, Ctrl-C, or `set -e` exit
+    never leaves a phantom `running` status. (Complements the
+    `render_status` pid-liveness check as belt-and-suspenders.)
 
 - **`configs/claude/scripts/skillclaw_evolve.py`**
   - Accept `--run-id` (and audit path override for tests).
-  - In the existing map-reduce loop, after each chunk completes, record the
-    chunk's wall-clock seconds and call the audit logger with a `chunk_done`
-    event (`i`, `total`, `chunk_seconds`); the logger updates `status.json`
-    (stage=evolve, chunk i/N, elapsed, eta) and the evolver prints one live
-    progress line to stderr: `[skillclaw] evolve · chunk 4/12 · 1m00s · ~2m left (est)`.
-  - Time is real wall-clock (`time.monotonic()`); the evolver already has the
-    chunk list, so `total` is known up front.
+  - In the existing map-reduce loop, after each chunk completes, call the audit
+    logger with a `chunk_done` event carrying `i`, `total`, this chunk's
+    `chunk_seconds`, **and the cumulative `elapsed_s` since the evolve stage
+    started** (so the ETA is computed statelessly from the event itself, not from
+    re-deriving cumulative time inside the logger). The logger updates
+    `status.json` (stage=evolve, chunk i/N, elapsed, eta) and the evolver prints
+    one live progress line to stderr:
+    `[skillclaw] evolve · chunk 4/12 · 1m00s · ~2m left (est)`.
+  - Time is real wall-clock (`time.monotonic()`), accumulated across chunks; the
+    evolver already has the chunk list, so `total` is known up front.
 
 ## Artifact schemas
 
@@ -115,7 +143,7 @@ Event sequence per run:
 {"ts":"…","run_id":"…","stage":"ingest","event":"stage_start"}
 {"ts":"…","run_id":"…","stage":"ingest","event":"stage_end","ingested":12,"skipped":459,"seconds":3.1}
 {"ts":"…","run_id":"…","stage":"evolve","event":"stage_start","chunks":12}
-{"ts":"…","run_id":"…","stage":"evolve","event":"chunk_done","i":1,"total":12,"chunk_seconds":14.2}
+{"ts":"…","run_id":"…","stage":"evolve","event":"chunk_done","i":1,"total":12,"chunk_seconds":14.2,"elapsed_s":14.2}
 …
 {"ts":"…","run_id":"…","stage":"classify","event":"candidates","new":["a"],"changed":["b"],"dropped":[{"name":"c","reason":"…"}]}
 {"ts":"…","run_id":"…","stage":"promote","event":"pr_opened","url":"https://…/pull/NNN"}
@@ -165,16 +193,23 @@ while preserving a meaningful history. `status.json` is a single snapshot
 
 ## Testing
 
-- **pytest `test_skillclaw_audit.py`:** `log()` appends a JSONL line and merges
-  `status.json`; `compute_eta` (`i<2 → estimating…`; `i≥2 → (total-i)*elapsed/i`);
-  `render_status` (running / done / none); `trim` keeps only the last N run_ids;
-  **fail-open** (unwritable path → returns cleanly, no raise, pipeline-safe).
+- **pytest `test_skillclaw_audit.py`:** `log()` appends a JSONL line and updates
+  `status.json`; **`run_start`/changed-`run_id` resets the snapshot** (prior
+  `pr_url`/metrics do not bleed in); `compute_eta` (`done<2 → estimating…`;
+  `total<=done` or non-positive → `estimating…`; else `(total-done)*elapsed/done`);
+  `render_status` (running / done / none / **`stale` when the run_id pid is
+  dead**); `trim` keeps only the last N run_ids **and writes atomically** (a
+  simulated mid-trim failure leaves the original log intact); **storage init**
+  (`mkdir -p` + 700 when the dir is absent); **fail-open** (unwritable path →
+  returns cleanly, no raise, pipeline-safe).
 - **pytest `test_skillclaw_evolve.py` (extend):** with the injectable runner + a
   temp audit dir, the map-reduce loop emits one `chunk_done` per chunk and
   `status.json` reflects the correct `chunk`/`total`.
 - **bats `skillclaw_promote.bats` (extend):** `run_id` minted and present in
   `promote.log`; `--status` renders from a seeded `status.json`; stage events are
-  logged; an **unwritable audit path does not abort** the run (exit 0).
+  logged; the **finalization trap logs `run_error` + sets `status.json` failed**
+  on a simulated mid-run interrupt; an **unwritable audit path does not abort**
+  the run (exit 0).
 - **shellcheck** clean; `promote.log` lines and `status.json` are valid JSON.
 
 ## Risks & mitigations
@@ -185,6 +220,10 @@ while preserving a meaningful history. `status.json` is a single snapshot
 | ETA misleads on high per-chunk variance | Labeled `(est)`; suppressed (`estimating…`) until ≥2 chunks; only evolve predicts |
 | Log grows unbounded | `trim` to last ~50 runs each run |
 | Concurrent reads of `status.json` mid-write | Write to `status.json.tmp` then atomic `mv` (same pattern as spec-review feedback) |
+| Crash/Ctrl-C leaves a phantom `running` status | `trap` finalizes status on EXIT/INT/TERM + `render_status` pid-liveness check reports `stale` |
+| New run inherits prior run's status fields (state bleed) | `run_start` / changed `run_id` initializes a fresh `status.json`, never merges across runs |
+| `trim` rewrite corrupts the log on interrupt | Atomic `promote.log.tmp` + `os.replace()` |
+| `compute_eta` produces negative/div-zero on corrupt status | Guards: `done≥2`, `total>done`, all positive — else `estimating…` |
 | Secrets leaking into the log | Log records counts/names/timings/URLs only — never session content; evolve inputs are already scrubbed upstream |
 
 ## Follow-ups (not in V1)

--- a/tests/bats/skillclaw_promote.bats
+++ b/tests/bats/skillclaw_promote.bats
@@ -156,3 +156,10 @@ EOF
     run bash "$SCRIPT" --no-evolve
     assert_success
 }
+
+@test "classify stage logs a stage_end with seconds" {
+    run bash "$SCRIPT" --no-evolve
+    assert_success
+    run grep -E '"stage": "classify".*"event": "stage_end"' "$SKILLCLAW_AUDIT_DIR/promote.log"
+    assert_success
+}

--- a/tests/bats/skillclaw_promote.bats
+++ b/tests/bats/skillclaw_promote.bats
@@ -42,6 +42,8 @@ EOF
     export SKILLCLAW_GITOPS="$MOCK_BIN/git_ops.sh"
     export PATH="$MOCK_BIN:$PATH"
     export SKILLCLAW_PROMOTE_LOG="$SANDBOX/log"
+    export SKILLCLAW_AUDIT_DIR="$SANDBOX/skillclaw"
+    mkdir -p "$SKILLCLAW_AUDIT_DIR"
     : > "$SKILLCLAW_PROMOTE_LOG"
 }
 
@@ -95,4 +97,62 @@ teardown() {
 @test "promote warns when candidates are rejected" {
   run grep -Ei 'failed schema validation|rejected' "$REPO_ROOT/configs/claude/scripts/skillclaw_promote.sh"
   [ "$status" -eq 0 ]
+}
+
+@test "promote mints a run_id and records it in promote.log" {
+    run bash "$SCRIPT" --no-evolve
+    assert_success
+    run grep -c '"event": "run_start"' "$SKILLCLAW_AUDIT_DIR/promote.log"
+    assert_output "1"
+    run grep -Eq '"run_id": "[0-9]{8}T[0-9]{6}Z-[0-9]+"' "$SKILLCLAW_AUDIT_DIR/promote.log"
+    assert_success
+}
+
+@test "--status renders from a seeded status.json" {
+    cat > "$SKILLCLAW_AUDIT_DIR/status.json" << 'EOF'
+{"run_id":"20260609T230501Z-4821","state":"done","stage":"-",
+ "totals":{"ingested":12,"candidates":3,"dropped":0},
+ "pr_url":"https://example.test/pr/7","total_seconds":252}
+EOF
+    run bash "$SCRIPT" --status
+    assert_success
+    assert_output --partial "done"
+    assert_output --partial "3 candidates"
+    assert_output --partial "PR https://example.test/pr/7"
+}
+
+@test "stage transitions are logged as stage_start events" {
+    run bash "$SCRIPT" --no-evolve
+    assert_success
+    run grep -c '"event": "stage_start"' "$SKILLCLAW_AUDIT_DIR/promote.log"
+    [ "$output" -ge 1 ]
+}
+
+@test "finalization trap records run_error + failed status on mid-run interrupt" {
+    # Make `git switch` fail so --apply dies after run_start/stages -> trap fires.
+    cat > "$MOCK_BIN/git" << 'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  rev-parse) echo "abc1234" ;;
+  switch) echo "boom" >&2; exit 1 ;;
+  *) : ;;
+esac
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/git"
+    export SKILLCLAW_OPEN_PR=""
+    run bash "$SCRIPT" --apply --no-evolve
+    assert_failure
+    run grep -c '"event": "run_error"' "$SKILLCLAW_AUDIT_DIR/promote.log"
+    [ "$output" -ge 1 ]
+    run grep -q '"state": "failed"' "$SKILLCLAW_AUDIT_DIR/status.json"
+    assert_success
+}
+
+@test "unwritable audit path does not abort the run" {
+    # Point the audit dir inside a regular file -> every audit call fails open.
+    printf 'x' > "$SANDBOX/blocker"
+    export SKILLCLAW_AUDIT_DIR="$SANDBOX/blocker/sub"
+    run bash "$SCRIPT" --no-evolve
+    assert_success
 }

--- a/tests/bats/skillclaw_promote.bats
+++ b/tests/bats/skillclaw_promote.bats
@@ -108,6 +108,15 @@ teardown() {
     assert_success
 }
 
+@test "run_start records real pipeline config (window_days/token_budget), not zeros" {
+    run bash "$SCRIPT" --no-evolve
+    assert_success
+    run grep '"event": "run_start"' "$SKILLCLAW_AUDIT_DIR/promote.log"
+    assert_output --partial '"window_days": 30'
+    assert_output --partial '"token_budget": 100000'
+    refute_output --partial '"window_days": 0'
+}
+
 @test "--status renders from a seeded status.json" {
     cat > "$SKILLCLAW_AUDIT_DIR/status.json" << 'EOF'
 {"run_id":"20260609T230501Z-4821","state":"done","stage":"-",

--- a/tests/python/test_skillclaw_audit.py
+++ b/tests/python/test_skillclaw_audit.py
@@ -155,3 +155,14 @@ def test_render_status_done_summary(tmp_path, monkeypatch):
     audit.log(rid, "-", "run_end", state="done", total_seconds=252.4)
     out = audit.render_status()
     assert "done" in out and "3 candidates" in out and "PR https://x/pull/7" in out
+
+
+def test_fmt_secs_negative_is_unknown():
+    assert audit._fmt_secs(-5) == "?"
+    assert audit._fmt_secs(None) == "?"
+
+
+def test_render_status_unknown_state_is_not_mislabeled_done(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    (tmp_path / "status.json").write_text('{"run_id": "r-1", "state": "aborted"}')
+    assert audit.render_status() == "no recent run"

--- a/tests/python/test_skillclaw_audit.py
+++ b/tests/python/test_skillclaw_audit.py
@@ -166,3 +166,27 @@ def test_render_status_unknown_state_is_not_mislabeled_done(tmp_path, monkeypatc
     monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
     (tmp_path / "status.json").write_text('{"run_id": "r-1", "state": "aborted"}')
     assert audit.render_status() == "no recent run"
+
+
+def test_trim_keeps_only_recent_run_ids(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    for i in range(5):
+        audit.log("run-%d" % i, "-", "run_start")
+    audit.trim(max_runs=2)
+    rids = {json.loads(ln)["run_id"]
+            for ln in (tmp_path / "promote.log").read_text().splitlines()}
+    assert rids == {"run-3", "run-4"}
+
+
+def test_trim_is_atomic_on_failure(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    for i in range(3):
+        audit.log("run-%d" % i, "-", "run_start")
+    original = (tmp_path / "promote.log").read_text()
+
+    def boom(*a, **k):
+        raise OSError("simulated mid-trim crash")
+
+    monkeypatch.setattr(audit.os, "replace", boom)
+    audit.trim(max_runs=1)  # fail-open: swallows the error
+    assert (tmp_path / "promote.log").read_text() == original  # untouched

--- a/tests/python/test_skillclaw_audit.py
+++ b/tests/python/test_skillclaw_audit.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/claude/scripts"))
@@ -35,3 +36,43 @@ def test_compute_eta_sub_minute_rounds_up_to_one_minute():
 def test_compute_eta_non_numeric_inputs_estimate_safely():
     assert audit.compute_eta(None, 12, 60) == (None, "estimating…")
     assert audit.compute_eta(4, "twelve", 60) == (None, "estimating…")
+
+
+def _read(p):
+    return json.loads(Path(p).read_text())
+
+
+def test_log_appends_jsonl_and_updates_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    audit.log("20260609T230501Z-4821", "-", "run_start",
+              window_days=30, token_budget=100000, apply=True)
+    log_lines = (tmp_path / "promote.log").read_text().splitlines()
+    assert len(log_lines) == 1
+    first = json.loads(log_lines[0])
+    assert first["event"] == "run_start" and first["window_days"] == 30
+    status = _read(tmp_path / "status.json")
+    assert status["run_id"] == "20260609T230501Z-4821"
+    assert status["state"] == "running"
+
+
+def test_chunk_done_event_records_eta(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "evolve", "stage_start", chunks=12)
+    audit.log(rid, "evolve", "chunk_done", i=4, total=12, chunk_seconds=15.0, elapsed_s=60)
+    status = _read(tmp_path / "status.json")
+    assert status["stage"] == "evolve"
+    assert status["evolve"]["chunk"] == 4 and status["evolve"]["total"] == 12
+    assert status["evolve"]["eta_s"] == 120
+    assert status["evolve"]["eta_label"] == "~2m left (est)"
+
+
+def test_new_run_id_resets_snapshot_no_state_bleed(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    audit.log("20260609T230501Z-1111", "promote", "pr_opened", url="https://x/pull/9")
+    audit.log("20260609T235959Z-2222", "-", "run_start")  # different run_id
+    status = _read(tmp_path / "status.json")
+    assert status["run_id"] == "20260609T235959Z-2222"
+    assert status["pr_url"] is None          # prior run's PR must not bleed in
+    assert status["state"] == "running"

--- a/tests/python/test_skillclaw_audit.py
+++ b/tests/python/test_skillclaw_audit.py
@@ -223,3 +223,32 @@ def test_cli_status_and_trim(tmp_path, monkeypatch, capsys):
     assert audit.main(["status"]) == 0
     assert capsys.readouterr().out.strip() == "no recent run"
     assert audit.main(["trim", "--max-runs", "10"]) == 0   # no log yet -> no-op, rc 0
+
+
+def test_cli_log_bare_key_is_silently_dropped(tmp_path, monkeypatch):
+    # A field passed without `=` (e.g. `apply` instead of `apply=true`) is dropped,
+    # never raised — the shell must never get a nonzero from a typo'd audit call.
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rc = audit.main(["log", "run-1", "-", "run_start", "apply", "window_days=30"])
+    assert rc == 0
+    status = json.loads((tmp_path / "status.json").read_text())
+    assert status.get("config", {}).get("window_days") == 30   # good pair kept
+    assert "apply" not in status.get("config", {})             # bare key dropped
+
+
+def test_cli_trim_non_int_max_runs_falls_back(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    for i in range(3):
+        audit.log("run-%d" % i, "-", "run_start")
+    rc = audit.main(["trim", "--max-runs", "notanint"])        # bad value -> default
+    assert rc == 0
+    rids = {json.loads(ln)["run_id"]
+            for ln in (tmp_path / "promote.log").read_text().splitlines()}
+    assert rids == {"run-0", "run-1", "run-2"}                 # default 50 keeps all
+
+
+def test_cli_log_with_too_few_args_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rc = audit.main(["log", "run-1"])                          # <3 positional -> no-op
+    assert rc == 0
+    assert not (tmp_path / "promote.log").exists()             # nothing written

--- a/tests/python/test_skillclaw_audit.py
+++ b/tests/python/test_skillclaw_audit.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/claude/scripts"))
+import skillclaw_audit as audit  # noqa: E402
+
+
+def test_compute_eta_estimating_until_two_chunks():
+    assert audit.compute_eta(0, 12, 0)[1] == "estimating…"
+    assert audit.compute_eta(1, 12, 14.2)[1] == "estimating…"
+
+
+def test_compute_eta_guards_bad_inputs():
+    # total <= done, and non-positive elapsed -> estimating, never negative/div0
+    assert audit.compute_eta(5, 5, 60)[0] is None
+    assert audit.compute_eta(6, 5, 60)[0] is None
+    assert audit.compute_eta(3, 12, 0)[0] is None
+    assert audit.compute_eta(3, 12, -1)[0] is None
+
+
+def test_compute_eta_linear_projection():
+    # (12-4) * (60/4) = 120s -> ~2m
+    eta_s, label = audit.compute_eta(4, 12, 60)
+    assert eta_s == 120
+    assert label == "~2m left (est)"

--- a/tests/python/test_skillclaw_audit.py
+++ b/tests/python/test_skillclaw_audit.py
@@ -190,3 +190,36 @@ def test_trim_is_atomic_on_failure(tmp_path, monkeypatch):
     monkeypatch.setattr(audit.os, "replace", boom)
     audit.trim(max_runs=1)  # fail-open: swallows the error
     assert (tmp_path / "promote.log").read_text() == original  # untouched
+
+
+def test_fail_open_on_unwritable_dir(tmp_path, monkeypatch):
+    # Point the audit dir *inside* a regular file so mkdir raises NotADirectoryError.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir")
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(blocker / "sub"))
+    audit.log("run-x", "-", "run_start")          # must not raise
+    assert audit.render_status() == "no recent run"
+
+
+def test_storage_auto_inits_when_absent(tmp_path, monkeypatch):
+    target = tmp_path / "fresh" / "nested"        # does not exist yet
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(target))
+    audit.log("run-1", "-", "run_start")
+    assert (target / "promote.log").exists()
+    assert (target / "status.json").exists()
+
+
+def test_cli_log_parses_key_value_and_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rc = audit.main(["log", "run-1", "classify", "candidates",
+                     'new=["a","b"]', "dropped=[]", "changed=[]"])
+    assert rc == 0
+    status = json.loads((tmp_path / "status.json").read_text())
+    assert status["totals"]["candidates"] == 2
+
+
+def test_cli_status_and_trim(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    assert audit.main(["status"]) == 0
+    assert capsys.readouterr().out.strip() == "no recent run"
+    assert audit.main(["trim", "--max-runs", "10"]) == 0   # no log yet -> no-op, rc 0

--- a/tests/python/test_skillclaw_audit.py
+++ b/tests/python/test_skillclaw_audit.py
@@ -121,3 +121,37 @@ def test_run_error_sets_failed_state_and_stage(tmp_path, monkeypatch):
     audit.log(rid, "evolve", "run_error", message="boom")
     st = _read(tmp_path / "status.json")
     assert st["state"] == "failed" and st["error_stage"] == "evolve"
+
+
+def test_render_status_no_recent_run(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    assert audit.render_status() == "no recent run"
+
+
+def test_render_status_running_evolve(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    monkeypatch.setattr(audit, "_pid_alive", lambda pid: True)
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "evolve", "stage_start", chunks=12)
+    audit.log(rid, "evolve", "chunk_done", i=4, total=12, chunk_seconds=15.0, elapsed_s=60)
+    out = audit.render_status()
+    assert "evolve" in out and "chunk 4/12" in out and "~2m left (est)" in out
+
+
+def test_render_status_stale_when_pid_dead(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    monkeypatch.setattr(audit, "_pid_alive", lambda pid: False)
+    audit.log("20260609T230501Z-4821", "-", "run_start")
+    assert "stale" in audit.render_status()
+
+
+def test_render_status_done_summary(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "classify", "candidates", new=["a", "b", "c"], changed=[], dropped=[])
+    audit.log(rid, "promote", "pr_opened", url="https://x/pull/7")
+    audit.log(rid, "-", "run_end", state="done", total_seconds=252.4)
+    out = audit.render_status()
+    assert "done" in out and "3 candidates" in out and "PR https://x/pull/7" in out

--- a/tests/python/test_skillclaw_audit.py
+++ b/tests/python/test_skillclaw_audit.py
@@ -76,3 +76,48 @@ def test_new_run_id_resets_snapshot_no_state_bleed(tmp_path, monkeypatch):
     assert status["run_id"] == "20260609T235959Z-2222"
     assert status["pr_url"] is None          # prior run's PR must not bleed in
     assert status["state"] == "running"
+
+
+def test_stage_end_ingested_recorded(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "ingest", "stage_end", ingested=12, seconds=3)
+    assert _read(tmp_path / "status.json")["totals"]["ingested"] == 12
+
+
+def test_candidates_counts_new_changed_and_dropped(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "classify", "candidates",
+              new=["a", "b"], changed=["c"], dropped=[{"name": "d", "reason": "x"}])
+    totals = _read(tmp_path / "status.json")["totals"]
+    assert totals["candidates"] == 3      # 2 new + 1 changed
+    assert totals["dropped"] == 1
+
+
+def test_pr_opened_sets_pr_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "promote", "pr_opened", url="https://x/pull/7")
+    assert _read(tmp_path / "status.json")["pr_url"] == "https://x/pull/7"
+
+
+def test_run_end_sets_state_and_total_seconds(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "-", "run_end", state="done", total_seconds=252.4)
+    st = _read(tmp_path / "status.json")
+    assert st["state"] == "done" and st["total_seconds"] == 252.4
+
+
+def test_run_error_sets_failed_state_and_stage(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path))
+    rid = "20260609T230501Z-4821"
+    audit.log(rid, "-", "run_start")
+    audit.log(rid, "evolve", "run_error", message="boom")
+    st = _read(tmp_path / "status.json")
+    assert st["state"] == "failed" and st["error_stage"] == "evolve"

--- a/tests/python/test_skillclaw_audit.py
+++ b/tests/python/test_skillclaw_audit.py
@@ -23,3 +23,15 @@ def test_compute_eta_linear_projection():
     eta_s, label = audit.compute_eta(4, 12, 60)
     assert eta_s == 120
     assert label == "~2m left (est)"
+
+
+def test_compute_eta_sub_minute_rounds_up_to_one_minute():
+    # 3 of 4 chunks done in 4s -> eta 1.33s, intentionally labelled ~1m (rough).
+    eta_s, label = audit.compute_eta(3, 4, 4)
+    assert eta_s < 60
+    assert label == "~1m left (est)"
+
+
+def test_compute_eta_non_numeric_inputs_estimate_safely():
+    assert audit.compute_eta(None, 12, 60) == (None, "estimating…")
+    assert audit.compute_eta(4, "twelve", 60) == (None, "estimating…")

--- a/tests/python/test_skillclaw_evolve.py
+++ b/tests/python/test_skillclaw_evolve.py
@@ -158,3 +158,10 @@ def test_evolve_emits_chunk_events_to_status(tmp_path, monkeypatch):
     status = json.loads((tmp_path / "audit" / "status.json").read_text())
     assert status["evolve"]["total"] >= 2
     assert status["evolve"]["chunk"] == status["evolve"]["total"]  # last chunk recorded
+
+    chunk_events = [json.loads(ln) for ln in log_lines
+                    if json.loads(ln)["event"] == "chunk_done"]
+    for e in chunk_events:
+        assert e["chunk_seconds"] <= e["elapsed_s"] + 1e-9   # delta never exceeds cumulative
+    elapsed_values = [e["elapsed_s"] for e in chunk_events]
+    assert elapsed_values == sorted(elapsed_values)          # cumulative is monotonic

--- a/tests/python/test_skillclaw_evolve.py
+++ b/tests/python/test_skillclaw_evolve.py
@@ -87,6 +87,26 @@ def test_evolve_empty_sessions_is_clean_noop(tmp_path):
     assert calls == []                 # no sessions -> no model calls
 
 
+def test_evolve_empty_sessions_with_run_id_emits_stage_start(tmp_path, monkeypatch):
+    # Even with no sessions, a run_id must produce a stage_start so --status shows
+    # evolve ran (and skipped) instead of leaving a stale prior stage in status.json.
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path / "audit"))
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    template = tmp_path / "tpl.md"
+    template.write_text("{{LIBRARY}}{{SESSIONS}}")
+    evolved = tmp_path / "evolved"
+    calls = []
+    summary = ev.evolve(sessions_dir, evolved, template, token_budget=100_000,
+                        runner=lambda p: calls.append(p) or "NO_SKILLS",
+                        run_id="20260609T230501Z-4821")
+    assert summary["candidates"] == 0
+    assert calls == []                 # no sessions -> still no model calls
+    status = json.loads((tmp_path / "audit" / "status.json").read_text())
+    assert status["stage"] == "evolve"
+    assert status["evolve"]["total"] == 0
+
+
 def test_evolve_shows_committed_library_not_output_dir(tmp_path):
     # The model must see the REAL committed library (so it doesn't re-propose
     # already-merged skills), not the evolved output dir.

--- a/tests/python/test_skillclaw_evolve.py
+++ b/tests/python/test_skillclaw_evolve.py
@@ -132,3 +132,29 @@ def test_evolve_multichunk_dedupes_candidates_by_name(tmp_path):
     assert summary["chunks"] >= 2
     assert summary["candidates"] == 1
     assert summary["written"] == ["dup"]
+
+
+def test_evolve_emits_chunk_events_to_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLCLAW_AUDIT_DIR", str(tmp_path / "audit"))
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    big = "x" * 160_000  # ~40k tokens each -> 2 sessions force >=2 chunks at budget 50k
+    for i in range(2):
+        (sessions_dir / f"s{i}.json").write_text(json.dumps(
+            {"session_id": f"s{i}", "turns": [
+                {"role": "user", "blocks": [{"kind": "text", "text": big}]}]}))
+    template = tmp_path / "tpl.md"
+    template.write_text("{{LIBRARY}}{{SESSIONS}}")
+    evolved = tmp_path / "evolved"
+    out = "~~~skill name=dup\n---\nname: dup\ndescription: d\n---\n# Dup\nstep\n~~~\n"
+
+    ev.evolve(sessions_dir, evolved, template, token_budget=50_000,
+              runner=lambda p: out, run_id="20260609T230501Z-4821")
+
+    log_lines = (tmp_path / "audit" / "promote.log").read_text().splitlines()
+    events = [json.loads(ln)["event"] for ln in log_lines]
+    assert "stage_start" in events
+    assert events.count("chunk_done") >= 2
+    status = json.loads((tmp_path / "audit" / "status.json").read_text())
+    assert status["evolve"]["total"] >= 2
+    assert status["evolve"]["chunk"] == status["evolve"]["total"]  # last chunk recorded


### PR DESCRIPTION
## Summary
Adds a durable audit log and live, queryable run status (with a rough ETA) to the SkillClaw `promote` pipeline — observability only, never changes what the pipeline promotes.

- **New `skillclaw_audit.py`** — single source of truth for two artifacts under `~/.skillclaw/`: append-only `promote.log` (JSONL history, self-trimmed to ~50 runs, atomic) and overwritten `status.json` (live snapshot + ETA). Public API: `compute_eta`, `log`, `render_status`, `trim`, plus a `log`/`status`/`trim` CLI.
- **`skillclaw_evolve.py`** — emits `stage_start` + per-chunk `chunk_done` events (cumulative `elapsed_s` for a stateless ETA, per-chunk `chunk_seconds` delta) and a live stderr progress line. Strict no-op without `--run-id`.
- **`skillclaw_promote.sh`** — mints a `run_id`, logs run/stage/candidates/`pr_opened`/`run_end` events, adds `--status`, installs a finalization trap (crash/Ctrl-C → `run_error` + `failed` status), and trims once per run. Every audit call is best-effort (`|| true`).
- **Docs** — `docs/SKILLCLAW.md` gains an "Audit log + live status" section; `CHANGELOG.md` updated.

Built spec-first via subagent-driven TDD (8 tasks, two-stage review each). Design spec: `docs/superpowers/specs/2026-06-09-skillclaw-promote-audit-log-design.md`. All 11 design guarantees verified by a final Opus review (MERGE-READY): two artifacts, ETA model, ~50-run retention, fail-open (Python + shell), stale-pid finalization, no-state-bleed reset, atomic writes, compute_eta bounds guards, storage auto-init, stateless ETA, and names-only secrets posture.

## Test Plan
- [x] `pytest tests/python/test_skillclaw_audit.py tests/python/test_skillclaw_evolve.py` — 39 passed
- [x] `bats tests/bats/skillclaw_promote.bats` — 12/12 passed (incl. trap→failed-status and unwritable-path-still-exits-0)
- [x] `shellcheck configs/claude/scripts/skillclaw_promote.sh` — clean
- [x] End-to-end JSON-validity check of `promote.log` + `status.json`
- [ ] Manual: run `skillclaw_promote.sh` and `skillclaw_promote.sh --status` against a real `~/.skillclaw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)