### PR TITLE
🎨 Palette: Improve CLI spinner UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,3 +11,7 @@ repeated script executions.
 **Action:** Instantiate these UI components with `transient=True` to
 automatically clear them upon completion, keeping the user's terminal history
 clean.
+
+## 2026-10-24 - CLI Loading Spinner UX
+**Learning:** Terminal loading spinners can create a jarring experience if output is randomly emitted during animation, and especially if the cursor jumps back and forth continuously.
+**Action:** Always implement shell spinners in a subshell, hide the cursor during animation (`tput civis`), buffer all output to a temporary file, restore the cursor via an `EXIT` trap (`tput cnorm`), and only print the buffered logs if the background task fails.

--- a/bootstrap/lib/common.sh
+++ b/bootstrap/lib/common.sh
@@ -56,25 +56,35 @@ command_exists() {
 # Show a spinner while a command runs
 # Usage: run_with_spinner "command args" "Loading message"
 run_with_spinner() {
-    local cmd="$1"
-    local msg="${2:-Working}"
-    local pid
-    local spin='-\|/'
-    local i=0
+    (
+        local cmd="$1"
+        local msg="${2:-Working}"
+        local log_file
+        log_file=$(mktemp)
 
-    eval "$cmd" &
-    pid=$!
+        tput civis 2>/dev/null || true
+        trap 'tput cnorm 2>/dev/null || true; rm -f "$log_file"' EXIT
 
-    while kill -0 "$pid" 2> /dev/null; do
-        i=$(((i + 1) % 4))
-        printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
-        sleep 0.2
-    done
+        eval "$cmd" > "$log_file" 2>&1 &
+        local pid=$!
 
-    wait "$pid"
-    local exit_code=$?
-    printf "\r\033[K"
-    return $exit_code
+        local spin='-\|/'
+        local i=0
+        while kill -0 "$pid" 2> /dev/null; do
+            i=$(((i + 1) % 4))
+            printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
+            sleep 0.2
+        done
+
+        local exit_code=0
+        wait "$pid" || exit_code=$?
+
+        printf "\r\033[K"
+        if [ "$exit_code" -ne 0 ]; then
+            cat "$log_file"
+        fi
+        exit "$exit_code"
+    )
 }
 
 # Create/recreate a symlink at link_path pointing to target


### PR DESCRIPTION
💡 What: Hide cursor and buffer logs during CLI spinner.\n🎯 Why: Prevents terminal clutter and cursor jumping, creating a much cleaner experience.\n📸 Before/After: Cursor used to jump around; now it is hidden and restored.\n♿ Accessibility: Reduces motion/flashing on screen for users sensitive to erratic terminal updates.

---
*PR created automatically by Jules for task [5657112188156290555](https://jules.google.com/task/5657112188156290555) started by @RB-chrismandich*