### PR TITLE
🎨 Palette: Add cursor hiding and output redirection to CLI spinner

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,3 +11,7 @@ repeated script executions.
 **Action:** Instantiate these UI components with `transient=True` to
 automatically clear them upon completion, keeping the user's terminal history
 clean.
+
+## 2026-06-10 - CLI Spinner Terminal UX
+**Learning:** In bash scripts, hiding the cursor for a cleaner spinner requires careful lifecycle management. Relying solely on an `EXIT` trap is insufficient, as `SIGINT` (Ctrl+C) bypasses it, leaving the user with a broken (invisible) cursor. Output buffering is also crucial to prevent standard output from clobbering the spinner line.
+**Action:** Always buffer output to a temp file, print it only on error, and trap `INT`, `TERM`, and `EXIT` to ensure `tput cnorm` restores the terminal cursor regardless of how the script terminates.

--- a/bootstrap/lib/common.sh
+++ b/bootstrap/lib/common.sh
@@ -58,23 +58,33 @@ command_exists() {
 run_with_spinner() {
     local cmd="$1"
     local msg="${2:-Working}"
-    local pid
-    local spin='-\|/'
-    local i=0
 
-    eval "$cmd" &
-    pid=$!
+    (
+        local log_file
+        log_file=$(mktemp)
+        trap 'tput cnorm 2>/dev/null || true; rm -f "$log_file"' INT TERM EXIT
+        tput civis 2>/dev/null || true
 
-    while kill -0 "$pid" 2> /dev/null; do
-        i=$(((i + 1) % 4))
-        printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
-        sleep 0.2
-    done
+        eval "$cmd" > "$log_file" 2>&1 &
+        local pid=$!
+        local spin='-\|/'
+        local i=0
 
-    wait "$pid"
-    local exit_code=$?
-    printf "\r\033[K"
-    return $exit_code
+        while kill -0 "$pid" 2> /dev/null; do
+            i=$(((i + 1) % 4))
+            printf "\r${CYAN}${spin:$i:1}${NC} %s..." "$msg"
+            sleep 0.2
+        done
+
+        local exit_code=0
+        wait "$pid" || exit_code=$?
+
+        printf "\r\033[K"
+        if [ "$exit_code" -ne 0 ]; then
+            cat "$log_file"
+        fi
+        exit "$exit_code"
+    )
 }
 
 # Create/recreate a symlink at link_path pointing to target


### PR DESCRIPTION
💡 What: Updated the `run_with_spinner` bash utility to gracefully hide the cursor while spinning and suppress normal output. Output is now buffered to a temporary file and only shown if the command fails. Additionally, we make sure that the traps clean up on SIGINT and SIGTERM.
🎯 Why: Reduces terminal scrollback clutter and creates a cleaner, less jittery visual experience during long-running background tasks. Traps avoid leaving the user's terminal hidden after Ctrl-C.
📸 Before/After: Before, cursor would blink over the spinner and output was interspersed. After, the cursor is hidden and the spinner runs cleanly.
♿ Accessibility: Improves visual clarity by removing terminal cursor jitter and output noise, allowing better focus on the status message.

---
*PR created automatically by Jules for task [8839241688409666259](https://jules.google.com/task/8839241688409666259) started by @RB-chrismandich*