### PR TITLE
docs: unified command tables, true counts, changelog, spec-systems map (specs/003 US2)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -96,3 +96,4 @@ python3 -c "import yaml; yaml.safe_load(open('configs/claude/config/command_conf
 | Gemini guide | `configs/gemini/GEMINI.md` |
 | Bootstrap | `bootstrap.sh` + `bootstrap/lib/` |
 | Tests | `tests/bats/`, `tests/python/` |
+| Spec/plan systems map | `docs/SPEC-SYSTEMS.md` (speckit vs superpowers vs .plans vs .Jules) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > Repository context and guidance for AI coding agents (Cursor, Claude Code, Gemini, Codex, etc.)
 
-**Last Updated**: 2026-02-11
+**Last Updated**: 2026-06-10
 **Audience**: AI assistants (Cursor Agent, Claude Code, Gemini CLI, Codex CLI), contributors
 **Purpose**: Provide AI agents with repository structure, deployment process, and testing guidelines
 
@@ -204,39 +204,50 @@ Required CLI tools (install those you want to use):
 
 ## Available Skills
 
-All agents share the same skill library from `.skillshare/skills/` (28 skills;
+All agents share the same skill library from `.skillshare/skills/` (69 skills;
 exposed via the `configs/claude/skills/` symlink).
 Skills are invoked as slash commands (e.g., `/refactor-python src/`).
 
 ### Skill Reference
 
-| Skill | Description | Parallel Agents |
-|-------|-------------|-----------------|
-| `/a11y-audit` | WCAG 2.2 AA accessibility audit | NO |
-| `/antipattern-detect` | Detect codebase antipatterns and suggest fixes | NO |
-| `/checkpoint` | Save context checkpoint for session continuity | NO |
-| `/ci-setup` | Configure CI/CD pipelines for target repository | NO |
-| `/code-quality` | Auto-triggered security and quality checks | AUTO |
-| `/dashboard` | Visualize agent efficiency metrics | NO |
-| `/docs-diagrams` | Generate Mermaid architecture diagrams | CONDITIONAL |
-| `/docs-improve` | Diataxis documentation framework analysis | CONDITIONAL |
+| Command | Description | Parallel Agents |
+|---------|-------------|-----------------|
+| `/project-commit` | Full commit pipeline: docs, pull, pre-commits, commit, push | CONDITIONAL (Phase 3) |
 | `/docs-readme` | Improve README documentation | NO |
-| `/health-check` | Verify CLI tools, auth, config, MCP, symlinks | NO |
-| `/issue-prioritize` | Score and rank open issues by impact | CONDITIONAL |
-| `/issue-triage` | Linear issue audit with duplicate detection | CONDITIONAL |
-| `/learning-loop` | Capture structured lessons learned | NO |
-| `/performance-check` | Core Web Vitals and bundle analysis | NO |
-| `/plan-manage` | Plan lifecycle with parallel agent orchestration | CONDITIONAL |
-| `/project-commit` | Full commit pipeline: docs, pull, pre-commits, commit, push | CONDITIONAL |
-| `/refactor-go` | Go codebase security and quality analysis | ALWAYS |
-| `/refactor-node` | Node.js/TypeScript security and quality analysis | ALWAYS |
+| `/docs-diagrams` | Generate Mermaid architecture diagrams | CONDITIONAL (5+ modules) |
+| `/docs-improve` | Diataxis documentation framework analysis | CONDITIONAL (>500 lines) |
+| `/docs-all` | Run docs-readme/docs-diagrams/docs-improve as sub-agents in one pass | CONDITIONAL |
 | `/refactor-python` | Python codebase security and quality analysis | ALWAYS |
 | `/refactor-shell` | Bash/Shell script security and quality analysis | ALWAYS |
-| `/refactor-terraform` | Terraform IaC security and modularity analysis | ALWAYS |
-| `/scaffold` | Initialize new project with quality gates and Manifest integration | NO |
-| `/sync-configs` | Detect cross-platform config drift | NO |
-| `/ux-review` | UX/accessibility/performance audit | NO |
+| `/refactor-node` | Node.js/TypeScript codebase security and quality analysis | ALWAYS |
+| `/refactor-go` | Go codebase security and quality analysis | ALWAYS |
+| `/refactor-terraform` | Terraform/OpenTofu IaC security, modularity, and quality analysis | ALWAYS |
+| `/issue-triage` | Linear issue audit: duplicates, staleness, priority validation | CONDITIONAL |
+| `/issue-prioritize` | Score and rank open issues by impact/urgency/readiness/risk | CONDITIONAL |
+| `/plan-manage` | Plan lifecycle with parallel agent orchestration | CONDITIONAL |
+| `/browser-test` | AI-powered E2E browser testing via browser-use YAML test prompts | CONDITIONAL |
+| `/checkpoint` | Create compact checkpoint summary when context is high | NO |
+| `/health-check` | Verify CLI tools, auth, config syntax, MCP, symlinks | NO |
+| `/sync-configs` | Detect cross-platform config drift and broken symlinks | NO |
+| `/version-pin` | Enforce specific, hashed version pins in dependency files (auto-fix on demand; warn-only save hook) | ALWAYS (Tier 1) |
+| `/pr-review` | Review all open PRs and recommend a disposition per PR (analysis-only) | NO |
+| `/branch-clean` | Prune merged/gone/stale branches safely (dry-run by default, local-only) | CONDITIONAL (--apply) |
+| `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default); requires SkillClaw enabled | NO |
+| `/pass-cli` | Retrieve credentials from Proton Pass vaults via `pass-cli` agent CLI | NO |
+| `/spec-review` | Independent Antigravity (agy) cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; works with speckit and superpowers layouts; silent-mode findings land in `.spec-review/feedback.md` | NO |
+| `/a11y-audit` | WCAG 2.2 AA accessibility audit | NO |
+| `/antipattern-detect` | Detect recurring antipatterns from lint, test, and review feedback | NO |
+| `/ci-setup` | Configure CI/CD pipelines for a target repository (GitHub Actions or GitLab CI) | NO |
+| `/code-quality` | Auto-triggered security and quality checks | AUTO (always when triggered) |
+| `/dashboard` | Visualize agent efficiency metrics | NO |
+| `/learning-loop` | Capture structured lessons learned | NO |
+| `/performance-check` | Frontend performance audit: bundle size, Core Web Vitals, caching | NO |
+| `/scaffold` | Initialize new projects with quality gates and Manifest integration | NO |
+| `/ux-review` | UX audit: accessibility, responsive design, performance budgets | NO |
 | `/verify` | Run linters, tests, and security scans in parallel | CONDITIONAL |
+
+**CLI tool** (installed to `~/.local/bin/`): `sync-skills` — sync `.skillshare/skills/`
+to all home targets (daily skill dev workflow).
 
 ### Cursor Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > Version history for the Manifest parallel agent orchestration framework
 
-**Last Updated**: 2026-05-31
+**Last Updated**: 2026-06-10
 
 All notable changes are documented here in reverse chronological order.
 
@@ -10,12 +10,41 @@ All notable changes are documented here in reverse chronological order.
 
 ## [Unreleased]
 
+### Changed
+- **Skill library consolidated 81 → 69** (specs/003) — six duplicate clusters
+  resolved (five merged, one cross-anchored): `address-pr-comments` (absorbs 2), `session-memory-compress`
+  (absorbs 1), `live-data-validation` (absorbs 3, mode subsections), new
+  `verify-premise` (absorbs 5), new `retire-component-cleanup` (absorbs 3);
+  `reset-reapply-clean-pr`/`clean-pr-from-stale-base` gain mutual decision
+  anchors. Evolve's `{{LIBRARY}}` prompt now carries `name — description`
+  lines so duplicates are suppressed at the source.
+- **Prune-on-deploy** — `deploy_home_skills` prunes previously-deployed skills
+  removed from the source of truth via a `.deployed-skills` manifest; skills
+  added by other tools are never touched (does NOT reintroduce the PR #255
+  blind `--delete` data-loss bug).
+- **Docs accuracy** — command tables unified to canonical `docs/COMMANDS.md`
+  (33 rows mirrored byte-identically in CLAUDE.md, AGENTS.md,
+  configs/claude/CLAUDE.md); skill counts corrected to 69.
+
+## [2026-06]
+
 ### Added
-- **SkillClaw promote audit log + live status/ETA** — new `skillclaw_audit.py`
+- **SkillClaw promote audit log + live status/ETA** (PR #284) — new `skillclaw_audit.py`
   writes an append-only `~/.skillclaw/promote.log` (JSONL history, self-trimmed to
   ~50 runs) and a live `status.json` snapshot. `skillclaw_promote.sh --status`
   reports where a run is and a rough ETA; the evolve stage prints per-chunk
   progress. Fail-open: audit I/O never blocks a promote run.
+- **45 SkillClaw-evolved skills** (PR #285) — promoted via the proxy-free
+  evolve pipeline, one commit per skill.
+- **spec-review reviewer: Gemini → agy (Antigravity)** (PR #282) — seam renamed
+  to `SPEC_REVIEW_CLI`, default reviewer `agy`.
+
+### Fixed
+- **label_sync.sh Bash 3.2 `set -u` crash** — empty `team_args[@]` expansion
+  guarded; sync no longer aborts after the first label.
+- **SkillClaw promote review fixes** (PRs #284/#285) — truthful `run_start`
+  config, dropped-candidate reasons, evolve `stage_start` on empty sessions,
+  ingest count in `stage_end`, `trim()` clamp.
 
 ## [2026-05]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > Repository context and guidance for Claude Code when working with this codebase
 
-**Last Updated**: 2026-02-11
+**Last Updated**: 2026-06-10
 **Audience**: AI assistants (Claude Code), contributors
 **Purpose**: Provide Claude Code with repository structure, deployment process, and testing guidelines
 
@@ -234,23 +234,41 @@ The following slash commands are available in Claude Code:
 | Command | Description | Parallel Agents |
 |---------|-------------|-----------------|
 | `/project-commit` | Full commit pipeline: docs, pull, pre-commits, commit, push | CONDITIONAL (Phase 3) |
-| `/refactor-python` | Python codebase security and quality analysis | ALWAYS |
-| `/refactor-shell` | Bash/Shell script security and quality analysis | ALWAYS |
+| `/docs-readme` | Improve README documentation | NO |
 | `/docs-diagrams` | Generate Mermaid architecture diagrams | CONDITIONAL (5+ modules) |
 | `/docs-improve` | Diataxis documentation framework analysis | CONDITIONAL (>500 lines) |
-| `/docs-readme` | Improve README documentation | NO |
-| `/issue-prioritize` | Fetch and rank open issues by impact/urgency/readiness/risk (GitHub/GitLab/Linear) | CONDITIONAL (top candidates) |
-| `/issue-triage` | Linear issue audit: duplicates, staleness, priority validation | CONDITIONAL (scenario-based) |
-| `/plan-manage` | Plan lifecycle with parallel agent orchestration for create/review | CONDITIONAL |
+| `/docs-all` | Run docs-readme/docs-diagrams/docs-improve as sub-agents in one pass | CONDITIONAL |
+| `/refactor-python` | Python codebase security and quality analysis | ALWAYS |
+| `/refactor-shell` | Bash/Shell script security and quality analysis | ALWAYS |
+| `/refactor-node` | Node.js/TypeScript codebase security and quality analysis | ALWAYS |
+| `/refactor-go` | Go codebase security and quality analysis | ALWAYS |
+| `/refactor-terraform` | Terraform/OpenTofu IaC security, modularity, and quality analysis | ALWAYS |
+| `/issue-triage` | Linear issue audit: duplicates, staleness, priority validation | CONDITIONAL |
+| `/issue-prioritize` | Score and rank open issues by impact/urgency/readiness/risk | CONDITIONAL |
+| `/plan-manage` | Plan lifecycle with parallel agent orchestration | CONDITIONAL |
 | `/browser-test` | AI-powered E2E browser testing via browser-use YAML test prompts | CONDITIONAL |
-| `/version-pin` | Enforce specific, hashed version pins in dependency files (auto-fix on demand, warn-only hook) | ALWAYS (Tier 1) |
-| `/docs-all` | Run docs-readme/docs-diagrams/docs-improve as sub-agents in one pass | NO |
+| `/checkpoint` | Create compact checkpoint summary when context is high | NO |
+| `/health-check` | Verify CLI tools, auth, config syntax, MCP, symlinks | NO |
+| `/sync-configs` | Detect cross-platform config drift and broken symlinks | NO |
+| `/version-pin` | Enforce specific, hashed version pins in dependency files (auto-fix on demand; warn-only save hook) | ALWAYS (Tier 1) |
 | `/pr-review` | Review all open PRs and recommend a disposition per PR (analysis-only) | NO |
 | `/branch-clean` | Prune merged/gone/stale branches safely (dry-run by default, local-only) | CONDITIONAL (--apply) |
-| `sync-skills` | Sync .skillshare/skills/ to all home targets (daily skill dev workflow) | NO |
-| `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run default) | NO |
+| `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default); requires SkillClaw enabled | NO |
 | `/pass-cli` | Retrieve credentials from Proton Pass vaults via `pass-cli` agent CLI | NO |
-| `/spec-review` | Independent Antigravity (agy) cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; engine: `~/.claude/scripts/spec_review.sh` (`--spec/--plan/--tasks/--silent/--format`) | NO |
+| `/spec-review` | Independent Antigravity (agy) cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; works with speckit and superpowers layouts; silent-mode findings land in `.spec-review/feedback.md` | NO |
+| `/a11y-audit` | WCAG 2.2 AA accessibility audit | NO |
+| `/antipattern-detect` | Detect recurring antipatterns from lint, test, and review feedback | NO |
+| `/ci-setup` | Configure CI/CD pipelines for a target repository (GitHub Actions or GitLab CI) | NO |
+| `/code-quality` | Auto-triggered security and quality checks | AUTO (always when triggered) |
+| `/dashboard` | Visualize agent efficiency metrics | NO |
+| `/learning-loop` | Capture structured lessons learned | NO |
+| `/performance-check` | Frontend performance audit: bundle size, Core Web Vitals, caching | NO |
+| `/scaffold` | Initialize new projects with quality gates and Manifest integration | NO |
+| `/ux-review` | UX audit: accessibility, responsive design, performance budgets | NO |
+| `/verify` | Run linters, tests, and security scans in parallel | CONDITIONAL |
+
+**CLI tool** (installed to `~/.local/bin/`): `sync-skills` — sync `.skillshare/skills/`
+to all home targets (daily skill dev workflow).
 
 ## Testing Changes
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Parallel LLM agent orchestration framework for Claude Code, Cursor IDE, Gemini CLI, Codex CLI, and Antigravity IDE
 
-**Last Updated**: 2026-06-08
+**Last Updated**: 2026-06-10
 
 Manifest is a configuration repository that deploys a sophisticated parallel agent
 orchestration system to `~/.claude/`, `~/.cursor/`, `~/.gemini/`, `~/.codex/`, and `~/.antigravity/`, enabling Claude Code,
@@ -140,6 +140,7 @@ Mermaid flowcharts showing bootstrap, execution, validation, and consensus flows
 | [Configuration](docs/CONFIGURATION.md) | All configuration options, YAML reference, environment variables | Operators | 15 min |
 | [Architecture Diagrams](docs/ARCHITECTURE_DIAGRAMS.md) | Visual system documentation with 15 Mermaid diagrams | Developers | 20 min |
 | [SkillClaw](docs/SKILLCLAW.md) | PR-gated skill evolution via passive transcript ingestion | Operators | 8 min |
+| [Spec Systems](docs/SPEC-SYSTEMS.md) | Map of the four spec/plan systems and when to use each | Contributors | 3 min |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Common problems, error messages, solutions | All users | 10 min |
 | [AGENTS.md](AGENTS.md) | AI agent instructions (Cursor, Claude, Gemini, Codex) | AI assistants | 8 min |
 | [CLAUDE.md](CLAUDE.md) | Claude Code-specific project context | AI assistants | 8 min |
@@ -223,7 +224,7 @@ Manifest/
 │       ├── python/                  # Python project starter
 │       └── terraform/               # Terraform project starter
 ├── .skillshare/                     # Skill source of truth (managed by skillshare)
-│   └── skills/                      # 29 skills deployed to ~/.claude/skills/ by bootstrap
+│   └── skills/                      # 69 skills deployed to ~/.claude/skills/ by bootstrap
 ├── tests/                           # Test suites
 │   ├── python/                      # pytest tests for parallel_agent and agents/
 │   └── bats/                        # Bats shell tests for bootstrap and scripts

--- a/configs/claude/CLAUDE.md
+++ b/configs/claude/CLAUDE.md
@@ -140,23 +140,38 @@ These integrate with the parallel agent orchestration framework.
 | `/docs-readme` | Improve README documentation | NO |
 | `/docs-diagrams` | Generate Mermaid architecture diagrams | CONDITIONAL (5+ modules) |
 | `/docs-improve` | Diataxis documentation framework analysis | CONDITIONAL (>500 lines) |
+| `/docs-all` | Run docs-readme/docs-diagrams/docs-improve as sub-agents in one pass | CONDITIONAL |
 | `/refactor-python` | Python codebase security and quality analysis | ALWAYS |
 | `/refactor-shell` | Bash/Shell script security and quality analysis | ALWAYS |
+| `/refactor-node` | Node.js/TypeScript codebase security and quality analysis | ALWAYS |
+| `/refactor-go` | Go codebase security and quality analysis | ALWAYS |
+| `/refactor-terraform` | Terraform/OpenTofu IaC security, modularity, and quality analysis | ALWAYS |
 | `/issue-triage` | Linear issue audit: duplicates, staleness, priority validation | CONDITIONAL |
 | `/issue-prioritize` | Score and rank open issues by impact/urgency/readiness/risk | CONDITIONAL |
-| `/plan-manage` | Plan lifecycle with parallel agent orchestration for create/review | CONDITIONAL |
+| `/plan-manage` | Plan lifecycle with parallel agent orchestration | CONDITIONAL |
 | `/browser-test` | AI-powered E2E browser testing via browser-use YAML test prompts | CONDITIONAL |
-| `/checkpoint` | Create compact checkpoint summary when context usage is high | NO |
+| `/checkpoint` | Create compact checkpoint summary when context is high | NO |
 | `/health-check` | Verify CLI tools, auth, config syntax, MCP, symlinks | NO |
 | `/sync-configs` | Detect cross-platform config drift and broken symlinks | NO |
-| `/sync-skills` | Sync .skillshare/skills/ to all home targets (daily skill dev workflow) | NO |
-| `/version-pin` | Enforce specific, hashed version pins in dependency files | ALWAYS (Tier 1) |
-| `/docs-all` | Run docs-readme/docs-diagrams/docs-improve as sub-agents in one pass | NO |
-| `/pr-review` | Review all open PRs, recommend disposition per PR (analysis-only) | NO |
-| `/branch-clean` | Prune merged/gone/stale branches safely (dry-run, local-only) | CONDITIONAL |
-| `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run default) | NO |
-| `/pass-cli` | Retrieve credentials from Proton Pass (auth is the user's step; PAT never stored) | NO |
-| `/spec-review` | Independent Antigravity (agy) cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; engine: `~/.claude/scripts/spec_review.sh` (`--spec/--plan/--tasks/--silent/--format`) | NO |
+| `/version-pin` | Enforce specific, hashed version pins in dependency files (auto-fix on demand; warn-only save hook) | ALWAYS (Tier 1) |
+| `/pr-review` | Review all open PRs and recommend a disposition per PR (analysis-only) | NO |
+| `/branch-clean` | Prune merged/gone/stale branches safely (dry-run by default, local-only) | CONDITIONAL (--apply) |
+| `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default); requires SkillClaw enabled | NO |
+| `/pass-cli` | Retrieve credentials from Proton Pass vaults via `pass-cli` agent CLI | NO |
+| `/spec-review` | Independent Antigravity (agy) cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; works with speckit and superpowers layouts; silent-mode findings land in `.spec-review/feedback.md` | NO |
+| `/a11y-audit` | WCAG 2.2 AA accessibility audit | NO |
+| `/antipattern-detect` | Detect recurring antipatterns from lint, test, and review feedback | NO |
+| `/ci-setup` | Configure CI/CD pipelines for a target repository (GitHub Actions or GitLab CI) | NO |
+| `/code-quality` | Auto-triggered security and quality checks | AUTO (always when triggered) |
+| `/dashboard` | Visualize agent efficiency metrics | NO |
+| `/learning-loop` | Capture structured lessons learned | NO |
+| `/performance-check` | Frontend performance audit: bundle size, Core Web Vitals, caching | NO |
+| `/scaffold` | Initialize new projects with quality gates and Manifest integration | NO |
+| `/ux-review` | UX audit: accessibility, responsive design, performance budgets | NO |
+| `/verify` | Run linters, tests, and security scans in parallel | CONDITIONAL |
+
+**CLI tool** (installed to `~/.local/bin/`): `sync-skills` — sync `.skillshare/skills/`
+to all home targets (daily skill dev workflow).
 
 ### Command Usage
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -2,7 +2,7 @@
 
 > Building custom commands for Claude Code with Manifest
 
-**Last Updated**: 2026-06-08
+**Last Updated**: 2026-06-10
 **Audience**: Command developers, advanced users
 **Prerequisites**: Manifest installed, basic understanding of Markdown and Bash
 
@@ -24,16 +24,20 @@
 
 ## Built-in Commands
 
-Manifest ships with 19 slash commands and 1 CLI tool (34 skills total, 1 auto-triggered).
+Manifest ships with 33 slash commands and 1 CLI tool (69 skills total, 1 auto-triggered).
 
 | Command | Description | Parallel Agents |
 |---------|-------------|-----------------|
-| `/project-commit` | Full commit pipeline: docs, pull, pre-commits, commit, push | CONDITIONAL |
+| `/project-commit` | Full commit pipeline: docs, pull, pre-commits, commit, push | CONDITIONAL (Phase 3) |
 | `/docs-readme` | Improve README documentation | NO |
-| `/docs-diagrams` | Generate Mermaid architecture diagrams | CONDITIONAL |
-| `/docs-improve` | Diataxis documentation framework analysis | CONDITIONAL |
+| `/docs-diagrams` | Generate Mermaid architecture diagrams | CONDITIONAL (5+ modules) |
+| `/docs-improve` | Diataxis documentation framework analysis | CONDITIONAL (>500 lines) |
+| `/docs-all` | Run docs-readme/docs-diagrams/docs-improve as sub-agents in one pass | CONDITIONAL |
 | `/refactor-python` | Python codebase security and quality analysis | ALWAYS |
 | `/refactor-shell` | Bash/Shell script security and quality analysis | ALWAYS |
+| `/refactor-node` | Node.js/TypeScript codebase security and quality analysis | ALWAYS |
+| `/refactor-go` | Go codebase security and quality analysis | ALWAYS |
+| `/refactor-terraform` | Terraform/OpenTofu IaC security, modularity, and quality analysis | ALWAYS |
 | `/issue-triage` | Linear issue audit: duplicates, staleness, priority validation | CONDITIONAL |
 | `/issue-prioritize` | Score and rank open issues by impact/urgency/readiness/risk | CONDITIONAL |
 | `/plan-manage` | Plan lifecycle with parallel agent orchestration | CONDITIONAL |
@@ -42,12 +46,21 @@ Manifest ships with 19 slash commands and 1 CLI tool (34 skills total, 1 auto-tr
 | `/health-check` | Verify CLI tools, auth, config syntax, MCP, symlinks | NO |
 | `/sync-configs` | Detect cross-platform config drift and broken symlinks | NO |
 | `/version-pin` | Enforce specific, hashed version pins in dependency files (auto-fix on demand; warn-only save hook) | ALWAYS (Tier 1) |
-| `/docs-all` | Run docs-readme/docs-diagrams/docs-improve as sub-agents in one pass | NO |
 | `/pr-review` | Review all open PRs and recommend a disposition per PR (analysis-only) | NO |
 | `/branch-clean` | Prune merged/gone/stale branches safely (dry-run by default, local-only) | CONDITIONAL (--apply) |
-| `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default); requires SkillClaw enabled | NEVER |
-| `/pass-cli` | Retrieve credentials from Proton Pass vaults via `pass-cli` agent CLI | NEVER |
+| `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default); requires SkillClaw enabled | NO |
+| `/pass-cli` | Retrieve credentials from Proton Pass vaults via `pass-cli` agent CLI | NO |
 | `/spec-review` | Independent Antigravity (agy) cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; works with speckit and superpowers layouts; silent-mode findings land in `.spec-review/feedback.md` | NO |
+| `/a11y-audit` | WCAG 2.2 AA accessibility audit | NO |
+| `/antipattern-detect` | Detect recurring antipatterns from lint, test, and review feedback | NO |
+| `/ci-setup` | Configure CI/CD pipelines for a target repository (GitHub Actions or GitLab CI) | NO |
+| `/code-quality` | Auto-triggered security and quality checks | AUTO (always when triggered) |
+| `/dashboard` | Visualize agent efficiency metrics | NO |
+| `/learning-loop` | Capture structured lessons learned | NO |
+| `/performance-check` | Frontend performance audit: bundle size, Core Web Vitals, caching | NO |
+| `/scaffold` | Initialize new projects with quality gates and Manifest integration | NO |
+| `/ux-review` | UX audit: accessibility, responsive design, performance budgets | NO |
+| `/verify` | Run linters, tests, and security scans in parallel | CONDITIONAL |
 
 **CLI tool** (installed to `~/.local/bin/`):
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@
 |------|-------------|--------------|--------|
 | [ARCHITECTURE_DIAGRAMS.md](ARCHITECTURE_DIAGRAMS.md) | Visual system documentation | 2026-06-08 | ✅ |
 | [SKILLCLAW.md](SKILLCLAW.md) | SkillClaw session-capture and skill-evolution guide | 2026-06-08 | ✅ |
+| [SPEC-SYSTEMS.md](SPEC-SYSTEMS.md) | Map of the four spec/plan systems and when to use each | 2026-06-10 | ✅ |
 
 ### Internal Documentation
 

--- a/docs/SHELL_ANALYSIS_REPORT.md
+++ b/docs/SHELL_ANALYSIS_REPORT.md
@@ -1,5 +1,10 @@
 # Shell Script Analysis Report
 
+> **[ARCHIVED 2026-06-10]** This report analyzes `parallel_agent.sh`, which was
+> retired in 2026-05 (PR #257) in favor of `parallel_agent.py`. Kept for
+> historical reference only — see `configs/claude/scripts/` for current tooling
+> and CI (`shellcheck` at warning severity) for live analysis.
+
 > Automated analysis of Bash scripts and YAML configuration files
 
 **Date:** 2026-01-27

--- a/docs/SHELL_ANALYSIS_REPORT.md
+++ b/docs/SHELL_ANALYSIS_REPORT.md
@@ -4,7 +4,7 @@
 > retired in 2026-05 (PR #257) in favor of `parallel_agent.py`. Kept for
 > historical reference only — see `configs/claude/scripts/` for current tooling
 > and CI (`shellcheck` at warning severity) for live analysis.
-
+>
 > Automated analysis of Bash scripts and YAML configuration files
 
 **Date:** 2026-01-27

--- a/docs/SPEC-SYSTEMS.md
+++ b/docs/SPEC-SYSTEMS.md
@@ -1,0 +1,37 @@
+# Spec & Plan Systems Map
+
+> Which planning system to use, when — and what each directory is for
+
+**Last Updated**: 2026-06-10
+**Audience**: Contributors, AI agents
+
+This repo accumulated four complementary planning/specification systems. They
+are not competing — each owns a distinct lifecycle stage and audience.
+
+| System | Location | Owns | Use when |
+|--------|----------|------|----------|
+| **Speckit** | `specs/` (artifacts) + `.specify/` (templates, scripts, constitution, extensions) | Full feature lifecycle: spec → clarify → plan → tasks → implement, with quality gates and the project constitution | Building a new feature of any real size. Entry point: `/speckit-specify` |
+| **Superpowers design docs** | `docs/superpowers/specs/` (designs) + `docs/superpowers/plans/` (implementation plans) | Dated design-decision history from the superpowers brainstorm→plan workflow | Recording a reviewed design for a focused change (e.g. a subsystem swap); historical reference |
+| **Plan-manage lifecycle** | `configs/claude/.plans/` (deployed to `~/.claude/.plans/`) | Lightweight operational plans on target machines: CREATE → ACTIVE → COMPLETED (`.archive/`) / ABANDONED (`.abandoned/`) | Day-to-day orchestrated work tracking via `/plan-manage`; not tied to this repo's features |
+| **Lesson journal** | `.Jules/` (`bolt.md`, `forge.md`, `palette.md`, `sentinel.md`) | Dated lessons learned (performance, security, UI, tooling) captured by agents during sessions | Append-only knowledge capture; consult when a task touches a previously-burned area |
+
+## Rules of thumb
+
+- **New feature?** Speckit. The constitution (`.specify/memory/constitution.md`)
+  is non-negotiable and its gates (parallel-agent cross-verification, quality
+  tiers) apply to the resulting PRs.
+- **Design review for a focused swap/refactor?** A superpowers design doc is
+  enough; link it from the implementing PR.
+- **Tracking multi-step operational work on a deployed machine?** `/plan-manage`
+  with `configs/claude/.plans/`.
+- **Learned something the hard way?** Append to the matching `.Jules/` file
+  (or via the `learning-loop` skill into `knowledge_base.yml`).
+- A speckit feature's spec directory is permanent history; when delivered, its
+  status line is marked **Delivered** (specs/ has no archive subdirectory —
+  that convention belongs to `configs/claude/.plans/`).
+
+## Related
+
+- [docs/COMMANDS.md](COMMANDS.md) — canonical slash-command table
+- [configs/claude/.plans/README.md](../configs/claude/.plans/README.md) — plan lifecycle reference
+- [.specify/memory/constitution.md](../.specify/memory/constitution.md) — project constitution

--- a/specs/003-skill-library-consolidation/tasks.md
+++ b/specs/003-skill-library-consolidation/tasks.md
@@ -17,7 +17,7 @@
 
 **Purpose**: Confirm a green baseline so every story-PR diff is attributable.
 
-- [ ] T001 Verify baseline: run `bats tests/bats/ && python3 -m pytest tests/python/ -q && shellcheck configs/claude/scripts/*.sh bootstrap.sh bootstrap/lib/*.sh` from repo root; record pass in PR-1 description
+- [x] T001 Verify baseline: run `bats tests/bats/ && python3 -m pytest tests/python/ -q && shellcheck configs/claude/scripts/*.sh bootstrap.sh bootstrap/lib/*.sh` from repo root; record pass in PR-1 description
 
 ---
 
@@ -35,26 +35,26 @@
 
 ### Tests first (pin new behavior)
 
-- [ ] T002 [P] [US1] Add prune-on-deploy bats cases to tests/bats/deploy_skills.bats per contracts/prune-on-deploy.md: (a) deploy → remove skill from source → redeploy → gone from target, (b) file outside skills dir survives, (c) double-deploy is a no-op — expect FAIL until T003
-- [ ] T003 [US1] Add `--delete` to the `rsync -a` in `deploy_home_skills()` in bootstrap/lib/common.sh (R1); T002 now passes
-- [ ] T004 [P] [US1] Add library-prompt pytest cases to tests/python/test_skillclaw_evolve.py per contracts/library-prompt.md: name—description line present; broken-frontmatter → name-only (run succeeds); >200-char description truncated — expect FAIL until T005
-- [ ] T005 [US1] Implement description-aware library rendering in configs/claude/scripts/skillclaw_evolve.py (extend `_library_names` → `_library_entries`, flatten/truncate at 200 chars, fail-open per contract); T004 now passes
-- [ ] T006 [US1] Update library-section wording in configs/claude/prompts/skillclaw_evolve.md: "do NOT duplicate these skills — match by purpose, not just name; improvements go under the EXISTING name" (contracts/library-prompt.md rule 5)
+- [x] T002 [P] [US1] Add prune-on-deploy bats cases to tests/bats/deploy_skills.bats per contracts/prune-on-deploy.md: (a) deploy → remove skill from source → redeploy → gone from target, (b) file outside skills dir survives, (c) double-deploy is a no-op — expect FAIL until T003
+- [x] T003 [US1] Implement manifest-scoped pruning (`.deployed-skills`) in `deploy_home_skills()` in bootstrap/lib/common.sh (R1 as revised — blind `rsync --delete` would break the deliberate externally-managed-content guarantee); T002 now passes
+- [x] T004 [P] [US1] Add library-prompt pytest cases to tests/python/test_skillclaw_evolve.py per contracts/library-prompt.md: name—description line present; broken-frontmatter → name-only (run succeeds); >200-char description truncated — expect FAIL until T005
+- [x] T005 [US1] Implement description-aware library rendering in configs/claude/scripts/skillclaw_evolve.py (extend `_library_names` → `_library_entries`, flatten/truncate at 200 chars, fail-open per contract); T004 now passes
+- [x] T006 [US1] Update library-section wording in configs/claude/prompts/skillclaw_evolve.md: "do NOT duplicate these skills — match by purpose, not just name; improvements go under the EXISTING name" (contracts/library-prompt.md rule 5)
 
 ### Cluster merges (each [P] — disjoint file sets; follow contracts/merged-skill.md)
 
-- [ ] T007 [P] [US1] Merge PR-comments cluster: rewrite .skillshare/skills/address-pr-comments/SKILL.md to absorb address-pr-review-comments + address-review-comments (description covers inline comments, review bodies, issue-level discussion; `> Absorbed:` footer); `git rm -r` the two absorbed dirs
-- [ ] T008 [P] [US1] Merge session-memory cluster: fold any distinct content from session-memory-digest into .skillshare/skills/session-memory-compress/SKILL.md (both modes); `git rm -r` .skillshare/skills/session-memory-digest
-- [ ] T009 [P] [US1] Merge live-data cluster: rewrite .skillshare/skills/live-data-validation/SKILL.md with Smoke / Before-merge / After-green-tests subsections absorbing live-data-validation-before-merge, live-data-smoke-validation, real-data-validation-after-green-tests; `git rm -r` the three absorbed dirs
-- [ ] T010 [P] [US1] Create .skillshare/skills/verify-premise/SKILL.md with CLI-binary / API-schema / image-runtime subsections absorbing verify-cli-premise, verify-cli-premise-before-tooling, verify-tool-premise, verify-api-schema-before-trust, verify-image-runtime-contract; `git rm -r` the five absorbed dirs
-- [ ] T011 [P] [US1] Create .skillshare/skills/retire-component-cleanup/SKILL.md with daemon / tool-runtime / plugin-MCP subsections absorbing daemon-migration-verification, retire-migrated-tool-runtime, plugin-mcp-clean-removal; `git rm -r` the three absorbed dirs
-- [ ] T012 [P] [US1] Add mutual decision-anchor lines to .skillshare/skills/reset-reapply-clean-pr/SKILL.md and .skillshare/skills/clean-pr-from-stale-base/SKILL.md ("If <other root cause>, use <other> instead")
+- [x] T007 [P] [US1] Merge PR-comments cluster: rewrite .skillshare/skills/address-pr-comments/SKILL.md to absorb address-pr-review-comments + address-review-comments (description covers inline comments, review bodies, issue-level discussion; `> Absorbed:` footer); `git rm -r` the two absorbed dirs
+- [x] T008 [P] [US1] Merge session-memory cluster: fold any distinct content from session-memory-digest into .skillshare/skills/session-memory-compress/SKILL.md (both modes); `git rm -r` .skillshare/skills/session-memory-digest
+- [x] T009 [P] [US1] Merge live-data cluster: rewrite .skillshare/skills/live-data-validation/SKILL.md with Smoke / Before-merge / After-green-tests subsections absorbing live-data-validation-before-merge, live-data-smoke-validation, real-data-validation-after-green-tests; `git rm -r` the three absorbed dirs
+- [x] T010 [P] [US1] Create .skillshare/skills/verify-premise/SKILL.md with CLI-binary / API-schema / image-runtime subsections absorbing verify-cli-premise, verify-cli-premise-before-tooling, verify-tool-premise, verify-api-schema-before-trust, verify-image-runtime-contract; `git rm -r` the five absorbed dirs
+- [x] T011 [P] [US1] Create .skillshare/skills/retire-component-cleanup/SKILL.md with daemon / tool-runtime / plugin-MCP subsections absorbing daemon-migration-verification, retire-migrated-tool-runtime, plugin-mcp-clean-removal; `git rm -r` the three absorbed dirs
+- [x] T012 [P] [US1] Add mutual decision-anchor lines to .skillshare/skills/reset-reapply-clean-pr/SKILL.md and .skillshare/skills/clean-pr-from-stale-base/SKILL.md ("If <other root cause>, use <other> instead")
 
 ### Story verification & PR
 
-- [ ] T013 [US1] Repo-wide reference sweep for all 12 deleted names (quickstart.md §US1 loop); fix any hits outside specs/003-* and CHANGELOG; confirm skill count = 69
-- [ ] T014 [US1] Run quickstart.md §US1 + full gate (pre-commit, bats, pytest); regenerate cursor rules (`configs/claude/scripts/generate_cursor_rules.sh`) since skill set changed; commit
-- [ ] T015 [US1] Parallel-agent cross-verification of the consolidation diff (Constitution II — >200 lines of skill content): `~/.claude/scripts/parallel_agent.py --json --timeout 600 --review` on the changed SKILL.md files; address findings; open PR-1 with content-preservation table (per-cluster: variant → where its content landed) and the R1 directory-scope pruning interpretation for reviewer sign-off
+- [x] T013 [US1] Repo-wide reference sweep for all 14 deleted skill dirs (net −12 after 2 new survivors) (quickstart.md §US1 loop); fix any hits outside specs/003-* and CHANGELOG; confirm skill count = 69
+- [x] T014 [US1] Run quickstart.md §US1 + full gate (pre-commit, bats, pytest); regenerate cursor rules (`configs/claude/scripts/generate_cursor_rules.sh`) since skill set changed; commit
+- [x] T015 [US1] Parallel-agent cross-verification of the consolidation diff (Constitution II — >200 lines of skill content): `~/.claude/scripts/parallel_agent.py --json --timeout 600 --review` on the changed SKILL.md files; address findings; open PR-1 with content-preservation table (per-cluster: variant → where its content landed) and the R1 directory-scope pruning interpretation for reviewer sign-off
 
 **Checkpoint**: PR-1 merged → library consolidated, pruning live, evolve dedup-hardened. MVP complete.
 
@@ -66,11 +66,11 @@
 
 **Independent test** (quickstart.md §US2): no "28 skills" hits; tables consistent; Unreleased clean; SPEC-SYSTEMS.md exists; cursor-rules drift check green.
 
-- [ ] T016 [US2] Update docs/COMMANDS.md as canonical: verify every row against `.skillshare/skills/*/SKILL.md` frontmatter and configs/claude/config/command_config.yml (post-US1 skill set), fix wording/flags (R6 note: /version-pin wording per docs/COMMANDS.md style)
-- [ ] T017 [US2] Unify the three mirror tables to match T016 exactly: root CLAUDE.md, AGENTS.md, configs/claude/CLAUDE.md; refresh their "Last Updated" stamps to change date; fix skill counts in AGENTS.md:207 and README.md (use `find .skillshare/skills -name SKILL.md | wc -l` result)
-- [ ] T018 [P] [US2] CHANGELOG.md: move shipped Unreleased items (promote audit log etc.) into a dated `[2026-06]` section; add entries for this feature's PRs as they land
-- [ ] T019 [P] [US2] Prepend archive banner to docs/SHELL_ANALYSIS_REPORT.md: `> [ARCHIVED 2026-06-10] Analyzes the retired parallel_agent.sh; superseded — see configs/claude/scripts/ for current tooling`
-- [ ] T020 [P] [US2] Create docs/SPEC-SYSTEMS.md per research R9 (roles of specs/+.specify/, docs/superpowers/, configs/claude/.plans/, .Jules/); link it from README.md, docs/README.md, and .claude/CLAUDE.md
+- [x] T016 [US2] Update docs/COMMANDS.md as canonical: verify every row against `.skillshare/skills/*/SKILL.md` frontmatter and configs/claude/config/command_config.yml (post-US1 skill set), fix wording/flags (R6 note: /version-pin wording per docs/COMMANDS.md style)
+- [x] T017 [US2] Unify the three mirror tables to match T016 exactly: root CLAUDE.md, AGENTS.md, configs/claude/CLAUDE.md; refresh their "Last Updated" stamps to change date; fix skill counts in AGENTS.md:207 and README.md (use `find .skillshare/skills -name SKILL.md | wc -l` result)
+- [x] T018 [P] [US2] CHANGELOG.md: move shipped Unreleased items (promote audit log etc.) into a dated `[2026-06]` section; add entries for this feature's PRs as they land
+- [x] T019 [P] [US2] Prepend archive banner to docs/SHELL_ANALYSIS_REPORT.md: `> [ARCHIVED 2026-06-10] Analyzes the retired parallel_agent.sh; superseded — see configs/claude/scripts/ for current tooling`
+- [x] T020 [P] [US2] Create docs/SPEC-SYSTEMS.md per research R9 (roles of specs/+.specify/, docs/superpowers/, configs/claude/.plans/, .Jules/); link it from README.md, docs/README.md, and .claude/CLAUDE.md
 - [ ] T021 [US2] Run quickstart.md §US2 + full gate; markdownlint clean; if the diff exceeds 200 lines (likely), run parallel-agent cross-verification (`~/.claude/scripts/parallel_agent.py --json --timeout 600 --review` on changed files) per Constitution II before opening PR-2
 
 **Checkpoint**: docs match reality; drift map published.


### PR DESCRIPTION
## Summary
**US2 of specs/003** (stacked on #289): restores documentation accuracy across the repo.

- **Canonical command table**: `docs/COMMANDS.md` now holds all 33 commands (13 added from AGENTS.md extras, flags reconciled with `command_config.yml`); root `CLAUDE.md`, `AGENTS.md`, `configs/claude/CLAUDE.md` mirror it **byte-identically** (verified programmatically).
- **True counts**: "28/29/34 skills" → **69** everywhere; `Last Updated` stamps refreshed.
- **CHANGELOG**: shipped features promoted from `[Unreleased]` to dated `[2026-06]` (audit log #284, 45 skills #285, agy reviewer #282, label_sync fix); new Unreleased entries for specs/003.
- **Archived** `docs/SHELL_ANALYSIS_REPORT.md` (analyzed the retired `parallel_agent.sh`).
- **NEW `docs/SPEC-SYSTEMS.md`**: map of the four spec/plan systems (speckit / superpowers docs / .plans lifecycle / .Jules journal) + rules of thumb; linked from README, docs hub, and the repo developer guide.

### Constitution II compliance (>200-line diff)
Cross-verified by two independent agents (`agy` + `claude -p`; canonical `parallel_agent.py` unavailable — no API keys in env, documented in #289). Findings addressed pre-push: AGENTS.md header + missing CLI-tool note unified, stale T003 task text corrected to the manifest-prune mechanism, deleted-dir count fixed (14 dirs, −12 net), "six clusters merged" → "five merged, one cross-anchored". Both reviewers verified: tables consistent, counts correct, links resolve, no deleted-skill references.

## Test Plan
- [x] Four-table byte-equality check (programmatic) — 3× MATCH
- [x] `grep "28 skills|29 skills"` → empty
- [x] Full bats + pytest green on the stacked branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)