### PR TITLE
chore(us5): hygiene — specs/002 closure, err() convention, --help coverage

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -84,6 +84,18 @@ yamllint configs/claude/config/*.yml
 python3 -c "import yaml; yaml.safe_load(open('configs/claude/config/command_config.yml'))"
 ```
 
+## Script Conventions (configs/claude/scripts/)
+
+- **Error output**: `err() { echo "<script-name>: $*" >&2; }` is canonical;
+  route all error/warning messages through it (helpers like `error_msg()` may
+  delegate to `err()`). Exempt: usage/help text, interactive prompts, blank
+  separator lines, and success/info status output. `bootstrap/lib/` keeps its
+  own `print_error()` family (specs/003 R7).
+- **`--help`**: every user-facing entry point script handles `--help`
+  (usage + flags, ≤15 lines, exit 0). Exempt with rationale (specs/003 R6):
+  `version_pin_hook.sh` (save-hook wrapper, not user-invoked) and
+  `git_platform.sh` (internal detection helper used by git_ops.sh).
+
 ## Key Paths (in this repo)
 
 | What | Path |

--- a/configs/claude/scripts/branch_clean.sh
+++ b/configs/claude/scripts/branch_clean.sh
@@ -38,8 +38,24 @@ EXTRA_PROTECT=()
 err() { echo "branch-clean: $*" >&2; }
 usage_error() { err "$*"; exit 2; }
 
+usage() {
+    cat <<'USAGE'
+Usage: branch_clean.sh [--apply] [--include-remote] [--stale-days N]
+                       [--protect GLOB]... [--default BRANCH] [--yes] [--json]
+
+  --apply           Perform deletions (otherwise dry-run preview only)
+  --include-remote  Also delete the matching remote branch (opt-in)
+  --stale-days N    Staleness threshold (default: config / 90)
+  --protect GLOB    Extra protected branch glob (repeatable)
+  --default BRANCH  Override default-branch detection
+  --yes             Skip the interactive confirmation prompt (for --apply)
+  --json            Machine-readable output
+USAGE
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --help|-h) usage; exit 0 ;;
         --apply) APPLY=true; shift ;;
         --include-remote) INCLUDE_REMOTE=true; shift ;;
         --stale-days) [[ $# -ge 2 ]] || usage_error "--stale-days needs an argument"; STALE_DAYS="$2"; shift 2 ;;

--- a/configs/claude/scripts/browser_test.sh
+++ b/configs/claude/scripts/browser_test.sh
@@ -19,7 +19,6 @@
 set -euo pipefail
 
 # --- Colors -----------------------------------------------------------
-RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
@@ -68,7 +67,8 @@ EXAMPLES:
 USAGE
 }
 
-error_msg() { echo -e "${RED}Error: $1${RESET}" >&2; }
+err() { echo "browser-test: $*" >&2; }
+error_msg() { err "$1"; }
 success_msg() { echo -e "${GREEN}$1${RESET}"; }
 warn_msg() { echo -e "${YELLOW}$1${RESET}"; }
 info_msg() { echo -e "${CYAN}$1${RESET}"; }
@@ -87,10 +87,10 @@ check_browser_use() {
 
     error_msg "browser-use is not installed"
     echo "" >&2
-    echo "Install with:" >&2
-    echo "  pip install browser-use" >&2
-    echo "  # or" >&2
-    echo "  pipx install browser-use" >&2
+    err "Install with:"
+    err "  pip install browser-use"
+    err "  # or"
+    err "  pipx install browser-use"
     return 2
 }
 

--- a/configs/claude/scripts/check_status.sh
+++ b/configs/claude/scripts/check_status.sh
@@ -19,8 +19,22 @@ BLUE='\033[0;34m'
 BOLD='\033[1m'
 NC='\033[0m'
 
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    cat <<'USAGE'
+Usage: check_status.sh [--verbose]
+
+Parallel-agent orchestration readiness check: services.yml enabled agents,
+CLI availability, auth, and Manifest state directories.
+
+  --verbose   Also print CLI locations and versions
+
+Full environment audit (MCP, symlinks, config syntax): /health-check skill.
+USAGE
+    exit 0
+fi
+
 VERBOSE=false
-if [[ "$1" == "--verbose" ]]; then
+if [[ "${1:-}" == "--verbose" ]]; then
     VERBOSE=true
 fi
 

--- a/configs/claude/scripts/git_ops.sh
+++ b/configs/claude/scripts/git_ops.sh
@@ -29,18 +29,20 @@
 
 set -euo pipefail
 
+err() { echo "git-ops: $*" >&2; }
+
 # Get script directory for sourcing git_platform.sh
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source platform detection
 if [[ ! -f "${SCRIPT_DIR}/git_platform.sh" ]]; then
-    echo "Error: git_platform.sh not found in ${SCRIPT_DIR}" >&2
+    err "git_platform.sh not found in ${SCRIPT_DIR}"
     exit 1
 fi
 
 # Detect platform
 if ! platform=$(bash "${SCRIPT_DIR}/git_platform.sh" 2>&1); then
-    echo "Error: Failed to detect Git platform: ${platform}" >&2
+    err "Failed to detect Git platform: ${platform}"
     exit 1
 fi
 
@@ -84,15 +86,15 @@ command_exists() {
 warn_missing_tool() {
     local tool="$1"
     local install_hint="$2"
-    echo "Warning: ${tool} CLI not found. Install it to enable this operation." >&2
-    echo "Install: ${install_hint}" >&2
+    err "Warning: ${tool} CLI not found. Install it to enable this operation."
+    err "Install: ${install_hint}"
     exit 1
 }
 
 # Helper: Fallback for plain git (no issue tracker)
 warn_no_tracker() {
-    echo "Warning: No issue tracker detected (plain git remote)." >&2
-    echo "This operation requires GitHub (gh) or GitLab (glab) CLI." >&2
+    err "Warning: No issue tracker detected (plain git remote)."
+    err "This operation requires GitHub (gh) or GitLab (glab) CLI."
     exit 1
 }
 
@@ -165,7 +167,7 @@ case "${platform}" in
                 bash "${SCRIPT_DIR}/label_sync.sh" "$@"
                 ;;
             *)
-                echo "Error: Unknown subcommand: ${subcommand}" >&2
+                err "Unknown subcommand: ${subcommand}"
                 exit 1
                 ;;
         esac
@@ -207,7 +209,7 @@ case "${platform}" in
                     done
                     glab api "projects/:id/issues/${issue_num}/notes/${last_note_id}" -X PUT -f "body=${body}"
                 else
-                    echo "Error: No comments found on issue ${issue_num}" >&2
+                    err "No comments found on issue ${issue_num}"
                     exit 1
                 fi
                 ;;
@@ -292,7 +294,7 @@ case "${platform}" in
                 bash "${SCRIPT_DIR}/label_sync.sh" "$@"
                 ;;
             *)
-                echo "Error: Unknown subcommand: ${subcommand}" >&2
+                err "Unknown subcommand: ${subcommand}"
                 exit 1
                 ;;
         esac
@@ -305,14 +307,14 @@ case "${platform}" in
                 warn_no_tracker
                 ;;
             *)
-                echo "Error: Unknown subcommand: ${subcommand}" >&2
+                err "Unknown subcommand: ${subcommand}"
                 exit 1
                 ;;
         esac
         ;;
 
     *)
-        echo "Error: Unknown platform: ${platform}" >&2
+        err "Unknown platform: ${platform}"
         exit 1
         ;;
 esac

--- a/configs/claude/scripts/git_ops.sh
+++ b/configs/claude/scripts/git_ops.sh
@@ -46,32 +46,43 @@ if ! platform=$(bash "${SCRIPT_DIR}/git_platform.sh" 2>&1); then
     exit 1
 fi
 
+usage() {
+    cat <<'USAGE'
+Usage: git_ops.sh <subcommand> [args...]
+
+Subcommands:
+  issue-view N       View issue/MR N
+  issue-list         List issues/MRs
+  issue-create       Create new issue/MR
+  issue-comment N    Add comment/note to issue/MR N
+  issue-comment-edit-last N  Edit last comment on issue/MR N
+  issue-close N      Close issue/MR N
+  issue-edit N       Edit issue/MR N
+  pr-create          Create pull/merge request
+  pr-view N          View PR/MR N
+  pr-list            List PRs/MRs
+  pr-review N        Review PR/MR N (pass --approve/--comment/--request-changes)
+  pr-approve N       Approve PR/MR N (shortcut for pr-review --approve)
+  pr-diff N          View PR/MR N diff
+  pr-checks N        View CI status for PR/MR N
+  pr-merge N         Merge PR/MR N
+  release-create     Create a release
+  release-list       List releases
+  label-create       Create label
+  label-list         List labels
+  label-sync         Sync labels from registry
+USAGE
+}
+
 # Validate subcommand
 if [[ $# -eq 0 ]]; then
-    echo "Usage: git_ops.sh <subcommand> [args...]" >&2
-    echo "" >&2
-    echo "Subcommands:" >&2
-    echo "  issue-view N       View issue/MR N" >&2
-    echo "  issue-list         List issues/MRs" >&2
-    echo "  issue-create       Create new issue/MR" >&2
-    echo "  issue-comment N    Add comment/note to issue/MR N" >&2
-    echo "  issue-comment-edit-last N  Edit last comment on issue/MR N" >&2
-    echo "  issue-close N      Close issue/MR N" >&2
-    echo "  issue-edit N       Edit issue/MR N" >&2
-    echo "  pr-create          Create pull/merge request" >&2
-    echo "  pr-view N          View PR/MR N" >&2
-    echo "  pr-list            List PRs/MRs" >&2
-    echo "  pr-review N        Review PR/MR N (pass --approve/--comment/--request-changes)" >&2
-    echo "  pr-approve N       Approve PR/MR N (shortcut for pr-review --approve)" >&2
-    echo "  pr-diff N          View PR/MR N diff" >&2
-    echo "  pr-checks N        View CI status for PR/MR N" >&2
-    echo "  pr-merge N         Merge PR/MR N" >&2
-    echo "  release-create     Create a release" >&2
-    echo "  release-list       List releases" >&2
-    echo "  label-create       Create label" >&2
-    echo "  label-list         List labels" >&2
-    echo "  label-sync         Sync labels from registry" >&2
+    usage >&2
     exit 1
+fi
+
+if [[ "$1" == "--help" || "$1" == "-h" || "$1" == "help" ]]; then
+    usage
+    exit 0
 fi
 
 subcommand="$1"

--- a/configs/claude/scripts/git_platform.sh
+++ b/configs/claude/scripts/git_platform.sh
@@ -11,6 +11,8 @@
 
 set -euo pipefail
 
+err() { echo "git-platform: $*" >&2; }
+
 # Allow override via env var
 if [[ -n "${MANIFEST_GIT_PLATFORM:-}" ]]; then
     case "${MANIFEST_GIT_PLATFORM}" in
@@ -19,8 +21,8 @@ if [[ -n "${MANIFEST_GIT_PLATFORM:-}" ]]; then
             exit 0
             ;;
         *)
-            echo "Error: Invalid MANIFEST_GIT_PLATFORM value: ${MANIFEST_GIT_PLATFORM}" >&2
-            echo "Valid values: github, gitlab, git" >&2
+            err "Invalid MANIFEST_GIT_PLATFORM value: ${MANIFEST_GIT_PLATFORM}"
+            err "Valid values: github, gitlab, git"
             exit 1
             ;;
     esac
@@ -31,13 +33,13 @@ remote_name="${1:-${MANIFEST_GIT_REMOTE:-origin}}"
 
 # Check if we're in a git repository
 if ! git rev-parse --git-dir &> /dev/null; then
-    echo "Error: Not a git repository" >&2
+    err "Not a git repository"
     exit 1
 fi
 
 # Get remote URL
 if ! remote_url=$(git remote get-url "${remote_name}" 2> /dev/null); then
-    echo "Error: Remote '${remote_name}' not found" >&2
+    err "Remote '${remote_name}' not found"
     exit 1
 fi
 

--- a/configs/claude/scripts/label_sync.sh
+++ b/configs/claude/scripts/label_sync.sh
@@ -15,6 +15,8 @@
 
 set -euo pipefail
 
+err() { echo "label-sync: $*" >&2; }
+
 # Colors for output
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -71,7 +73,7 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         *)
-            echo "Error: Unknown option: $1" >&2
+            err "Unknown option: $1"
             exit 1
             ;;
     esac
@@ -85,7 +87,7 @@ find_labels_file() {
             echo "$LABELS_FILE"
             return 0
         fi
-        echo "Error: Labels file not found: $LABELS_FILE" >&2
+        err "Labels file not found: $LABELS_FILE"
         return 1
     fi
 
@@ -102,7 +104,7 @@ find_labels_file() {
         fi
     done
 
-    echo "Error: labels.yml not found. Searched: ${candidates[*]}" >&2
+    err "labels.yml not found. Searched: ${candidates[*]}"
     return 1
 }
 

--- a/configs/claude/scripts/learning_capture.sh
+++ b/configs/claude/scripts/learning_capture.sh
@@ -20,11 +20,12 @@
 set -euo pipefail
 
 # --- Colors -----------------------------------------------------------
-RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 RESET='\033[0m'
+
+err() { echo "learning-capture: $*" >&2; }
 
 # --- Knowledge base file location ------------------------------------
 if [[ -f "${HOME}/.claude/config/knowledge_base.yml" ]]; then
@@ -32,7 +33,7 @@ if [[ -f "${HOME}/.claude/config/knowledge_base.yml" ]]; then
 elif [[ -f ".claude/config/knowledge_base.yml" ]]; then
     KNOWLEDGE_BASE_FILE=".claude/config/knowledge_base.yml"
 else
-    echo -e "${RED}Error: knowledge_base.yml not found in ~/.claude/config/ or .claude/config/${RESET}" >&2
+    err "knowledge_base.yml not found in ~/.claude/config/ or .claude/config/"
     exit 1
 fi
 
@@ -87,9 +88,7 @@ EXAMPLES:
 USAGE
 }
 
-error_msg() {
-    echo -e "${RED}Error: $1${RESET}" >&2
-}
+error_msg() { err "$1"; }
 
 success_msg() {
     echo -e "${GREEN}$1${RESET}"
@@ -109,7 +108,7 @@ validate_category() {
         pattern | antipattern | tool_discovery | config_insight) return 0 ;;
         *)
             error_msg "Invalid category: $cat"
-            echo "  Valid categories: pattern, antipattern, tool_discovery, config_insight" >&2
+            err "  Valid categories: pattern, antipattern, tool_discovery, config_insight"
             return 1
             ;;
     esac
@@ -121,7 +120,7 @@ validate_confidence() {
         high | medium | low) return 0 ;;
         *)
             error_msg "Invalid confidence: $conf"
-            echo "  Valid levels: high, medium, low" >&2
+            err "  Valid levels: high, medium, low"
             return 1
             ;;
     esac

--- a/configs/claude/scripts/learning_capture.sh
+++ b/configs/claude/scripts/learning_capture.sh
@@ -32,6 +32,8 @@ if [[ -f "${HOME}/.claude/config/knowledge_base.yml" ]]; then
     KNOWLEDGE_BASE_FILE="${HOME}/.claude/config/knowledge_base.yml"
 elif [[ -f ".claude/config/knowledge_base.yml" ]]; then
     KNOWLEDGE_BASE_FILE=".claude/config/knowledge_base.yml"
+elif [[ "${1:-}" == "--help" || "${1:-}" == "-h" || "${1:-}" == "help" ]]; then
+    KNOWLEDGE_BASE_FILE=""   # --help must work without a KB (fresh clone / CI)
 else
     err "knowledge_base.yml not found in ~/.claude/config/ or .claude/config/"
     exit 1

--- a/configs/claude/scripts/linear_ops.sh
+++ b/configs/claude/scripts/linear_ops.sh
@@ -1202,7 +1202,24 @@ cmd_transition_state() {
 }
 
 # Main command router
+usage() {
+    cat <<'USAGE'
+Usage: linear_ops.sh <subcommand> [args...]
+
+Subcommands:
+  team-list            team-states          issue-list
+  issue-view           issue-update         issue-comment
+  issue-close          issue-mark-duplicate create-sub-issue
+  list-sub-issues      add-attachment       list-cycles
+  add-comment          transition-state     label-list
+  label-create
+
+Requires LINEAR_API_KEY. Run a subcommand with no args for its usage.
+USAGE
+}
+
 main() {
+    if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then usage; exit 0; fi
     [[ $# -eq 0 ]] && error "Usage: linear_ops.sh <subcommand> [args...]
 
 Subcommands:

--- a/configs/claude/scripts/linear_ops.sh
+++ b/configs/claude/scripts/linear_ops.sh
@@ -5,19 +5,18 @@
 set -euo pipefail
 
 # Colors for output
-RED='\033[0;31m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Error handling
+# Error handling (canonical err() convention; error() exits, warning() continues)
+err() { echo "linear-ops: $*" >&2; }
 error() {
-    echo -e "${RED}Error: $1${NC}" >&2
+    err "$1"
     exit 1
 }
 
 warning() {
-    echo -e "${YELLOW}Warning: $1${NC}" >&2
+    err "Warning: $1"
 }
 
 success() {

--- a/configs/claude/scripts/pr_review.sh
+++ b/configs/claude/scripts/pr_review.sh
@@ -28,8 +28,23 @@ JSON_OUT=false
 err() { echo "pr-review: $*" >&2; }
 usage_error() { err "$*"; exit 2; }
 
+usage() {
+    cat <<'USAGE'
+Usage: pr_review.sh [--platform github|gitlab] [--stale-days N] [--json]
+
+Triage all open pull/merge requests (analysis-only; no mutations).
+
+  --platform P    Force platform instead of auto-detection
+  --stale-days N  Days without update before a PR counts as stale (default 30)
+  --json          Machine-readable output
+
+Exit codes: 0 = success (incl. empty queue); 2 = usage / platform / auth error
+USAGE
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --help|-h) usage; exit 0 ;;
         --platform) [[ $# -ge 2 ]] || usage_error "--platform needs an argument"; PLATFORM="$2"; shift 2 ;;
         --stale-days) [[ $# -ge 2 ]] || usage_error "--stale-days needs an argument"; STALE_DAYS="$2"; shift 2 ;;
         --json) JSON_OUT=true; shift ;;

--- a/configs/claude/scripts/skillclaw_promote.sh
+++ b/configs/claude/scripts/skillclaw_promote.sh
@@ -50,8 +50,24 @@ APPLY=false; SKILL=""; DO_EVOLVE=true; FORCE_NEW=false
 err() { echo "skillclaw-promote: $*" >&2; }
 usage_error() { err "$*"; exit 2; }
 
+usage() {
+    cat <<'USAGE'
+Usage: skillclaw_promote.sh [--apply] [--skill NAME] [--no-evolve]
+                            [--force-new] [--status]
+
+Turn evolved SkillClaw skills into a review PR. Dry-run by default.
+
+  --apply       Branch, commit per skill, and open the review PR
+  --skill NAME  Limit the run to a single evolved skill
+  --no-evolve   Skip the evolve step (promote existing candidates only)
+  --force-new   Proceed even if an open skillclaw/evolve-* PR exists
+  --status      Print pipeline status from the audit log and exit
+USAGE
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --help|-h) usage; exit 0 ;;
         --status) python3 "$AUDIT" status; exit 0 ;;
         --apply) APPLY=true; shift ;;
         --skill) [[ $# -ge 2 ]] || usage_error "--skill needs a name"; SKILL="$2"; shift 2 ;;

--- a/configs/claude/scripts/sync-skills.sh
+++ b/configs/claude/scripts/sync-skills.sh
@@ -3,6 +3,18 @@ set -euo pipefail
 
 err() { echo "sync-skills: $*" >&2; }
 
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    cat <<'USAGE'
+Usage: sync-skills
+
+Sync .skillshare/skills/ (source of truth) to all home targets
+(~/.claude/skills + Cursor/Gemini/Codex/Antigravity symlinks) and run
+skillshare sync for the Copilot target. No flags. Requires MANIFEST_ROOT
+(set by bootstrap.sh).
+USAGE
+    exit 0
+fi
+
 [[ -z "${MANIFEST_ROOT:-}" ]] && { err "MANIFEST_ROOT not set. Re-run bootstrap.sh."; exit 1; }
 [[ ! -d "$MANIFEST_ROOT" ]]  && { err "MANIFEST_ROOT '$MANIFEST_ROOT' not found."; exit 1; }
 

--- a/configs/claude/scripts/sync-skills.sh
+++ b/configs/claude/scripts/sync-skills.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-[[ -z "${MANIFEST_ROOT:-}" ]] && { echo "Error: MANIFEST_ROOT not set. Re-run bootstrap.sh." >&2; exit 1; }
-[[ ! -d "$MANIFEST_ROOT" ]]  && { echo "Error: MANIFEST_ROOT '$MANIFEST_ROOT' not found." >&2; exit 1; }
+err() { echo "sync-skills: $*" >&2; }
+
+[[ -z "${MANIFEST_ROOT:-}" ]] && { err "MANIFEST_ROOT not set. Re-run bootstrap.sh."; exit 1; }
+[[ ! -d "$MANIFEST_ROOT" ]]  && { err "MANIFEST_ROOT '$MANIFEST_ROOT' not found."; exit 1; }
 
 SKILLS_SRC="$MANIFEST_ROOT/.skillshare/skills"
-[[ ! -d "$SKILLS_SRC" ]] && { echo "Error: skills source not found: $SKILLS_SRC" >&2; exit 1; }
+[[ ! -d "$SKILLS_SRC" ]] && { err "skills source not found: $SKILLS_SRC"; exit 1; }
 
 # Copilot sync via skillshare (warn and continue if not installed or fails)
 if command -v skillshare > /dev/null 2>&1; then
-    (cd "$MANIFEST_ROOT" && skillshare sync) || echo "Warning: skillshare sync failed — continuing"
+    (cd "$MANIFEST_ROOT" && skillshare sync) || err "Warning: skillshare sync failed — continuing"
 else
-    echo "Warning: skillshare not installed — skipping Copilot sync"
+    err "Warning: skillshare not installed — skipping Copilot sync"
 fi
 
 # Home targets — parallel rsync, PID-tracked so failures are visible
@@ -26,7 +28,7 @@ done
 failed=0
 for i in "${!pids[@]}"; do
     if ! wait "${pids[$i]}"; then
-        echo "Warning: rsync to ${targets[$i]} failed" >&2
+        err "Warning: rsync to ${targets[$i]} failed"
         [[ "${targets[$i]}" == "$HOME/.claude/skills" ]] && failed=1
     fi
 done

--- a/configs/claude/scripts/version_pin.sh
+++ b/configs/claude/scripts/version_pin.sh
@@ -54,9 +54,25 @@ CHANGED=false   # set by process_* to signal the file needs rewriting
 err() { echo "version-pin: $*" >&2; }
 usage_error() { err "$*"; exit 2; }
 
+usage() {
+    cat <<'USAGE'
+Usage: version_pin.sh [<path>...] [--check] [--requested NAME=VERSION]...
+                      [--rule ID] [--config FILE]
+
+  <path>...            Files/dirs to scan (default: current directory tree)
+  --check              Warn-only: report violations + fixes, make NO edits
+  --requested NAME=VER Pin NAME to an exact requested version (repeatable)
+  --rule ID            Limit to one rule-set entry from the config
+  --config FILE        Alternate command_config.yml
+
+Bypass a line with a trailing '# version-pin:ignore' marker.
+USAGE
+}
+
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            --help|-h) usage; exit 0 ;;
             --check) CHECK_ONLY=true; shift ;;
             --rule) [[ $# -ge 2 ]] || usage_error "--rule needs an argument"; RULE_FILTER="$2"; shift 2 ;;
             --config) [[ $# -ge 2 ]] || usage_error "--config needs an argument"; CONFIG="$2"; shift 2 ;;

--- a/specs/002-new-agent-skills/plan.md
+++ b/specs/002-new-agent-skills/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: New Agent Skills (Version Pinning, Docs Orchestration, PR Review, Branch Cleanup)
 
-**Branch**: `002-new-agent-skills` | **Date**: 2026-06-01 | **Spec**: [spec.md](./spec.md)
+**Branch**: `002-new-agent-skills` | **Date**: 2026-06-01 | **Status**: Delivered 2026-06 | **Spec**: [spec.md](./spec.md)
 
 **Input**: Feature specification from `/specs/002-new-agent-skills/spec.md`
 

--- a/specs/002-new-agent-skills/spec.md
+++ b/specs/002-new-agent-skills/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-01
 
-**Status**: Draft
+**Status**: Delivered 2026-06
 
 **Input**: User description: "Add new skills to do the following: Skill: Enforce version pinning — specific version (avoid latest, recommended latest stable, or request version); ensure version pin also includes hash if supported; force it on specific file types / name as a hook (e.g. requirements.txt, docker-compose.yaml, common files that support version pinning). Skill: Create an all-in-one docs command that runs our existing DOCS in sub-agents in the appropriate order to support any order of precedency. Skill: GitHub PR Reviewer (review all open PRs, identify if they are needed...); GitHub/Git Branch Cleaner."
 

--- a/specs/002-new-agent-skills/tasks.md
+++ b/specs/002-new-agent-skills/tasks.md
@@ -131,9 +131,9 @@ never listed, dry-run deletes nothing, and `--apply` deletes only confirmed bran
 
 - [x] T023 [P] Run full lint sweep: `shellcheck configs/claude/scripts/version_pin.sh configs/claude/scripts/pr_review.sh configs/claude/scripts/branch_clean.sh` and `yamllint configs/claude/config/*.yml`
 - [x] T024 [P] Run full test suite: `bats tests/bats/` (all new + existing) to confirm no regressions
-- [ ] T025 [P] Deploy check: `./bootstrap.sh` then confirm `ls ~/.claude/skills | grep -E 'version-pin|docs-all|pr-review|branch-clean'` lists all four (Constitution V idempotency: re-run is a no-op)
+- [x] T025 [P] Deploy check: `./bootstrap.sh` then confirm `ls ~/.claude/skills | grep -E 'version-pin|docs-all|pr-review|branch-clean'` lists all four (Constitution V idempotency: re-run is a no-op). *Verified 2026-06-11*: all four present in `.skillshare/skills/` and deployed in `~/.claude/skills/`
 - [x] T026 Final docs consistency pass: ensure CLAUDE.md / configs/claude/CLAUDE.md / docs/COMMANDS.md tables, `Available Commands`, and `Adding New Skills` references are consistent across all four skills
-- [ ] T027 [P] Constitution Principle II gate — cross-verify the security-sensitive shell helpers with parallel agents before merge: `~/.claude/scripts/parallel_agent.py --json --timeout 600 --review <abs-path>/configs/claude/scripts/version_pin.sh` and the same for `branch_clean.sh` (its destructive `--apply` path). Resolve any ≥HIGH consensus findings; record the consensus verdict in the PR description
+- [x] T027 [P] Constitution Principle II gate — cross-verify the security-sensitive shell helpers with parallel agents before merge: `~/.claude/scripts/parallel_agent.py --json --timeout 600 --review <abs-path>/configs/claude/scripts/version_pin.sh` and the same for `branch_clean.sh` (its destructive `--apply` path). Resolve any ≥HIGH consensus findings; record the consensus verdict in the PR description. *Closed 2026-06-11*: equivalent gate applied retroactively during specs/003 — version_pin.sh and branch_clean.sh were hardened (US3, PR #293) and independently reviewed by Copilot + Gemini CLI + an isolated Claude reviewer across PRs #289-#294 (parallel_agent.py SDK backends unavailable on this machine)
 
 ---
 

--- a/specs/003-skill-library-consolidation/tasks.md
+++ b/specs/003-skill-library-consolidation/tasks.md
@@ -121,10 +121,10 @@
 **Independent test** (quickstart.md §US5): records/ ignored; no stale current-plan pointer; --help present on the 8 user-facing scripts.
 
 - [x] T036 [P] [US5] Add `records/` to .gitignore with comment `# local tool side-effect, origin unknown (not SkillClaw — see specs/003 research R10)`
-- [ ] T037 [P] [US5] Review specs/002-new-agent-skills/ deliverables (R11); if delivered mark plan.md/spec.md status "Delivered 2026-06"; confirm root CLAUDE.md SPECKIT pointer already repointed to 003 (done in planning) and remove any other stale "current plan" references
-- [ ] T038 [US5] err() convention sweep in configs/claude/scripts/*.sh: convert bare `echo ... >&2` / print_error uses to `err()` (bootstrap/lib/ exempt per clarification); document the convention + exemption in .claude/CLAUDE.md
-- [ ] T039 [US5] Add minimal `--help` (usage + flags, ≤15 lines) to the 8 user-facing scripts lacking it: branch_clean.sh, check_status.sh, git_ops.sh, linear_ops.sh, pr_review.sh, skillclaw_promote.sh, sync-skills.sh, version_pin.sh; document exemptions (version_pin_hook.sh, git_platform.sh) in .claude/CLAUDE.md (R6)
-- [ ] T040 [US5] Run quickstart.md §US5 + full gate; if the diff exceeds 200 lines (likely — 10-script sweep), run parallel-agent cross-verification per Constitution II; open PR-5
+- [x] T037 [P] [US5] Review specs/002-new-agent-skills/ deliverables (R11); if delivered mark plan.md/spec.md status "Delivered 2026-06"; confirm root CLAUDE.md SPECKIT pointer already repointed to 003 (done in planning) and remove any other stale "current plan" references
+- [x] T038 [US5] err() convention sweep in configs/claude/scripts/*.sh: convert bare `echo ... >&2` / print_error uses to `err()` (bootstrap/lib/ exempt per clarification); document the convention + exemption in .claude/CLAUDE.md
+- [x] T039 [US5] Add minimal `--help` (usage + flags, ≤15 lines) to the 8 user-facing scripts lacking it: branch_clean.sh, check_status.sh, git_ops.sh, linear_ops.sh, pr_review.sh, skillclaw_promote.sh, sync-skills.sh, version_pin.sh; document exemptions (version_pin_hook.sh, git_platform.sh) in .claude/CLAUDE.md (R6)
+- [x] T040 [US5] Run quickstart.md §US5 + full gate; if the diff exceeds 200 lines (likely — 10-script sweep), run parallel-agent cross-verification per Constitution II; open PR-5
 
 **Checkpoint**: hygiene complete.
 

--- a/tests/bats/help_coverage.bats
+++ b/tests/bats/help_coverage.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# specs/003 T039 / R6: every user-facing entry point in configs/claude/scripts/
+# handles --help (usage to stdout, exit 0). Exempt with documented rationale
+# (.claude/CLAUDE.md): version_pin_hook.sh (save-hook wrapper) and
+# git_platform.sh (internal helper used by git_ops.sh).
+
+setup() {
+    load '../test_helper/bats-support/load'
+    load '../test_helper/bats-assert/load'
+    SCRIPTS="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../configs/claude/scripts" && pwd)"
+}
+
+USER_FACING="branch_clean.sh check_status.sh git_ops.sh linear_ops.sh
+pr_review.sh skillclaw_promote.sh sync-skills.sh version_pin.sh
+browser_test.sh label_sync.sh learning_capture.sh spec_review.sh"
+
+@test "every user-facing script: --help exits 0 and prints Usage on stdout" {
+    for f in $USER_FACING; do
+        run bash "$SCRIPTS/$f" --help
+        [ "$status" -eq 0 ] || { echo "$f: exit $status"; false; }
+        [[ "$output" == *"Usage"* || "$output" == *"USAGE"* ]] \
+            || { echo "$f: no Usage in --help output"; false; }
+    done
+}
+
+@test "--help output stays concise (<= 50 lines per script)" {
+    # R6's <=15-line guideline applies to the minimal helps ADDED by T039;
+    # pre-existing comprehensive helps (learning_capture: 44) get headroom.
+    for f in $USER_FACING; do
+        lines=$(bash "$SCRIPTS/$f" --help | wc -l | tr -d ' ')
+        [ "$lines" -le 50 ] || { echo "$f: $lines lines"; false; }
+    done
+}
+
+@test "exempt scripts are documented in .claude/CLAUDE.md" {
+    doc="$SCRIPTS/../../../.claude/CLAUDE.md"
+    grep -q "version_pin_hook.sh" "$doc"
+    grep -q "git_platform.sh" "$doc"
+}


### PR DESCRIPTION
## Summary

US5 of `specs/003-skill-library-consolidation` (PR-5 of 5, final story):

### specs/002 closure (T037)
- spec.md/plan.md marked **Delivered 2026-06**; all four skills (version-pin, docs-all, pr-review, branch-clean) verified in `.skillshare/skills/` and deployed to `~/.claude/skills/`
- T025 checked with verification evidence; T027 closed citing the retroactive equivalent gate from the 003 reviews

### err() convention sweep (T038, R7)
- Canonical `err() { echo "<script>: $*" >&2; }` across `configs/claude/scripts/`: added to git_platform, label_sync, git_ops, sync-skills; colored helpers in learning_capture/linear_ops/browser_test now delegate to it (`error()` still exits 1)
- Exempt: usage text, interactive prompts, blank separators, success/info output; `bootstrap/lib/` keeps `print_error`
- Unused color vars removed (SC2034); convention documented in `.claude/CLAUDE.md`

### --help coverage (T039, R6)
- Minimal `--help`/`-h` (usage + flags, stdout, exit 0) added to the 8 user-facing scripts lacking it: branch_clean, check_status, git_ops, linear_ops, pr_review, skillclaw_promote, sync-skills, version_pin
- git_ops' inline stderr usage refactored into `usage()` shared by the no-args error path (>&2, exit 1) and `--help` (stdout, exit 0); linear_ops help lists the real dispatcher subcommands
- Exemptions documented: version_pin_hook.sh (save-hook wrapper), git_platform.sh (internal helper)
- New `tests/bats/help_coverage.bats` pins `--help` across all 12 user-facing scripts

## Cross-verification (Constitution II, diff >200 lines — T040)

- **Gemini CLI**: APPROVED — no Tier 1 findings; confirmed `linear_ops error()` exit-1 preserved and stdout/stderr usage split correct
- **Independent Claude reviewer**: NEEDS_REVIEW — zero Tier 1 issues; one consistency suggestion (`spec_review.sh --help` uses `return 0` not `exit 0`). **Rejected with rationale**: spec_review.sh is deliberately sourceable (spec_review.bats `source`s it 14×); `exit` in `main()` would kill the sourcing shell. `return 0` is the correct form there.

## Verification

- `bats tests/bats/` — **310 tests, 0 failures** (307 + 3 new)
- `pytest tests/python/` — **198 passed**
- `shellcheck -S warning configs/claude/scripts/*.sh` — clean
- quickstart.md §US5 — err() canonical, --help present on all 8, specs/002 delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)