### PR TITLE
Fix silent bootstrap abort after deploy (set -e trap in skillclaw launchd cleanup)

### DIFF
--- a/bootstrap/lib/deploy.sh
+++ b/bootstrap/lib/deploy.sh
@@ -184,9 +184,21 @@ deploy_configs() {
     # List deployed files
     echo ""
     print_info "Deployed files:"
-    find "$TARGET_DIR" -type f \( -name "*.md" -o -name "*.yml" -o -name "*.sh" \) 2> /dev/null | head -20 | while read -r file; do
-        echo "    ${file#"$HOME"/}"
-    done
+    list_deployed_files "$TARGET_DIR"
+}
+
+# list_deployed_files DIR — print up to 20 deployed config files.
+# SIGPIPE-safe: `find | head | while` under bootstrap.sh's `set -e` killed the
+# whole bootstrap (exit 141) once the target held >20 matching files — find
+# dies of SIGPIPE when head exits, and pipefail surfaces it. Buffer through a
+# guarded command substitution instead.
+list_deployed_files() {
+    local dir="$1" deployed_files file
+    deployed_files=$(find "$dir" -type f \( -name "*.md" -o -name "*.yml" -o -name "*.sh" \) 2> /dev/null | head -20) || true
+    while IFS= read -r file; do
+        [[ -n "$file" ]] && echo "    ${file#"$HOME"/}"
+    done <<< "$deployed_files"
+    return 0
 }
 
 # Deploy Cursor IDE configuration (mirrors .claude with symlinks)

--- a/bootstrap/lib/skillclaw.sh
+++ b/bootstrap/lib/skillclaw.sh
@@ -28,17 +28,28 @@ skillclaw_remove_wrappers() {
 }
 
 # Remove the retired launchd/systemd supervisor if a prior install left one.
+# NOTE: must not end on a failed `[[ -f ... ]] && {...}` list — when the unit
+# is absent (the normal case) that made the function return 1, and under
+# bootstrap.sh's `set -e` the bare call aborted the entire bootstrap silently
+# right after deploy_configs (skipping skillclaw state, deps, auth, summary).
 _skillclaw_remove_launchd() {
     case "$(uname -s)" in
         Darwin)
             local plist="$HOME/Library/LaunchAgents/com.manifest.skillclaw.plist"
-            [[ -f "$plist" ]] && { launchctl unload "$plist" >/dev/null 2>&1 || true; rm -f "$plist"; }
+            if [[ -f "$plist" ]]; then
+                launchctl unload "$plist" >/dev/null 2>&1 || true
+                rm -f "$plist"
+            fi
             ;;
         Linux)
             local unit="$HOME/.config/systemd/user/skillclaw.service"
-            [[ -f "$unit" ]] && { systemctl --user disable --now skillclaw.service >/dev/null 2>&1 || true; rm -f "$unit"; }
+            if [[ -f "$unit" ]]; then
+                systemctl --user disable --now skillclaw.service >/dev/null 2>&1 || true
+                rm -f "$unit"
+            fi
             ;;
     esac
+    return 0
 }
 
 # Apply desired state. Transcript-fed evolution needs NO daemon and NO proxy —

--- a/tests/bats/deploy_skills.bats
+++ b/tests/bats/deploy_skills.bats
@@ -383,3 +383,44 @@ STUB
     run grep -c 'export PATH="$HOME/.local/bin:$PATH"' "$fake_profile"
     assert_output "1"
 }
+
+# ---------------------------------------------------------------------------
+# list_deployed_files — SIGPIPE-safe deployed-files listing.
+# `find | head -20 | while` under bootstrap.sh's `set -e` killed the whole
+# bootstrap (exit 141) once ~/.claude held >20 matching files, silently
+# skipping skillclaw state, python deps, auth checks, and the summary.
+# ---------------------------------------------------------------------------
+
+@test "list_deployed_files survives set -e with more than 20 files" {
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh"
+    mkdir -p "$SANDBOX/target"
+    for i in $(seq 1 30); do echo x > "$SANDBOX/target/file$i.md"; done
+
+    run bash -c "
+        set -euo pipefail
+        source '$REPO_ROOT/bootstrap/lib/common.sh'
+        source '$REPO_ROOT/bootstrap/lib/deploy.sh'
+        list_deployed_files '$SANDBOX/target'
+        echo SURVIVED
+    "
+    assert_success
+    assert_output --partial "SURVIVED"
+    # Truncation to 20 entries still applies
+    [ "$(echo "$output" | grep -c 'file')" -eq 20 ]
+}
+
+@test "list_deployed_files handles an empty directory" {
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh"
+    mkdir -p "$SANDBOX/empty"
+    run bash -c "
+        set -euo pipefail
+        source '$REPO_ROOT/bootstrap/lib/common.sh'
+        source '$REPO_ROOT/bootstrap/lib/deploy.sh'
+        list_deployed_files '$SANDBOX/empty'
+        echo SURVIVED
+    "
+    assert_success
+    assert_output --partial "SURVIVED"
+}

--- a/tests/bats/deploy_skills.bats
+++ b/tests/bats/deploy_skills.bats
@@ -385,10 +385,12 @@ STUB
 }
 
 # ---------------------------------------------------------------------------
-# list_deployed_files — SIGPIPE-safe deployed-files listing.
-# `find | head -20 | while` under bootstrap.sh's `set -e` killed the whole
-# bootstrap (exit 141) once ~/.claude held >20 matching files, silently
-# skipping skillclaw state, python deps, auth checks, and the summary.
+# list_deployed_files — SIGPIPE-safe deployed-files listing (defensive).
+# With >20 matching files, head exits early and find dies of SIGPIPE (141).
+# That is fatal only under `pipefail` — bootstrap.sh currently sets only -e,
+# so this hardens against the trap being armed if pipefail is ever added.
+# (The silent bootstrap abort itself was _skillclaw_remove_launchd — see
+# skillclaw_lib.bats.) Tests run under -euo pipefail, the strictest mode.
 # ---------------------------------------------------------------------------
 
 @test "list_deployed_files survives set -e with more than 20 files" {

--- a/tests/bats/skillclaw_lib.bats
+++ b/tests/bats/skillclaw_lib.bats
@@ -98,3 +98,27 @@ PROF
     run grep -Eq 'no daemon|transcript' "$REPO_ROOT/bootstrap/lib/skillclaw.sh"
     [ "$status" -eq 0 ]
 }
+
+@test "skillclaw_apply_state survives set -e when no launchd plist exists" {
+    # _skillclaw_remove_launchd ended with `[[ -f plist ]] && {...}` — when the
+    # plist is absent (the normal case) that list returns 1 as the function's
+    # exit status, and under bootstrap.sh's `set -e` the bare call aborted the
+    # ENTIRE bootstrap silently right after deploy_configs (found 2026-06-11:
+    # every run died before skillclaw state, python deps, auth, and summary).
+    run bash -c "
+        set -e
+        HOME='$SANDBOX/home'
+        mkdir -p \"\$HOME\"
+        export SKILLCLAW_HOME='$SANDBOX/.skillclaw'
+        export SHELL_PROFILE_FILE='$SANDBOX/home/.zshrc'
+        touch '$SANDBOX/home/.zshrc'
+        print_step() { :; }; print_success() { :; }; print_info() { :; }
+        print_warning() { :; }; print_error() { :; }
+        launchctl() { :; }; systemctl() { :; }
+        source '$REPO_ROOT/bootstrap/lib/skillclaw.sh'
+        ENABLE_SKILLCLAW=true skillclaw_apply_state
+        echo SURVIVED
+    "
+    assert_success
+    assert_output --partial "SURVIVED"
+}


### PR DESCRIPTION
## Summary

Re-applying the manifest after merging #332/#333 exposed that **every bootstrap run has been silently dying** right after the "Deployed files" listing — exit 1, zero error output — skipping the SkillClaw state step, Python dependency installation, auth checks, verification, and the final summary. (Check your past bootstrap output: it always ends at the file listing.)

## Root cause

`_skillclaw_remove_launchd` ended with:

```bash
[[ -f "$plist" ]] && { launchctl unload ...; rm -f "$plist"; }
```

When no retired launchd plist exists — the normal case on every machine — the `&&` list returns 1 **as the function's exit status**, and under `bootstrap.sh`'s `set -e` the bare call in `skillclaw_apply_state` aborts the whole script. Minimal repro confirmed the mechanism; the abort point matches the observed logs exactly. Rewritten as an explicit `if` + `return 0` (Darwin and Linux branches), with a regression test that runs `skillclaw_apply_state` under `set -e` with no plist present. A scan for the same last-command-of-function `&&` pattern across `bootstrap/lib/` found no other instances.

## Also included (defensive)

Extracted the deployed-files listing into a SIGPIPE-safe `list_deployed_files()` helper — `find | head -20 | while` exits 141 under `pipefail` once the target exceeds 20 files (~/.claude has ~3900). Bootstrap currently sets only `-e`, so this is hardening, not the root cause; tested either way.

## Verification

- Failing tests written first (skillclaw set -e regression + 2 listing tests), then green
- **Live: `./bootstrap.sh --skip-install --skip-auth --force` now exits 0** and runs the complete pipeline through "Setup Complete" — the first full bootstrap run this machine has ever had
- Full bats suite + 235 pytest pass; shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)