### PR TITLE
Refresh documentation set after PRs #332–#334 (/docs-all)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Parallel LLM agent orchestration framework for Claude Code, Cursor IDE, Gemini CLI, Codex CLI, and Antigravity IDE
 
-**Last Updated**: 2026-06-10
+**Last Updated**: 2026-06-12
 
 Manifest is a configuration repository that deploys a sophisticated parallel agent
 orchestration system to `~/.claude/`, `~/.cursor/`, `~/.gemini/`, `~/.codex/`, and `~/.antigravity/`, enabling Claude Code,
@@ -52,6 +52,8 @@ cd Manifest
 - **Consensus Scoring**: Variance-based algorithm calculates agreement (≥80% = high confidence, <50% = escalate + synthesis)
 - **Intelligent Model Selection**: Task-based routing (security→opus/gpt-5.2, review→sonnet/gpt-5.1-codex, quick→haiku/mini)
 - **Credit Exhaustion Fallback**: Automatic detection and retry with cheaper models (opus→sonnet→haiku)
+- **OAuth-Only Friendly**: Claude/Gemini agents auto-select SDK or CLI backends — no API keys
+  needed when the `claude`/`gemini` CLIs are logged in (SDK + API key still preferred when present)
 - **Cross-Platform**: Native support for macOS (Intel/Apple Silicon) and 5 major Linux distributions
 - **Unified Label Management**: Canonical label registry with sync across GitHub, GitLab, and Linear
 - **Production Templates**: Pre-configured permission templates for Django, Express, Go microservices, Python monorepos
@@ -129,6 +131,9 @@ Mermaid flowcharts showing bootstrap, execution, validation, and consensus flows
 - Python 3.9+ (3.12+ recommended, auto-detected by bootstrap)
 - Install deps: `pip install -r configs/claude/scripts/requirements.txt`
 - Key packages: `anthropic`, `google-genai`, `rich`, `pyyaml`, `aiohttp`
+- API keys are optional: with `ANTHROPIC_API_KEY`/`GOOGLE_API_KEY` set, the Claude/Gemini
+  agents use the SDK; without keys, they fall back to the logged-in `claude`/`gemini` CLIs
+  (OAuth subscription login works out of the box)
 
 ---
 
@@ -260,6 +265,9 @@ Manifest/
 ./bootstrap.sh --install-mcp
 ```
 
+The "Services to configure" banner and end-of-run summary reflect the effective
+configuration (existing `~/.claude/config/services.yml` merged with explicit CLI flags).
+
 ### Model Selection
 
 ```bash
@@ -275,6 +283,11 @@ Manifest/
   --claude-model haiku \
   "Quick question"
 ```
+
+Model tiers map to concrete pins in `~/.claude/config/parallel_agent.yml` (`model_tiers`),
+e.g. Gemini `flash`/`pro` → `gemini-3-flash-preview` / `gemini-3-pro-preview`. Verify pins
+against live provider listings with `model_check.sh` (add `MODEL_CHECK_PROBE=1` for a
+one-shot CLI probe per pin on OAuth-only machines without API keys).
 
 **See**: [Configuration Guide](docs/CONFIGURATION.md) for complete YAML reference, environment variables, and advanced options
 
@@ -297,6 +310,16 @@ cat ~/.claude/config/services.yml
 
 # Verify CLI tools installed
 which claude gemini cursor codex
+```
+
+**Model pins reported as unverified by check_status.sh:**
+
+```bash
+# Symptom: "N check(s) unverified (no API credentials ...)"
+# On OAuth-only machines there are no API keys to list models with, so
+# check_status.sh reports the pins as unverified rather than falsely green.
+# Live-verify each pin with a one-shot CLI probe (one tiny LLM call per pin):
+MODEL_CHECK_PROBE=1 ~/.claude/scripts/model_check.sh
 ```
 
 **Codex fails with session permission errors:**

--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -2,7 +2,7 @@
 
 > Visual documentation of the Manifest parallel LLM agent orchestration framework
 
-**Last Updated**: 2026-06-08
+**Last Updated**: 2026-06-12
 **Project**: Manifest - AI Agent Orchestration Framework
 
 ---
@@ -12,18 +12,20 @@
 1. [Application Architecture](#application-architecture)
 2. [Python Parallel Agent Architecture](#python-parallel-agent-architecture)
 3. [agents/ Package Module Dependency Graph](#agents-package-module-dependency-graph)
-4. [Git Platform Detection & Operations](#git-platform-detection--operations)
-5. [Bootstrap Installation Flow](#bootstrap-installation-flow)
-6. [Parallel Agent Execution Flow](#parallel-agent-execution-flow)
-7. [Skill Processing Architecture](#skill-processing-architecture)
-8. [Validation Pipeline](#validation-pipeline)
-9. [Model Selection & Credit Fallback](#model-selection--credit-fallback)
-10. [Configuration Layer](#configuration-layer)
-11. [Cross-Verification Consensus](#cross-verification-consensus)
-12. [Service State Management](#service-state-management)
-13. [Issue Management Architecture](#issue-management-architecture)
-14. [Label Management Architecture](#label-management-architecture)
-15. [SkillClaw Passive Ingest & Evolve Pipeline](#skillclaw-passive-ingest--evolve-pipeline)
+4. [Agent Backend Selection (SDK vs CLI Fallback)](#agent-backend-selection-sdk-vs-cli-fallback)
+5. [Git Platform Detection & Operations](#git-platform-detection--operations)
+6. [Bootstrap Installation Flow](#bootstrap-installation-flow)
+7. [Parallel Agent Execution Flow](#parallel-agent-execution-flow)
+8. [Skill Processing Architecture](#skill-processing-architecture)
+9. [Validation Pipeline](#validation-pipeline)
+10. [Model Selection & Credit Fallback](#model-selection--credit-fallback)
+11. [Model Pin Staleness Check](#model-pin-staleness-check)
+12. [Configuration Layer](#configuration-layer)
+13. [Cross-Verification Consensus](#cross-verification-consensus)
+14. [Service State Management](#service-state-management)
+15. [Issue Management Architecture](#issue-management-architecture)
+16. [Label Management Architecture](#label-management-architecture)
+17. [SkillClaw Passive Ingest & Evolve Pipeline](#skillclaw-passive-ingest--evolve-pipeline)
 
 ---
 
@@ -67,10 +69,11 @@ flowchart TB
     end
 
     subgraph "Agent Services"
-        GEMINI["Gemini CLI"]:::external
+        GEMINI["Gemini<br/>(SDK or gemini CLI)"]:::external
         CURSOR["Cursor Agent"]:::external
-        CLAUDE_API["Claude API"]:::external
+        CLAUDE_API["Claude<br/>(SDK or claude CLI)"]:::external
         CODEX["Codex CLI"]:::external
+        AGY["Antigravity CLI (agy)"]:::external
         GH["GitHub CLI (gh)"]:::external
         GLAB["GitLab CLI (glab)"]:::external
     end
@@ -97,6 +100,7 @@ flowchart TB
     PARALLEL_PY --> CURSOR
     PARALLEL_PY --> CLAUDE_API
     PARALLEL_PY --> CODEX
+    PARALLEL_PY --> AGY
     SERVICES -.->|config| PARALLEL_PY
     COMMAND_CFG -.->|thresholds| PARALLEL_PY
     VALIDATION_CFG -.->|criteria| PARALLEL_PY
@@ -110,7 +114,10 @@ flowchart TB
 - **parallel_agent.py**: Python orchestrator with full feature parity
   (logging, validation, synthesis, streaming, Codex agent, services.yml)
 - **Configuration Layer**: YAML files controlling behavior, validation rules, and Phase 3 features
-- **Agent Services**: External LLM and Git hosting CLIs
+- **Agent Services**: External LLM and Git hosting CLIs. Claude and Gemini execute via their
+  SDK when the package + API key are present, otherwise fall back to their OAuth-authenticated
+  CLI binaries (`claude` / `gemini`) through the generic CLIAgent — all five providers can run
+  through CLIAgent paths
 - **SkillClaw Subsystem**: Passive transcript ingestion pipeline — reads existing Claude Code
   session `.jsonl` files, scrubs secrets, distills candidate skills via `claude -p` (Max-backed
   map-reduce), and opens a PR-gated review into `.skillshare/skills/`; no daemon, no proxy
@@ -135,6 +142,7 @@ flowchart TB
 
     subgraph "agents/cli.py"
         MAIN["main()"]:::active
+        SELECT["select_backend()<br/>(sdk | cli | skip)"]:::active
     end
 
     subgraph "agents/config.py"
@@ -151,9 +159,9 @@ flowchart TB
 
     subgraph "agents/runners.py"
         BASE["BaseAgent<br/>(rate limiting, timeout, fallback)"]:::active
-        CLAUDE_AG["ClaudeAgent<br/>(streaming support)"]:::active
-        GEMINI_AG["GeminiAgent<br/>(dual package support)"]:::active
-        CLI_AG["CLIAgent<br/>(cursor | codex | antigravity, config-driven)"]:::active
+        CLAUDE_AG["ClaudeAgent<br/>(SDK, streaming support)"]:::active
+        GEMINI_AG["GeminiAgent<br/>(SDK, dual package support)"]:::active
+        CLI_AG["CLIAgent<br/>(claude | gemini | cursor | codex | antigravity,<br/>config-driven)"]:::active
     end
 
     subgraph "agents/validation.py + synthesis.py"
@@ -164,7 +172,7 @@ flowchart TB
     subgraph "External APIs"
         ANTHROPIC["Anthropic API<br/>(Claude)"]:::external
         GOOGLE["Google Gemini API<br/>(OAuth/API key)"]:::external
-        CLI_BINS["CLI binaries<br/>(cursor | codex | agy)"]:::external
+        CLI_BINS["CLI binaries<br/>(claude | gemini | cursor | codex | agy)"]:::external
     end
 
     subgraph "Configuration Files"
@@ -184,6 +192,10 @@ flowchart TB
     MAIN --> CONFIG
     MAIN --> SVC_CFG
     MAIN --> LOGGER
+    MAIN --> SELECT
+    SELECT -.->|sdk| CLAUDE_AG
+    SELECT -.->|sdk| GEMINI_AG
+    SELECT -.->|cli fallback| CLI_AG
     MAIN --> ORCH
     CONFIG -.->|load| PA_YML
     SVC_CFG -.->|load| SVC_YML
@@ -225,28 +237,34 @@ flowchart TB
 - **SynthesisEngine**: Automatic disagreement resolution when consensus < 50%, uses Claude Sonnet with synthesis.md template
 - **Streaming**: Real-time Rich Live display with progressive updates (4 updates/sec, 500 char truncation)
 - **RateLimiter**: Token bucket algorithm with burst support and adaptive backoff
-- **CLIAgent**: Generic YAML-driven subprocess agent; provider variation (cursor | codex |
-  antigravity) is config data in the `cli_agents:` block — no per-provider subclass needed
+- **select_backend()**: Per-provider backend picker for SDK-capable providers (Claude, Gemini):
+  SDK when package + API key are both present, else OAuth-authenticated CLI binary via CLIAgent,
+  else SDK-own-auth (ADC/OAuth), else skip with a warning — never a crashed orchestration
+- **CLIAgent**: Generic YAML-driven subprocess agent; provider variation (claude | gemini |
+  cursor | codex | antigravity) is config data in the `cli_agents:` block — no per-provider
+  subclass needed. The claude/gemini entries back the OAuth CLI fallback
 - **Dual Package Support**: google-genai (new) with fallback to google-generativeai (legacy), unified interface
 
 **Execution Flow**:
 
 1. **Initialization**: Load config + services.yml, create logger with correlation ID, set up rate limiters
 2. **Agent Selection**: services.yml state -> `--*-only` exclusive flags -> `--no-*` overrides -> minimum agent check
-3. **Agent Execution**: Run Claude/Gemini/Cursor/Codex in parallel with streaming or progress display
-4. **Consensus**: Calculate consensus score using keyword-based analysis
-5. **Synthesis**: If consensus < 50%, trigger SynthesisEngine for unified recommendation
-6. **Validation**: Run ValidationEngine if `--validate` flag set
-7. **Output**: Write structured logs, JSON results (with duration), markdown summary (sandbox-aware fallback)
+3. **Backend Selection**: `select_backend()` picks SDK vs CLI fallback for Claude/Gemini;
+   Cursor/Codex/Antigravity always run via CLIAgent
+4. **Agent Execution**: Run Claude/Gemini/Cursor/Codex/Antigravity in parallel with streaming or progress display
+5. **Consensus**: Calculate consensus score using keyword-based analysis
+6. **Synthesis**: If consensus < 50%, trigger SynthesisEngine for unified recommendation
+7. **Validation**: Run ValidationEngine if `--validate` flag set
+8. **Output**: Write structured logs, JSON results (with duration), markdown summary (sandbox-aware fallback)
 
 **Statistics**:
 
 - Modules: 6 (`config`, `runners`, `synthesis`, `validation`, `orchestrator`, `cli`) + `__init__`
-- Classes: 10 (Config, ServiceConfig, Logger, RateLimiter, ValidationEngine, SynthesisEngine,
+- Classes: 11 (Config, ServiceConfig, Logger, RateLimiter, ValidationEngine, SynthesisEngine,
   BaseAgent, ClaudeAgent, GeminiAgent, CLIAgent, Orchestrator)
-- CLI Flags: 30 (argparse in `agents/cli.py`)
+- CLI Flags: 28 (argparse in `agents/cli.py`)
 - Agents: 5 (Claude, Gemini, Cursor, Codex, Antigravity)
-- Total lines: ~2,400 across package (~27-line entry point)
+- Total lines: ~2,540 across package (27-line entry point)
 
 ---
 
@@ -305,6 +323,65 @@ flowchart LR
 
 **Design principle**: Dependency arrows flow strictly bottom-up. No circular imports.
 `config.py` is independently testable; `orchestrator.py` is testable without `cli.py`.
+
+---
+
+## Agent Backend Selection (SDK vs CLI Fallback)
+
+How `select_backend()` in `agents/cli.py` picks an execution backend for the SDK-capable
+providers (Claude, Gemini). The SDK is preferred only when both the package and its API key
+are present; otherwise the OAuth-authenticated provider CLI (`claude` / `gemini`) is used via
+the generic CLIAgent — the common subscription-login setup needs no API key. An installed SDK
+may carry its own auth (ADC/OAuth), so it is tried before the provider is skipped.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart TD
+    classDef input fill:#f0f9ff,stroke:#0284c7,color:#0c4a6e
+    classDef decision fill:#fef3c7,stroke:#d97706,color:#78350f
+    classDef sdk fill:#22c55e,stroke:#166534,color:#fff
+    classDef cli fill:#3b82f6,stroke:#1d4ed8,color:#fff
+    classDef skip fill:#ef4444,stroke:#dc2626,color:#fff
+
+    PROVIDER["Enabled SDK-capable provider<br/>(claude | gemini)"]:::input
+
+    SDK_KEY{"SDK package installed<br/>AND API key set?<br/>(ANTHROPIC_API_KEY /<br/>GOOGLE_API_KEY)"}:::decision
+    CLI_PATH{"Provider CLI on PATH?<br/>(claude / gemini binary)"}:::decision
+    SDK_ONLY{"SDK package<br/>installed?"}:::decision
+
+    SDK_BACKEND["backend = sdk<br/>ClaudeAgent / GeminiAgent"]:::sdk
+    CLI_BACKEND["backend = cli<br/>CLIAgent (OAuth-authenticated CLI,<br/>cli_agents: claude/gemini entry)"]:::cli
+    SDK_OWN_AUTH["backend = sdk<br/>(SDK-own-auth: ADC/OAuth)"]:::sdk
+    SKIP["Skip provider<br/>(warning, never a crash)"]:::skip
+
+    CONSTRUCT{"Agent construction<br/>raises?<br/>(missing key, broken auth,<br/>malformed cli_agents)"}:::decision
+    AGENTS["Agent joins the<br/>parallel run"]:::sdk
+
+    PROVIDER --> SDK_KEY
+    SDK_KEY -->|Yes| SDK_BACKEND
+    SDK_KEY -->|No| CLI_PATH
+    CLI_PATH -->|Yes| CLI_BACKEND
+    CLI_PATH -->|No| SDK_ONLY
+    SDK_ONLY -->|Yes| SDK_OWN_AUTH
+    SDK_ONLY -->|No| SKIP
+
+    SDK_BACKEND --> CONSTRUCT
+    CLI_BACKEND --> CONSTRUCT
+    SDK_OWN_AUTH --> CONSTRUCT
+    CONSTRUCT -->|No| AGENTS
+    CONSTRUCT -->|Yes| SKIP
+```
+
+**Key points**:
+
+- **Cursor / Codex / Antigravity** have no SDK path — they always run via CLIAgent and bypass
+  `select_backend()` entirely
+- **All five providers** can therefore execute through CLIAgent paths; the `cli_agents:` block
+  in `parallel_agent.yml` carries the per-provider argv shape (`base_args`, `model_args`,
+  `prompt_args`, output strategy)
+- **Degradation is per-provider**: a failed backend (exception at construction) skips just that
+  provider with a warning; orchestration continues with the remaining agents subject to the
+  minimum-agent check
 
 ---
 
@@ -372,7 +449,11 @@ flowchart LR
 
 ## Bootstrap Installation Flow
 
-Complete installation and configuration deployment process with Git CLI auto-detection.
+Complete installation and configuration deployment process. Mirrors `main()` in
+`bootstrap.sh` plus the routines in `bootstrap/lib/`: the services banner is printed
+**after** the existing config is loaded (so displayed toggles match what deploys), and
+soft-failure guards keep `set -e` from aborting the pipeline mid-flight — the full
+deploy → skillclaw state → python deps → auth → verify → summary sequence always runs.
 
 ```mermaid
 %%{init: {'theme':'neutral'}}%%
@@ -382,123 +463,82 @@ flowchart TD
     classDef decision fill:#fef3c7,stroke:#d97706,color:#78350f
     classDef success fill:#22c55e,stroke:#166534,color:#fff
     classDef skip fill:#e5e7eb,stroke:#6b7280,color:#374151
+    classDef warning fill:#eab308,stroke:#a16207,color:#fff
 
     START["./bootstrap.sh"]:::input
-    PARSE_ARGS["Parse CLI Arguments<br/>(--enable/--disable flags)"]:::process
-    DETECT_PLATFORM["Detect OS Platform<br/>(macOS, Linux distro)"]:::process
+    LOAD_LIBS["Load bootstrap/lib/*.sh<br/>+ parse CLI arguments"]:::process
 
-    LOAD_CONFIG{"Load Existing<br/>services.yml?"}:::decision
-    MERGE_CONFIG["Merge File Config<br/>with CLI Args"]:::process
+    RECONFIG{"--reconfigure?"}:::decision
+    RECONFIG_PATH["Reconfigure path:<br/>services.yml → skillclaw state<br/>→ python deps + browser-use"]:::process
 
-    INSTALL_PKG["Install Package Manager<br/>(Homebrew on macOS)"]:::process
-    INSTALL_NODE["Install Node.js<br/>(for npm CLIs)"]:::process
+    LOAD_CONFIG["Load existing services.yml<br/>(merge with CLI flags;<br/>explicit flags win)"]:::process
+    BANNER["Show services banner<br/>(printed AFTER config load —<br/>reflects merged toggles)"]:::process
+    CONFIRM{"Continue<br/>with setup?"}:::decision
+    CANCELLED["Setup cancelled"]:::skip
 
-    CHECK_CLAUDE{"Claude<br/>Enabled?"}:::decision
-    INSTALL_CLAUDE["Install Claude CLI<br/>(npm install -g)"]:::process
-    SKIP_CLAUDE["Skip Claude"]:::skip
+    PLATFORM["Check platform +<br/>create ~/.manifest state dirs"]:::process
 
-    CHECK_GEMINI{"Gemini<br/>Enabled?"}:::decision
-    INSTALL_GEMINI["Install Gemini CLI<br/>(npm install -g)"]:::process
-    SKIP_GEMINI["Skip Gemini"]:::skip
+    SKIP_INSTALL{"--skip-install?"}:::decision
+    INSTALLS["Install CLIs (soft-fail, counted):<br/>package manager · node · claude<br/>gemini · codex · gh · glab · jq · cursor"]:::process
 
-    CHECK_GH{"GitHub CLI<br/>Enabled/Auto?"}:::decision
-    AUTO_GH{"gh already<br/>installed?"}:::decision
-    INSTALL_GH["Install GitHub CLI<br/>(brew/apt/dnf)"]:::process
-    SKIP_GH["Disable GitHub CLI"]:::skip
+    DEPLOY["deploy_configs<br/>(~/.claude primary; chmod +x<br/>scripts/*.sh AND *.py;<br/>write services.yml)"]:::process
+    SKILLCLAW["skillclaw_apply_state<br/>(launchd cleanup guarded —<br/>no set -e abort)"]:::process
+    PYDEPS["Install python deps<br/>+ browser-use (if enabled)"]:::process
 
-    CHECK_GLAB{"GitLab CLI<br/>Enabled/Auto?"}:::decision
-    AUTO_GLAB{"glab already<br/>installed?"}:::decision
-    INSTALL_GLAB["Install GitLab CLI<br/>(brew/apt/dnf)"]:::process
-    SKIP_GLAB["Disable GitLab CLI"]:::skip
+    MCP{"--install-mcp?"}:::decision
+    INSTALL_MCP["Configure MCP servers<br/>(interactive per-server)"]:::process
 
-    CHECK_JQ["Check jq<br/>(required by git_ops.sh)"]:::process
-    INSTALL_JQ["Install jq"]:::process
+    SKIP_AUTH{"--skip-auth?"}:::decision
+    AUTH["Auth checks (soft-fail, counted):<br/>claude · gemini · codex<br/>gh · glab · cursor info"]:::process
 
-    CHECK_CURSOR{"Cursor<br/>Enabled?"}:::decision
-    OPEN_CURSOR["Open Cursor<br/>Download Page"]:::process
-    SKIP_CURSOR["Skip Cursor"]:::skip
+    VERIFY["verify_installation<br/>(errors counted, never aborts)"]:::process
+    SUMMARY["print_summary<br/>(quick-start + auth guidance)"]:::process
+    DONE["Installation complete"]:::success
+    EXIT_WARN["Exit 1 if verification<br/>reported errors"]:::warning
 
-    CHECK_SKILLCLAW{"SkillClaw<br/>Enabled?"}:::decision
-    INSTALL_SKILLCLAW["Enable SkillClaw<br/>chmod 700 storage<br/>(transcript evolution; no daemon)"]:::process
-    SKIP_SKILLCLAW["Skip SkillClaw"]:::skip
-
-    DEPLOY["Deploy Config Files<br/>(~/.claude, ~/.cursor, ~/.gemini)"]:::process
-    WRITE_SERVICES["Write services.yml<br/>(with final toggles)"]:::process
-
-    AUTH_CLAUDE["Setup Claude Auth"]:::process
-    AUTH_GEMINI["Setup Gemini Auth"]:::process
-    AUTH_GH["Setup GitHub Auth<br/>(gh auth login)"]:::process
-    AUTH_GLAB["Setup GitLab Auth<br/>(glab auth login)"]:::process
-
-    VERIFY["Verify Installation<br/>(check files, CLIs, scripts)"]:::process
-    DONE["Installation Complete"]:::success
-
-    START --> PARSE_ARGS
-    PARSE_ARGS --> DETECT_PLATFORM
-    DETECT_PLATFORM --> LOAD_CONFIG
-
-    LOAD_CONFIG -->|Yes| MERGE_CONFIG
-    LOAD_CONFIG -->|No| INSTALL_PKG
-    MERGE_CONFIG --> INSTALL_PKG
-
-    INSTALL_PKG --> INSTALL_NODE
-    INSTALL_NODE --> CHECK_CLAUDE
-
-    CHECK_CLAUDE -->|Yes| INSTALL_CLAUDE
-    CHECK_CLAUDE -->|No| SKIP_CLAUDE
-    INSTALL_CLAUDE --> CHECK_GEMINI
-    SKIP_CLAUDE --> CHECK_GEMINI
-
-    CHECK_GEMINI -->|Yes| INSTALL_GEMINI
-    CHECK_GEMINI -->|No| SKIP_GEMINI
-    INSTALL_GEMINI --> CHECK_GH
-    SKIP_GEMINI --> CHECK_GH
-
-    CHECK_GH -->|Enabled| INSTALL_GH
-    CHECK_GH -->|Auto| AUTO_GH
-    CHECK_GH -->|Disabled| SKIP_GH
-    AUTO_GH -->|Yes| SKIP_GH
-    AUTO_GH -->|No| SKIP_GH
-    INSTALL_GH --> CHECK_GLAB
-    SKIP_GH --> CHECK_GLAB
-
-    CHECK_GLAB -->|Enabled| INSTALL_GLAB
-    CHECK_GLAB -->|Auto| AUTO_GLAB
-    CHECK_GLAB -->|Disabled| SKIP_GLAB
-    AUTO_GLAB -->|Yes| SKIP_GLAB
-    AUTO_GLAB -->|No| SKIP_GLAB
-    INSTALL_GLAB --> CHECK_JQ
-    SKIP_GLAB --> CHECK_JQ
-
-    CHECK_JQ -->|Not Found| INSTALL_JQ
-    CHECK_JQ -->|Found| CHECK_CURSOR
-    INSTALL_JQ --> CHECK_CURSOR
-
-    CHECK_CURSOR -->|Yes| OPEN_CURSOR
-    CHECK_CURSOR -->|No| SKIP_CURSOR
-    OPEN_CURSOR --> CHECK_SKILLCLAW
-    SKIP_CURSOR --> CHECK_SKILLCLAW
-
-    CHECK_SKILLCLAW -->|Yes| INSTALL_SKILLCLAW
-    CHECK_SKILLCLAW -->|No| SKIP_SKILLCLAW
-    INSTALL_SKILLCLAW --> DEPLOY
-    SKIP_SKILLCLAW --> DEPLOY
-
-    DEPLOY --> WRITE_SERVICES
-    WRITE_SERVICES --> AUTH_CLAUDE
-    AUTH_CLAUDE --> AUTH_GEMINI
-    AUTH_GEMINI --> AUTH_GH
-    AUTH_GH --> AUTH_GLAB
-    AUTH_GLAB --> VERIFY
-    VERIFY --> DONE
+    START --> LOAD_LIBS
+    LOAD_LIBS --> RECONFIG
+    RECONFIG -->|Yes| RECONFIG_PATH
+    RECONFIG_PATH --> DONE
+    RECONFIG -->|No| LOAD_CONFIG
+    LOAD_CONFIG --> BANNER
+    BANNER --> CONFIRM
+    CONFIRM -->|No| CANCELLED
+    CONFIRM -->|Yes| PLATFORM
+    PLATFORM --> SKIP_INSTALL
+    SKIP_INSTALL -->|No| INSTALLS
+    SKIP_INSTALL -->|Yes| DEPLOY
+    INSTALLS --> DEPLOY
+    DEPLOY --> SKILLCLAW
+    SKILLCLAW --> PYDEPS
+    PYDEPS --> MCP
+    MCP -->|Yes| INSTALL_MCP
+    MCP -->|No| SKIP_AUTH
+    INSTALL_MCP --> SKIP_AUTH
+    SKIP_AUTH -->|No| AUTH
+    SKIP_AUTH -->|Yes| VERIFY
+    AUTH --> VERIFY
+    VERIFY --> SUMMARY
+    SUMMARY --> DONE
+    SUMMARY -.-> EXIT_WARN
 ```
 
 **Key Features**:
 
+- **Banner after config load**: the services banner is printed only after
+  `load_existing_config` merges `services.yml` with CLI flags, so the displayed toggles
+  always match what will actually be deployed
+- **Soft-fail install/auth/verify**: per-tool installs, auth checks, and
+  `verify_installation` return error counts instead of aborting under `set -e`; the
+  pipeline always reaches the summary (verification errors still exit 1 at the end)
+- **Deploy chmod covers Python**: `deploy_configs` marks both `scripts/*.sh` and
+  `scripts/*.py` executable
+- **skillclaw_apply_state runs unconditionally after deploy**: applies enable/disable state
+  and removes any legacy launchd capture daemon; the launchd cleanup is guarded so a missing
+  service can no longer abort the rest of the bootstrap (python deps, auth, verify, summary)
 - **Auto-Detection**: gh/glab default to `auto` mode (enable if already installed)
 - **Platform-Specific Install**: Uses appropriate package manager (brew/apt/dnf/pacman)
 - **Dependency Checking**: Verifies jq is installed (required for git_ops.sh JSON normalization)
-- **Service Toggles**: Writes final enabled/disabled state to services.yml
 - **SkillClaw (disabled by default)**: When `--enable-skillclaw` is passed, sets `chmod 700`
   on `~/.skillclaw/` and enables the passive transcript-ingestion pipeline; no proxy, no daemon,
   no supervisor required
@@ -530,9 +570,9 @@ flowchart TB
     CHECK_SERVICES{"Check<br/>services.yml"}:::decision
 
     subgraph "Agent Execution (Parallel)"
-        GEMINI_EXEC["Gemini CLI<br/>(gemini-3-flash-preview / 3-pro-preview)"]:::process
+        GEMINI_EXEC["Gemini — SDK or gemini CLI<br/>(gemini-3-flash-preview / 3-pro-preview)"]:::process
         CURSOR_EXEC["Cursor Agent<br/>(gpt-5.1/5.2)"]:::process
-        CLAUDE_EXEC["Claude CLI<br/>(haiku/sonnet/opus/fable)"]:::process
+        CLAUDE_EXEC["Claude — SDK or claude CLI<br/>(haiku/sonnet/opus/fable)"]:::process
         CODEX_EXEC["Codex CLI<br/>(gpt-5.4-mini/gpt-5.4/gpt-5.5)"]:::process
         AGY_EXEC["Antigravity CLI<br/>(agy, Gemini 3.5 Flash (High))"]:::process
     end
@@ -601,6 +641,9 @@ flowchart TB
 
 - **Sandbox Detection**: Auto-detects write restrictions and falls back to `/tmp` if needed
 - **Parallel Execution**: All enabled agents run simultaneously via background processes
+- **Backend Selection**: Claude/Gemini run via SDK when package + API key are present,
+  otherwise via their OAuth-authenticated CLI through CLIAgent (see
+  [Agent Backend Selection](#agent-backend-selection-sdk-vs-cli-fallback))
 - **Output Verification**: Explicit check that files were created before proceeding
 - **Retry Logic**: Failed agents retry once after 5s delay
 - **Credit Fallback**: Automatically retries with cheaper models on quota errors
@@ -844,13 +887,19 @@ flowchart TD
 **Cursor Fallback Chain**:
 
 ```text
-gpt-5.2 (advanced) → gpt-5.1-codex (flash) → gpt-5.1-codex-mini (mini) → auto
+gpt-5.2 (advanced) → gpt-5.1-codex (flash) → gpt-5.1-codex-mini (mini)
 ```
 
 **Claude Fallback Chain**:
 
 ```text
 fable → opus → sonnet → haiku
+```
+
+**Gemini Fallback Chain**:
+
+```text
+gemini-3-pro-preview (pro) → gemini-3-flash-preview (flash)
 ```
 
 **Codex Fallback Chain**:
@@ -865,6 +914,86 @@ The script parses stderr for patterns:
 - "credit", "quota", "rate limit", "insufficient"
 - Automatically retries with next cheaper model
 - Continues with available agents if one exhausts credits
+
+---
+
+## Model Pin Staleness Check
+
+How `model_check.sh` verifies the `model_tiers` pins in `parallel_agent.yml` against live
+provider listings, including the opt-in live-probe mode (`MODEL_CHECK_PROBE=1`) for
+OAuth-only machines, and how `check_status.sh` reports the result honestly
+(stale / unverified / verified). Warn-only: every failure degrades to SKIPPED and the
+exit code is always 0.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart TD
+    classDef input fill:#f0f9ff,stroke:#0284c7,color:#0c4a6e
+    classDef process fill:#f0fdf4,stroke:#16a34a,color:#14532d
+    classDef decision fill:#fef3c7,stroke:#d97706,color:#78350f
+    classDef ok fill:#22c55e,stroke:#166534,color:#fff
+    classDef warn fill:#eab308,stroke:#a16207,color:#fff
+    classDef stale fill:#ef4444,stroke:#dc2626,color:#fff
+
+    CALLER["check_status.sh /<br/>/health-check"]:::input
+    MODEL_CHECK["model_check.sh<br/>(reads model_tiers pins)"]:::process
+
+    API_KEY{"API key set?<br/>(claude / gemini)"}:::decision
+    LISTING["List models via API<br/>(api.anthropic.com /<br/>generativelanguage)"]:::process
+    PROBE_OPT{"MODEL_CHECK_PROBE=1<br/>and CLI installed?"}:::decision
+    PROBE["Live one-shot probe per pin<br/>(claude --model X -p /<br/>gemini -m X -p)"]:::process
+
+    AGY_LIST["antigravity: agy models<br/>listing check"]:::process
+    UNSUP["cursor / codex:<br/>UNSUPPORTED<br/>(no listing command)"]:::warn
+
+    PIN_OK["OK<br/>(pin verified)"]:::ok
+    PIN_STALE["STALE<br/>(pin not served)"]:::stale
+    PIN_SKIP["SKIPPED<br/>(no credentials /<br/>probe failed)"]:::warn
+
+    AGG{"check_status.sh<br/>aggregation"}:::decision
+    REPORT_STALE["⚠ N stale model pin(s) —<br/>update model_tiers"]:::stale
+    REPORT_UNVER["○ N check(s) unverified —<br/>run MODEL_CHECK_PROBE=1<br/>for a live CLI probe"]:::warn
+    REPORT_OK["✓ all pins verified"]:::ok
+
+    CALLER --> MODEL_CHECK
+    MODEL_CHECK --> API_KEY
+    MODEL_CHECK --> AGY_LIST
+    MODEL_CHECK --> UNSUP
+    API_KEY -->|Yes| LISTING
+    API_KEY -->|No| PROBE_OPT
+    PROBE_OPT -->|Yes| PROBE
+    PROBE_OPT -->|No| PIN_SKIP
+    LISTING --> PIN_OK
+    LISTING --> PIN_STALE
+    PROBE --> PIN_OK
+    PROBE --> PIN_STALE
+    PROBE --> PIN_SKIP
+    AGY_LIST --> PIN_OK
+    AGY_LIST --> PIN_STALE
+
+    PIN_OK --> AGG
+    PIN_STALE --> AGG
+    PIN_SKIP --> AGG
+    AGG -->|stale > 0| REPORT_STALE
+    AGG -->|skipped > 0| REPORT_UNVER
+    AGG -->|all OK| REPORT_OK
+```
+
+**Check modes per provider**:
+
+| Provider | With API key | Without API key | Notes |
+|----------|--------------|-----------------|-------|
+| claude | `GET /v1/models` listing | `MODEL_CHECK_PROBE=1`: one tiny `claude --model <pin> -p` call per pin; else SKIPPED | Probe needed because OAuth-only machines have no key — broken pins would otherwise read as green |
+| gemini | `GET /v1beta/models` listing | `MODEL_CHECK_PROBE=1`: one tiny `gemini -m <pin> -p` call per pin; else SKIPPED | Current pins: `gemini-3-flash-preview` / `gemini-3-pro-preview` |
+| antigravity | n/a | `agy models` listing (no key needed) | CLI listing only |
+| cursor / codex | n/a | n/a | UNSUPPORTED — no model-listing command |
+
+**Honest reporting** (`check_status.sh`):
+
+- Any STALE pins → yellow warning with count (update `model_tiers`)
+- Any SKIPPED checks → "unverified" line suggesting `MODEL_CHECK_PROBE=1 model_check.sh`;
+  the green "all pins verified" line never overclaims what was actually checked
+- All OK → green "Model pin check complete — all pins verified"
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,7 +2,7 @@
 
 > Comprehensive reference for all Manifest configuration options
 
-**Last Updated**: 2026-06-08
+**Last Updated**: 2026-06-12
 **Audience**: System operators, advanced users
 **Prerequisites**: Manifest installed via bootstrap.sh or manually
 
@@ -17,8 +17,9 @@
 5. [Validation Criteria](#validation-criteria)
 6. [Model Selection](#model-selection)
 7. [Environment Variables](#environment-variables)
-8. [Command-Line Options](#command-line-options)
-9. [Override Precedence](#override-precedence)
+8. [CLI Agent Command Configuration](#cli-agent-command-configuration)
+9. [Command-Line Options](#command-line-options)
+10. [Override Precedence](#override-precedence)
 
 ---
 
@@ -680,6 +681,27 @@ export GEMINI_MODEL_FLASH="gemini-3-flash-preview"
 export GEMINI_MODEL_PRO="gemini-3-pro-preview"
 ```
 
+### Provider API Keys (Optional)
+
+```bash
+# When set (and the SDK package is installed), Claude/Gemini run via the SDK.
+# When unset, they fall back to the logged-in `claude` / `gemini` CLIs (OAuth).
+export ANTHROPIC_API_KEY="sk-ant-..."   # Claude SDK backend
+export GOOGLE_API_KEY="AIza..."         # Gemini SDK backend
+```
+
+### Model Pin Verification
+
+```bash
+# Live one-shot CLI probe per claude/gemini pin (one tiny LLM call each) —
+# use on OAuth-only machines where no API key is available to list models
+MODEL_CHECK_PROBE=1 ~/.claude/scripts/model_check.sh
+
+# Override the probe binaries (e.g. test doubles)
+export MODEL_CHECK_CLAUDE_BIN="claude"
+export MODEL_CHECK_GEMINI_BIN="gemini"
+```
+
 ### Spec Review Configuration
 
 ```bash
@@ -709,6 +731,20 @@ is configuration-only — define its command shape here plus `model_tiers`,
 
 ```yaml
 cli_agents:
+  # claude/gemini entries back the OAuth CLI fallback: used when the provider
+  # SDK or its API key is unavailable but the CLI is installed and logged in.
+  claude:
+    binary: claude
+    base_args: []
+    model_args: ["--model", "{model}"]
+    prompt_args: ["-p", "{prompt}"]
+    output: stdout
+  gemini:
+    binary: gemini
+    base_args: []
+    model_args: ["-m", "{model}"]
+    prompt_args: ["-p", "{prompt}"]
+    output: stdout
   cursor:
     binary: cursor
     base_args: []
@@ -722,14 +758,31 @@ cli_agents:
     output: file_then_stdout
   antigravity:
     binary: agy
-    base_args: ["--print"]
+    base_args: []
     model_args: ["--model", "{model}"]
+    prompt_args: ["--print", "{prompt}"]
     output: stdout
 ```
 
 `output: file_then_stdout` reads the tempfile first, falling back to stdout;
-`output: stdout` streams directly. `{model}` and `{output_file}` are substitution
-tokens filled at runtime.
+`output: stdout` streams directly. `{model}`, `{prompt}`, and `{output_file}` are
+substitution tokens filled at runtime.
+
+### Execution Backend (SDK vs CLI Fallback)
+
+Claude and Gemini pick an execution backend per run (`agents/cli.py`
+`select_backend()`):
+
+1. **SDK** — when the provider package (`anthropic` / `google-genai`) AND its API
+   key (`ANTHROPIC_API_KEY` / `GOOGLE_API_KEY`) are both present.
+2. **CLI fallback** — otherwise, when the provider CLI (`claude` / `gemini`) is on
+   PATH. OAuth/subscription logins work here with no API key — this is the default
+   path on machines authenticated via `claude` / Gemini OAuth login.
+3. **SDK with its own auth** (ADC/OAuth) as a last resort, else the provider is
+   skipped with a warning.
+
+The CLI fallback uses the `cli_agents.claude` / `cli_agents.gemini` command shapes
+above. Cursor, Codex, and Antigravity always run via their CLI entries.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 > Step-by-step guide to installing and using the Manifest parallel agent orchestration framework
 
-**Last Updated**: 2026-06-08
+**Last Updated**: 2026-06-12
 **Audience**: New users
 **Prerequisites**: macOS 10.15+ or Linux, internet connection
 **Estimated Time**: 10-15 minutes
@@ -28,6 +28,7 @@ Manifest deploys a parallel LLM agent orchestration system that enables Claude C
 - **Gemini CLI**: Broad knowledge and creative solutions
 - **Claude CLI**: Deep reasoning and security analysis
 - **Codex CLI**: Terminal-based coding agent with sandbox execution
+- **Antigravity (agy)**: Independent IDE-backed agent for cross-family verification
 
 These agents run in parallel, analyze the same task from different perspectives,
 and their outputs are synthesized with consensus scoring to provide higher-quality
@@ -101,7 +102,8 @@ npm install -g @google/gemini-cli
 # Visit: https://cursor.sh
 
 # 4. Deploy configuration
-cp -r .claude/* ~/.claude/
+cp -r configs/claude/* ~/.claude/
+cp -r configs/claude/.[!.]* ~/.claude/ 2>/dev/null || true
 chmod +x ~/.claude/scripts/*.sh ~/.claude/scripts/parallel_agent.py
 
 # 5. Configure services (see Configuration section)
@@ -161,6 +163,11 @@ Run a simple test to verify all agents are working:
 
 - `status: "missing"` → Agent CLI not installed
 - `status: "failed"` → Authentication issue or quota exceeded
+
+> **No API keys required**: the Claude and Gemini agents pick an execution backend
+> per run — the provider SDK when its package and API key
+> (`ANTHROPIC_API_KEY` / `GOOGLE_API_KEY`) are both present, otherwise the
+> logged-in `claude` / `gemini` CLI. OAuth/subscription logins work out of the box.
 
 See [Troubleshooting](TROUBLESHOOTING.md) for solutions.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 > Complete documentation index for the Manifest parallel agent orchestration framework
 
-**Last Updated**: 2026-06-08
+**Last Updated**: 2026-06-12
 
 ---
 
@@ -37,7 +37,8 @@
 |----------|-------------|----------|
 | [Architecture Diagrams](ARCHITECTURE_DIAGRAMS.md) | System design and data flows | Understanding internals |
 | [CLAUDE.md](../CLAUDE.md) | Repository context and structure | Contributing code |
-| [.claude/CLAUDE.md](../.claude/CLAUDE.md) | Orchestration guide (deployed version) | Deep dive into orchestration |
+| [.claude/CLAUDE.md](../.claude/CLAUDE.md) | Repo developer guide (skillshare, tests, conventions) | Working inside this repo |
+| [configs/claude/CLAUDE.md](../configs/claude/CLAUDE.md) | Orchestration guide (deployed to `~/.claude/`) | Deep dive into orchestration |
 
 ### For Contributors
 
@@ -54,7 +55,7 @@
 
 | File | Description | Last Updated | Status |
 |------|-------------|--------------|--------|
-| [README.md](../README.md) | Project overview and quick start | 2026-06-08 | ✅ |
+| [README.md](../README.md) | Project overview and quick start | 2026-06-12 | ✅ |
 | [CLAUDE.md](../CLAUDE.md) | AI assistant context for the repository | 2026-02-11 | ✅ |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | How to contribute to the project | 2026-05-31 | ✅ |
 | [CHANGELOG.md](../CHANGELOG.md) | Version history and release notes | 2026-05-31 | ✅ |
@@ -63,17 +64,21 @@
 
 | File | Description | Last Updated | Status |
 |------|-------------|--------------|--------|
-| [GETTING_STARTED.md](GETTING_STARTED.md) | First-time user guide | 2026-06-08 | ✅ |
-| [CONFIGURATION.md](CONFIGURATION.md) | Configuration reference | 2026-06-08 | ✅ |
-| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Common issues and solutions | 2026-06-08 | ✅ |
+| [GETTING_STARTED.md](GETTING_STARTED.md) | First-time user guide | 2026-06-12 | ✅ |
+| [CONFIGURATION.md](CONFIGURATION.md) | Configuration reference | 2026-06-12 | ✅ |
+| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Common issues and solutions | 2026-06-12 | ✅ |
+| [COMMANDS.md](COMMANDS.md) | Built-in commands and how to build custom ones | 2026-06-10 | ✅ |
 
 ### Technical Documentation
 
 | File | Description | Last Updated | Status |
 |------|-------------|--------------|--------|
-| [ARCHITECTURE_DIAGRAMS.md](ARCHITECTURE_DIAGRAMS.md) | Visual system documentation | 2026-06-08 | ✅ |
+| [ARCHITECTURE_DIAGRAMS.md](ARCHITECTURE_DIAGRAMS.md) | Visual system documentation | 2026-06-12 | ✅ |
 | [SKILLCLAW.md](SKILLCLAW.md) | SkillClaw session-capture and skill-evolution guide | 2026-06-08 | ✅ |
 | [SPEC-SYSTEMS.md](SPEC-SYSTEMS.md) | Map of the four spec/plan systems and when to use each | 2026-06-10 | ✅ |
+| [METRICS.md](METRICS.md) | Agent performance dashboard template (`/dashboard`) | 2026-02-11 | ✅ |
+| [KNOWLEDGE_BASE.md](KNOWLEDGE_BASE.md) | Auto-generated captured learnings (`learning_capture.sh sync-docs`) | 2026-02-13 | ✅ |
+| [PRE_COMMIT.md](PRE_COMMIT.md) | Pre-commit hook reference | 2026-02-05 | ✅ |
 
 ### Internal Documentation
 
@@ -162,6 +167,11 @@ services:
 
 **Recent Additions**:
 
+- ✅ 2026-06-12: Documented the OAuth CLI fallback (SDK vs CLI backend selection for
+  Claude/Gemini), `MODEL_CHECK_PROBE=1` live model-pin verification, and the honest
+  `check_status.sh` pin summary — README, architecture diagrams,
+  CONFIGURATION/GETTING_STARTED/TROUBLESHOOTING; fixed stale deploy paths
+  (`.claude/` → `configs/claude/`) and output paths (`~/.claude/.agent_outputs/`)
 - ✅ 2026-06-08: Documentation refresh for SkillClaw + `/pass-cli` — README, architecture
   diagrams, CONFIGURATION/TROUBLESHOOTING sections, and a Diataxis cross-link audit
 - ✅ 2026-06-07: Added SKILLCLAW.md — SkillClaw passive-ingest transcript reader and skill evolution guide

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 > Common problems and solutions for the Manifest parallel agent orchestration framework
 
-**Last Updated**: 2026-06-08
+**Last Updated**: 2026-06-12
 **Audience**: All users
 **Quick Help**: Most issues are fixed by checking service configuration and verifying CLI installations
 
@@ -397,6 +397,12 @@ If it still aborts with "open PR already exists":
 
 ## Authentication Issues
 
+> **API keys are optional.** The Claude/Gemini agents select an execution backend
+> per run: the provider SDK when its package and API key
+> (`ANTHROPIC_API_KEY` / `GOOGLE_API_KEY`) are both present, otherwise the
+> logged-in `claude` / `gemini` CLI (OAuth/subscription login). As long as the
+> CLIs are authenticated, orchestration works without any API key.
+
 ### Claude CLI: "Not authenticated"
 
 **Symptom:**
@@ -408,20 +414,19 @@ Error: You are not authenticated. Run 'claude auth login'
 **Solution:**
 
 ```bash
-# Log in to Claude CLI
+# Log in to Claude CLI (OAuth/subscription login — no API key required)
 claude auth login
-
-# Follow prompts to enter API key
 
 # Verify authentication
 claude auth status
 ```
 
-**Get API Key:**
+**API key (optional, for the SDK backend):**
 
 1. Visit: <https://console.anthropic.com/account/keys>
 2. Create new API key
-3. Copy key for `claude auth login`
+3. Export it as `ANTHROPIC_API_KEY` to make the orchestrator use the SDK
+   backend instead of the CLI fallback
 
 ---
 
@@ -443,11 +448,12 @@ gemini  # first run prompts a Google OAuth login
 gemini auth status
 ```
 
-**Get API Key:**
+**API key (optional, for the SDK backend):**
 
 1. Visit: <https://makersuite.google.com/app/apikey>
 2. Create new API key
-3. Copy key for `gemini  # first run prompts a Google OAuth login`
+3. Export it as `GOOGLE_API_KEY` to make the orchestrator use the SDK
+   backend instead of the CLI fallback
 
 ---
 
@@ -493,7 +499,8 @@ Warning: No services config, use defaults (all enabled)
 
 ```bash
 # Deploy configuration
-cp -r .claude/* ~/.claude/
+cp -r configs/claude/* ~/.claude/
+cp -r configs/claude/.[!.]* ~/.claude/ 2>/dev/null || true
 
 # Or re-run bootstrap
 ./bootstrap.sh --force
@@ -520,8 +527,8 @@ python3 -c "import yaml; yaml.safe_load(open('~/.claude/config/services.yml'))"
 # - Missing colons
 # - Unquoted strings with special characters
 
-# Restore from backup
-cp .claude/config/services.yml ~/.claude/config/services.yml
+# Restore from the repo source
+cp configs/claude/config/services.yml ~/.claude/config/services.yml
 ```
 
 ---
@@ -545,6 +552,32 @@ cat ~/.claude/config/services.yml
 # Run without CLI flag overrides
 ~/.claude/scripts/parallel_agent.py "Task"
 ```
+
+---
+
+### Model Pins Reported as Unverified
+
+**Symptom:**
+
+```text
+○ 2 check(s) unverified (no API credentials — run MODEL_CHECK_PROBE=1 model_check.sh for a live CLI probe)
+```
+
+**Cause:** On OAuth-only machines (no `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY`)
+there is no API to list models with, so `check_status.sh` reports the
+claude/gemini pins in `parallel_agent.yml` (`model_tiers`) as unverified rather
+than falsely green.
+
+**Solution:**
+
+```bash
+# Live-verify each pin with a one-shot CLI probe (one tiny LLM call per pin)
+MODEL_CHECK_PROBE=1 ~/.claude/scripts/model_check.sh
+```
+
+If a pin reports `STALE`, update the corresponding `model_tiers` entry in
+`~/.claude/config/parallel_agent.yml` (current Gemini pins:
+`gemini-3-flash-preview` / `gemini-3-pro-preview`).
 
 ---
 
@@ -603,7 +636,9 @@ Error: Agent timed out after 600 seconds
 ```bash
 # Use lightweight models by default
 export CURSOR_MODEL_FLASH="gpt-5.1-codex-mini"  # Instead of gpt-5.1-codex
-export CLAUDE_MODEL_TIER="haiku"                 # Instead of sonnet
+
+# Or pass a lighter Claude tier per run
+~/.claude/scripts/parallel_agent.py --claude-model haiku "Task"
 
 # Configure in command_config.yml
 vim ~/.claude/config/command_config.yml
@@ -630,7 +665,7 @@ vim ~/.claude/config/command_config.yml
 ~/.claude/scripts/parallel_agent.py --json "Task" | jq .
 
 # Check output files directly
-cat ~/.manifest/orchestration/outputs/results_*.json
+cat ~/.claude/.agent_outputs/results_*.json
 
 # Validate JSON
 ~/.claude/scripts/parallel_agent.py --json "Task" | python3 -m json.tool
@@ -649,29 +684,31 @@ cat ~/.manifest/orchestration/outputs/results_*.json
 ~/.claude/scripts/parallel_agent.py --json --full-output "Task"
 
 # Check output files for complete responses
-cat ~/.manifest/claude/outputs/claude_*.txt
-cat ~/.manifest/gemini/outputs/gemini_*.txt
+cat ~/.claude/.agent_outputs/claude_*.txt
+cat ~/.claude/.agent_outputs/gemini_*.txt
 ```
 
 ---
 
 ### No Output Files Generated
 
-**Symptom:** Expected files in `~/.manifest/orchestration/outputs/` don't exist
+**Symptom:** Expected files in `~/.claude/.agent_outputs/` don't exist
 
-**Cause:** Output directory not created or permissions issue
+**Cause:** Output directory not created or permissions issue. On permission
+errors (e.g. sandboxed runs) the script falls back to
+`/tmp/.claude_agent_outputs_<pid>` — check there too.
 
 **Solution:**
 
 ```bash
 # Create output directory
-mkdir -p ~/.manifest/orchestration/outputs
+mkdir -p ~/.claude/.agent_outputs
 
 # Fix permissions
-chmod 700 ~/.manifest/orchestration/outputs
+chmod 700 ~/.claude/.agent_outputs
 
 # Specify custom output directory
-~/.claude/scripts/parallel_agent.py --output ~/.manifest/orchestration/outputs "Task"
+~/.claude/scripts/parallel_agent.py --output /tmp/agent_outputs "Task"
 ```
 
 ---
@@ -766,14 +803,17 @@ cat ~/.claude/config/validation_criteria.yml
 
 ```bash
 # View recent outputs
-ls -lth ~/.manifest/orchestration/outputs/ | head -20
+ls -lth ~/.claude/.agent_outputs/ | head -20
 
 # View latest agent outputs
-tail ~/.manifest/claude/outputs/claude_*.txt
-tail ~/.manifest/gemini/outputs/gemini_*.txt
+tail ~/.claude/.agent_outputs/claude_*.txt
+tail ~/.claude/.agent_outputs/gemini_*.txt
 
 # View JSON results
-cat ~/.manifest/orchestration/outputs/results_*.json | python3 -m json.tool
+cat ~/.claude/.agent_outputs/results_*.json | python3 -m json.tool
+
+# View the orchestrator log
+tail ~/.claude/.agent_outputs/parallel_agent.log
 ```
 
 ### Test Network Connectivity


### PR DESCRIPTION
## Summary

`/docs-all` run after today's three merged PRs (#332 validation fixes, #333 OAuth CLI fallback + pin probe, #334 bootstrap silent-abort fix). Order: `docs-diagrams` ∥ `docs-readme` → `docs-improve` (architecture-heavy changes → diagrams prioritized; improve last per dependency).

### docs-diagrams (`docs/ARCHITECTURE_DIAGRAMS.md`)
- **New:** Agent Backend Selection (SDK vs CLI fallback decision flow from `select_backend()`)
- **New:** Model Pin Staleness Check (`check_status.sh` → `model_check.sh` incl. `MODEL_CHECK_PROBE=1` probes and honest aggregation)
- **Rewritten:** Bootstrap Installation Flow to match actual `main()` (banner after config load, soft-fail installs, `*.py` chmod, guarded launchd cleanup, full pipeline to summary)
- Refreshed: Application Architecture, Python Parallel Agent Architecture, Execution Flow, Model Selection & Credit Fallback
- All 17 Mermaid blocks validated with mermaid-cli

### docs-readme (`README.md`)
- New "OAuth-Only Friendly" feature bullet; API keys marked optional with CLI fallback explained
- Model-pin notes (`gemini-3-flash-preview`/`-pro-preview`, `MODEL_CHECK_PROBE=1`) and a troubleshooting entry for unverified pins

### docs-improve (Diataxis audit of `docs/`)
- `CONFIGURATION.md`: `cli_agents` example now matches shipped config (claude/gemini entries, `prompt_args`); new Execution Backend, Provider API Keys (Optional), and Model Pin Verification sections
- `GETTING_STARTED.md`: fixed wrong manual-deploy path (`.claude/*` → `configs/claude/*`); Antigravity added to the agent list (text said 5, listed 4); no-API-keys callout
- `TROUBLESHOOTING.md`: fixed 6 wrong agent-output paths and 2 stale deploy paths; removed nonexistent `CLAUDE_MODEL_TIER` env var; auth sections rewritten for optional keys; new "Model Pins Reported as Unverified" entry
- `docs/README.md` hub: 4 previously orphaned docs added to the tables; `.claude/CLAUDE.md` mislabel corrected

Honest gaps recorded by the audit (not fixed, none blocking): `claude/gemini auth status` premise worth a future verify pass; METRICS.md template date left to `/dashboard`; archived report docs intentionally excluded from hub.

## Test plan
- [x] markdownlint clean across README.md + docs/
- [x] All Mermaid blocks validated
- [x] All relative links resolve
- [x] Claims verified against code before writing (per skill rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)