### PR TITLE
Fix markdown block markers in meta-prompt-optimize SKILL.md

### DIFF
--- a/.skillshare/skills/meta-prompt-optimize/SKILL.md
+++ b/.skillshare/skills/meta-prompt-optimize/SKILL.md
@@ -42,7 +42,6 @@ When a raw prompt payload is received via the scheduled task pipeline, execute t
 
 The output must be returned strictly using this layout so downstream agent layers can parse it deterministically:
 
-```xml
 <problem_structure>
   <problem_definition>
     [Action-oriented task statement with precise boolean endpoints or metrics]
@@ -63,7 +62,6 @@ The output must be returned strictly using this layout so downstream agent layer
     [Strict formatting payload requirements: JSON object layouts, XML schemas, or fixed markdown tables]
   </desired_output>
 </problem_structure>
-```
 
 ## 5. Normalized Structural Blueprints
 
@@ -96,11 +94,9 @@ Format Requirements:
 2. **State Payload Specification**: Strict definitions of variables passed across isolation boundaries.
 3. **Execution Telemetry JSON**:
 
-```json
 {
   "plan_status": "success | failed",
   "steps_executed": [],
   "resulting_state": {},
   "telemetry": ""
 }
-```

--- a/.skillshare/skills/meta-prompt-optimize/SKILL.md
+++ b/.skillshare/skills/meta-prompt-optimize/SKILL.md
@@ -40,7 +40,8 @@ When a raw prompt payload is received via the scheduled task pipeline, execute t
 
 ## 4. Target Serialization Schema
 
-The output must be returned strictly using this layout so downstream agent layers can parse it deterministically:
+The output must be returned strictly using this layout so downstream agent layers
+can parse it deterministically (raw XML — do NOT wrap it in Markdown code fences):
 
 <problem_structure>
   <problem_definition>
@@ -92,7 +93,7 @@ Format Requirements:
 
 1. **Constitution Compliance**: Immediate boundary verification before spawning worker threads.
 2. **State Payload Specification**: Strict definitions of variables passed across isolation boundaries.
-3. **Execution Telemetry JSON**:
+3. **Execution Telemetry JSON** (raw JSON — do NOT wrap it in Markdown code fences):
 
 {
   "plan_status": "success | failed",


### PR DESCRIPTION
Strips the `xml` and `json` markdown code block closures from the `meta-prompt-optimize` skill template. This ensures that when the LLM generates output based on this prompt, the results are formatted as bare XML/JSON strings, allowing downstream automated agent layers to parse the payloads deterministically without needing to strip markdown wrapping.

---
*PR created automatically by Jules for task [6841503448171528003](https://jules.google.com/task/6841503448171528003) started by @RB-chrismandich*