### PR TITLE
Token economy always-on: standing baseline, reminder hooks, health-check fix

### DIFF
--- a/.skillshare/skills/health-check/SKILL.md
+++ b/.skillshare/skills/health-check/SKILL.md
@@ -178,6 +178,7 @@ stat -c '%a' ~/.skillclaw 2>/dev/null || stat -f '%Lp' ~/.skillclaw
 # Legacy artifacts must be ABSENT (leftovers from the pre-proxy-free install)
 grep -q "MANIFEST SKILLCLAW WRAPPERS" "${ZDOTDIR:-$HOME}/.zshrc" && echo "legacy wrappers: PRESENT (stale)" || echo "legacy wrappers: absent (ok)"
 ls ~/Library/LaunchAgents/*skillclaw* 2>/dev/null && echo "legacy plist: PRESENT (stale)" || echo "legacy plist: absent (ok)"
+pgrep -f skillclaw >/dev/null 2>&1 && echo "legacy daemon process: RUNNING (stale)" || echo "legacy daemon process: absent (ok)"
 ```
 
 Report storage perms != 700 as WARN; legacy wrappers or plist PRESENT as WARN

--- a/.skillshare/skills/health-check/SKILL.md
+++ b/.skillshare/skills/health-check/SKILL.md
@@ -168,19 +168,21 @@ Report: executable or not executable.
 
 Only when `skillclaw.enabled: true` in `~/.claude/config/services.yml`:
 
+SkillClaw is proxy-free (`bootstrap/lib/skillclaw.sh`): no daemon, no socket,
+no shell wrappers. Enabling means storage-only setup.
+
 ```bash
-# Daemon health (fail-open: a red here means capture is off, not that agents are broken)
-curl -sf --max-time 0.3 http://127.0.0.1:8765/health && echo "daemon: up" || echo "daemon: down"
-
-# Wrapper functions present in the shell profile
-grep -q "MANIFEST SKILLCLAW WRAPPERS" "${ZDOTDIR:-$HOME}/.zshrc" && echo "wrappers: present" || echo "wrappers: MISSING"
-
-# Storage locked down (must be 700) — GNU-first so it works on Linux and macOS
+# Storage exists and is locked down (must be 700) — GNU-first for Linux/macOS
 stat -c '%a' ~/.skillclaw 2>/dev/null || stat -f '%Lp' ~/.skillclaw
+
+# Legacy artifacts must be ABSENT (leftovers from the pre-proxy-free install)
+grep -q "MANIFEST SKILLCLAW WRAPPERS" "${ZDOTDIR:-$HOME}/.zshrc" && echo "legacy wrappers: PRESENT (stale)" || echo "legacy wrappers: absent (ok)"
+ls ~/Library/LaunchAgents/*skillclaw* 2>/dev/null && echo "legacy plist: PRESENT (stale)" || echo "legacy plist: absent (ok)"
 ```
 
-Report `daemon: down` as INFO (capture paused, agents unaffected), but
-`wrappers: MISSING` or storage perms != 700 as WARN.
+Report storage perms != 700 as WARN; legacy wrappers or plist PRESENT as WARN
+(rerun `./bootstrap.sh` to clean them). Storage missing entirely as WARN
+(enable was never completed).
 
 ## Output Format
 

--- a/.skillshare/skills/token-economy/SKILL.md
+++ b/.skillshare/skills/token-economy/SKILL.md
@@ -38,8 +38,8 @@ default verbosity and apply until the session ends or the user says otherwise.
 
 ## Persistence caveat
 
-This mode lives only in the session context. In a long session the invocation
-can scroll out of the active window and default verbosity returns — if you
-notice that (roughly 30k+ tokens in), re-invoke `/token-economy`. True always-on
-enforcement would require a hook (e.g. `ai-hooks-integration`); that is out of
-scope for this skill.
+A baseline of these rules is always on via the deployed orchestration guides
+("Token Economy (always on)" in `~/.claude/CLAUDE.md`, GEMINI.md, AGENTS.md,
+and the Cursor orchestration rule) — CLAUDE.md is resent every turn, so it
+cannot scroll out. This skill remains the stronger session-scoped re-assert:
+invoke it when responses drift verbose despite the baseline.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ It follows the [AGENTS.md standard](https://agents.md/) for unified coding agent
 
 Apply at all times, in every session:
 
-- Lead with the result. No filler, no closing summaries.
+- Lead with the result. No filler ("Sure", "Here's the…"), no closing summaries.
 - Match response length to the task; don't re-explain code you just wrote unless asked.
 - Use programmatic edit tools for targeted edits; never reprint a whole file for a small change.
 - If an implementation detail is genuinely ambiguous, ask ONE targeted question instead of guessing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,18 @@
 This file provides guidance to AI coding agents when working with code in this repository.
 It follows the [AGENTS.md standard](https://agents.md/) for unified coding agent instructions.
 
+## Token Economy (always on)
+
+Apply at all times, in every session:
+
+- Lead with the result. No filler, no closing summaries.
+- Match response length to the task; don't re-explain code you just wrote unless asked.
+- Use programmatic edit tools for targeted edits; never reprint a whole file for a small change.
+- If an implementation detail is genuinely ambiguous, ask ONE targeted question instead of guessing.
+- Read what a change depends on (types, signatures, callers); skip speculative
+  whole-tree crawls and re-reads of unchanged files. Don't starve context —
+  a wrong edit costs more than one extra dependency read.
+
 ## MCP Default Policy
 
 Default MCP/tool routing — use the matching tool when the task domain matches:

--- a/bootstrap/lib/deploy.sh
+++ b/bootstrap/lib/deploy.sh
@@ -241,6 +241,41 @@ deploy_cursor_configs() {
     print_success "Cursor configuration deployed to $CURSOR_TARGET_DIR"
 }
 
+# Merge repo-defined hooks into an existing ~/.gemini/settings.json without
+# touching user settings (auth, mcpServers, …). Fail-open: parse errors leave
+# the file untouched and warn. Exit 3 from the merge means "nothing to add".
+merge_gemini_hooks() {
+    local src="$1" tgt="$2"
+    if ! command_exists python3; then
+        print_info "python3 unavailable — skipped hooks merge into existing settings.json"
+        return 0
+    fi
+    local rc=0
+    python3 - "$src" "$tgt" <<'PYEOF' || rc=$?
+import json, sys
+src_path, tgt_path = sys.argv[1], sys.argv[2]
+src = json.load(open(src_path))
+tgt = json.load(open(tgt_path))
+changed = False
+for event, entries in src.get("hooks", {}).items():
+    cur = tgt.setdefault("hooks", {}).setdefault(event, [])
+    for e in entries:
+        if e not in cur:
+            cur.append(e)
+            changed = True
+if changed:
+    with open(tgt_path, "w") as f:
+        json.dump(tgt, f, indent=2)
+        f.write("\n")
+sys.exit(0 if changed else 3)
+PYEOF
+    case $rc in
+        0) print_success "Merged repo hooks into existing settings.json" ;;
+        3) print_info "Existing settings.json already has repo hooks - preserved" ;;
+        *) print_warning "Could not merge hooks into existing settings.json (manual merge may be needed)" ;;
+    esac
+}
+
 # Deploy Gemini CLI configuration (mirrors .claude with symlinks)
 deploy_gemini_configs() {
     if [[ "${ENABLE_GEMINI:-true}" != true ]]; then
@@ -271,7 +306,7 @@ deploy_gemini_configs() {
     if [[ -f "$gemini_source_dir/settings.json" ]]; then
         # Merge with existing settings rather than overwriting (preserve auth)
         if [[ -f "$GEMINI_TARGET_DIR/settings.json" ]]; then
-            print_info "Existing settings.json found - preserving (manual merge may be needed)"
+            merge_gemini_hooks "$gemini_source_dir/settings.json" "$GEMINI_TARGET_DIR/settings.json"
         else
             cp "$gemini_source_dir/settings.json" "$GEMINI_TARGET_DIR/settings.json"
             print_success "Deployed settings.json to $GEMINI_TARGET_DIR/"

--- a/configs/claude/CLAUDE.md
+++ b/configs/claude/CLAUDE.md
@@ -3,6 +3,20 @@
 This document defines how Claude should leverage parallel LLM agents
 (Gemini, Cursor, Claude CLI, Codex, Antigravity) for cross-verification, planning, and validation.
 
+## Token Economy (always on)
+
+Apply at all times, in every session:
+
+- Lead with the result. No filler ("Sure", "Here's the…"), no closing summaries.
+- Match response length to the task; don't re-explain code you just wrote unless asked.
+- Use programmatic edit tools for targeted edits; never reprint a whole file for a small change.
+- If an implementation detail is genuinely ambiguous, ask ONE targeted question instead of guessing.
+- Read what a change depends on (types, signatures, callers); skip speculative
+  whole-tree crawls and re-reads of unchanged files. Don't starve context —
+  a wrong edit costs more than one extra dependency read.
+
+`/token-economy` re-asserts this mode if drift is noticed mid-session.
+
 ## Parallel Agent Script
 
 **Location**: `~/.claude/scripts/parallel_agent.py`

--- a/configs/claude/settings.local.json
+++ b/configs/claude/settings.local.json
@@ -50,6 +50,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'token-economy: lead with result; terse; surgical edits; one targeted question if ambiguous'"
+          }
+        ]
+      }
     ]
   },
   "mcpServers": {

--- a/configs/cursor/rules/orchestration.mdc
+++ b/configs/cursor/rules/orchestration.mdc
@@ -11,6 +11,18 @@ This rule defines how the Cursor agent should leverage parallel LLM agents
 
 <!-- Adapted from: .claude/CLAUDE.md -->
 
+## Token Economy (always on)
+
+Apply at all times, in every session:
+
+- Lead with the result. No filler, no closing summaries.
+- Match response length to the task; don't re-explain code you just wrote unless asked.
+- Use programmatic edit tools for targeted edits; never reprint a whole file for a small change.
+- If an implementation detail is genuinely ambiguous, ask ONE targeted question instead of guessing.
+- Read what a change depends on (types, signatures, callers); skip speculative
+  whole-tree crawls and re-reads of unchanged files. Don't starve context —
+  a wrong edit costs more than one extra dependency read.
+
 ## Parallel Agent Script
 
 **Location**: `~/.claude/scripts/parallel_agent.py` (symlinked at `.cursor/scripts/`)

--- a/configs/cursor/rules/orchestration.mdc
+++ b/configs/cursor/rules/orchestration.mdc
@@ -15,7 +15,7 @@ This rule defines how the Cursor agent should leverage parallel LLM agents
 
 Apply at all times, in every session:
 
-- Lead with the result. No filler, no closing summaries.
+- Lead with the result. No filler ("Sure", "Here's the…"), no closing summaries.
 - Match response length to the task; don't re-explain code you just wrote unless asked.
 - Use programmatic edit tools for targeted edits; never reprint a whole file for a small change.
 - If an implementation detail is genuinely ambiguous, ask ONE targeted question instead of guessing.

--- a/configs/gemini/GEMINI.md
+++ b/configs/gemini/GEMINI.md
@@ -14,13 +14,15 @@ validation criteria.
 
 Apply at all times, in every session:
 
-- Lead with the result. No filler, no closing summaries.
+- Lead with the result. No filler ("Sure", "Here's the…"), no closing summaries.
 - Match response length to the task; don't re-explain code you just wrote unless asked.
 - Use programmatic edit tools for targeted edits; never reprint a whole file for a small change.
 - If an implementation detail is genuinely ambiguous, ask ONE targeted question instead of guessing.
 - Read what a change depends on (types, signatures, callers); skip speculative
   whole-tree crawls and re-reads of unchanged files. Don't starve context —
   a wrong edit costs more than one extra dependency read.
+
+`/token-economy` re-asserts this mode if drift is noticed mid-session.
 
 ## Parallel Agent Script
 

--- a/configs/gemini/GEMINI.md
+++ b/configs/gemini/GEMINI.md
@@ -10,6 +10,18 @@ point back to their canonical locations under `~/.claude/`. Only this guide
 and ensures both agents always operate from the same orchestration rules and
 validation criteria.
 
+## Token Economy (always on)
+
+Apply at all times, in every session:
+
+- Lead with the result. No filler, no closing summaries.
+- Match response length to the task; don't re-explain code you just wrote unless asked.
+- Use programmatic edit tools for targeted edits; never reprint a whole file for a small change.
+- If an implementation detail is genuinely ambiguous, ask ONE targeted question instead of guessing.
+- Read what a change depends on (types, signatures, callers); skip speculative
+  whole-tree crawls and re-reads of unchanged files. Don't starve context —
+  a wrong edit costs more than one extra dependency read.
+
 ## Parallel Agent Script
 
 **Location**: `~/.claude/scripts/parallel_agent.py`

--- a/configs/gemini/settings.json
+++ b/configs/gemini/settings.json
@@ -12,5 +12,19 @@
       "url": "https://mcp.linear.app/mcp",
       "type": "http"
     }
+  },
+  "hooks": {
+    "BeforeAgent": [
+      {
+        "hooks": [
+          {
+            "name": "token-economy-reminder",
+            "type": "command",
+            "command": "echo 'token-economy: lead with result; terse; surgical edits; one targeted question if ambiguous'",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
   }
 }

--- a/tests/bats/context_budget.bats
+++ b/tests/bats/context_budget.bats
@@ -22,8 +22,10 @@ assert_budget() {
 }
 
 @test "configs/claude/CLAUDE.md stays within always-loaded budget" {
-    # Deployed to ~/.claude/CLAUDE.md: loaded in EVERY session on EVERY project
-    assert_budget "configs/claude/CLAUDE.md" 6600
+    # Deployed to ~/.claude/CLAUDE.md: loaded in EVERY session on EVERY project.
+    # Re-based from 6600 after the intentional "Token Economy (always on)"
+    # baseline section landed (file at 6448; restores ~15% headroom).
+    assert_budget "configs/claude/CLAUDE.md" 7400
 }
 
 @test "root CLAUDE.md stays within always-loaded budget" {
@@ -32,6 +34,27 @@ assert_budget() {
 
 @test ".claude/CLAUDE.md stays within always-loaded budget" {
     assert_budget ".claude/CLAUDE.md" 3900
+}
+
+@test "token-economy section bullets are identical across all four guides" {
+    # The same rules are stated in 4 always-loaded guides; this pins them
+    # together so copies cannot drift. Compares only the '- '/continuation
+    # bullet lines of the section (the /token-economy re-assert line is
+    # platform-specific and excluded).
+    local ref="" cur f
+    for f in "configs/claude/CLAUDE.md" "configs/gemini/GEMINI.md" \
+             "AGENTS.md" "configs/cursor/rules/orchestration.mdc"; do
+        cur=$(awk '/^## Token Economy \(always on\)$/{found=1; next}
+                   found && /^## /{exit}
+                   found && (/^- / || /^  [^ ]/)' "$REPO_ROOT/$f")
+        [ -n "$cur" ] || { echo "$f: token-economy section missing or empty" >&2; return 1; }
+        if [ -z "$ref" ]; then ref="$cur"; reffile="$f"; continue; fi
+        if [ "$cur" != "$ref" ]; then
+            echo "$f token-economy bullets differ from $reffile:" >&2
+            diff <(echo "$ref") <(echo "$cur") >&2 || true
+            return 1
+        fi
+    done
 }
 
 @test "skill frontmatter descriptions stay within per-session budget" {

--- a/tests/bats/gemini_hooks_merge.bats
+++ b/tests/bats/gemini_hooks_merge.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# merge_gemini_hooks(): repo hooks must reach EXISTING ~/.gemini/settings.json
+# installs (the preserve-only branch silently skipped them, so hooks shipped
+# in configs/gemini/settings.json never propagated to bootstrapped machines).
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+
+setup() {
+    TMPDIR_T="$(mktemp -d)"
+    SRC="$TMPDIR_T/src.json"
+    TGT="$TMPDIR_T/tgt.json"
+
+    # Minimal stubs for the helpers merge_gemini_hooks uses
+    command_exists() { command -v "$1" > /dev/null 2>&1; }
+    print_info() { echo "INFO: $*"; }
+    print_success() { echo "OK: $*"; }
+    print_warning() { echo "WARN: $*"; }
+    export -f command_exists print_info print_success print_warning 2> /dev/null || true
+
+    # shellcheck disable=SC1091
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh" 2> /dev/null || true
+
+    cat > "$SRC" <<'EOF'
+{
+  "hooks": {
+    "BeforeAgent": [
+      { "hooks": [ { "name": "token-economy-reminder", "type": "command",
+          "command": "echo reminder", "timeout": 5000 } ] }
+    ]
+  }
+}
+EOF
+}
+
+teardown() {
+    rm -rf "$TMPDIR_T"
+}
+
+@test "adds repo hook to existing settings.json and preserves user keys" {
+    cat > "$TGT" <<'EOF'
+{ "mcpServers": { "user-server": { "url": "https://example.test" } } }
+EOF
+    run merge_gemini_hooks "$SRC" "$TGT"
+    assert_success
+    assert_output --partial "Merged repo hooks"
+
+    run python3 -c "
+import json
+d = json.load(open('$TGT'))
+assert d['mcpServers']['user-server']['url'] == 'https://example.test'
+assert d['hooks']['BeforeAgent'][0]['hooks'][0]['name'] == 'token-economy-reminder'
+print('merged-and-preserved')"
+    assert_output --partial "merged-and-preserved"
+}
+
+@test "second run is idempotent (no duplicate hook entries)" {
+    cat > "$TGT" <<'EOF'
+{}
+EOF
+    run merge_gemini_hooks "$SRC" "$TGT"
+    assert_success
+    run merge_gemini_hooks "$SRC" "$TGT"
+    assert_success
+    assert_output --partial "already has repo hooks"
+
+    run python3 -c "
+import json
+d = json.load(open('$TGT'))
+assert len(d['hooks']['BeforeAgent']) == 1, d
+print('no-duplicates')"
+    assert_output --partial "no-duplicates"
+}
+
+@test "malformed existing settings.json fails open (file untouched, warning)" {
+    echo '{ not json' > "$TGT"
+    local before
+    before=$(cat "$TGT")
+    run merge_gemini_hooks "$SRC" "$TGT"
+    assert_success
+    assert_output --partial "WARN"
+    assert_equal "$(cat "$TGT")" "$before"
+}
+
+@test "repo settings.json source contains the BeforeAgent reminder hook" {
+    run python3 -c "
+import json
+d = json.load(open('$REPO_ROOT/configs/gemini/settings.json'))
+entries = d['hooks']['BeforeAgent']
+assert any('token-economy' in json.dumps(e) for e in entries)
+print('source-hook-present')"
+    assert_output --partial "source-hook-present"
+}


### PR DESCRIPTION
## Summary

Follow-up to #338 — these three commits landed on the old branch after its squash-merge and were never in main:

1. **Standing token-economy baseline** in all four always-loaded platform guides (configs/claude/CLAUDE.md, GEMINI.md, AGENTS.md, orchestration.mdc). Guide content is resent every turn, so it cannot scroll out — always-on without hook overhead.
2. **Per-prompt reminder hooks** for recency reinforcement: Claude `UserPromptSubmit` + Gemini `BeforeAgent` echo hooks (~15 tokens/prompt). Cursor covered by its alwaysApply rule; Codex/Antigravity have no hooks API (AGENTS.md / prompt templates cover them).
3. **health-check SkillClaw section** updated for the proxy-free architecture — the old check flagged the correct state (no wrappers/daemon) as WARN.

## Verification
- context_budget.bats 4/4 within budgets; 45 settings-related bats pass; markdownlint 0 errors
- Live e2e smoke on this device: parallel_agent.py 3/3 agents OK (claude sonnet-4-6, gemini 3-flash-preview, antigravity Gemini 3.5 Flash High)

🤖 Generated with [Claude Code](https://claude.com/claude-code)