### PR TITLE
feat: issue-linking git hooks (pr-issue-sync + commit-issue-sync)

### DIFF
--- a/.skillshare/skills/commit-issue-sync/SKILL.md
+++ b/.skillshare/skills/commit-issue-sync/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: commit-issue-sync
+description: |
+  Keep the linked GitHub/GitLab issue in sync when commits land on a feature branch:
+  advance a planned issue to in-progress, deduplicated across commits. Runs as a
+  hook (PostToolUse or native post-commit); fail-open (never blocks the commit).
+---
+
+# Commit → Issue Sync Skill
+
+When a commit lands on a feature branch, this skill moves the linked issue into
+"active" status so the tracker reflects work-in-progress as soon as it starts. It is
+one half of the issue-linking hooks (see also [`pr-issue-sync`]); both delegate to the
+shared engine `configs/claude/scripts/issue_support.sh`.
+
+## What it does
+
+For each issue resolved from the commit (branch-number prefix → commit-message
+references/trailers):
+
+1. Advances a `planned` issue to `in-progress` (forward-only). Unlabeled issues are
+   left untouched — they are outside the managed lifecycle.
+2. Posts an idempotent back-link comment, de-duplicated so repeated commits do not
+   re-comment or re-transition the same issue.
+
+When no issue resolves, it defers to the missing-issue creation flow (offer on
+confirmation; non-interactive → no-create + warning).
+
+**Fail-open**: any error or unreachable tracker degrades to a warning and never blocks
+the commit. A timed-out run self-heals on the next commit or a manual re-run.
+
+## Invocation
+
+```bash
+configs/claude/scripts/issue_support.sh sync-commit HEAD [--dry-run] [--no-create]
+```
+
+## Hook trigger
+
+Installed via `configs/claude/scripts/install_issue_hooks.sh --enable` (unified
+`PostToolUse`, matched to `git commit`) and optionally `--native` to add a guarded
+git `post-commit` hook for commits made outside an AI tool. Opt-in: gated by
+`tool_policies.commit-issue-sync.enabled`.
+
+## Configuration
+
+`command_config.yml → tool_policies.commit-issue-sync`: `enabled` (default false),
+`hook_timeout_seconds` (default 5), `commit_hook_mode` (`sync` only in v1;
+`background` is reserved and falls back to `sync` with a warning).

--- a/.skillshare/skills/pr-issue-sync/SKILL.md
+++ b/.skillshare/skills/pr-issue-sync/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: pr-issue-sync
+description: |
+  Keep the linked GitHub/GitLab issue in sync when a pull/merge request is opened:
+  back-link comment, advance status label to needs-review, ensure the closing keyword.
+  Runs as a PostToolUse hook; fail-open (never blocks PR creation).
+---
+
+# PR → Issue Sync Skill
+
+When a pull/merge request is opened, this skill updates each issue the PR relates
+to so the tracker reflects "up for review" without manual upkeep. It is one half of
+the issue-linking hooks (see also [`commit-issue-sync`]); both delegate to the shared
+engine `configs/claude/scripts/issue_support.sh`.
+
+## What it does
+
+For each issue resolved from the PR (branch-number prefix → PR body references →
+commit references):
+
+1. Posts an idempotent back-link comment (deduped by a hidden marker).
+2. Advances the issue's status label to `needs-review` (forward-only — never regresses).
+3. Ensures the PR description contains `Closes #N` (appends it non-destructively if missing).
+
+When no issue resolves, it offers to create a best-of-breed tracking issue
+(dedup-checked, templated, `planned`-labeled) — only on confirmation; non-interactive
+contexts default to no-create + warning.
+
+**Fail-open**: any error, missing credential, or unreachable tracker degrades to a
+single warning and never aborts PR creation. A timed-out run self-heals on re-run.
+
+## Invocation
+
+```bash
+# Self-resolves the current branch's PR:
+configs/claude/scripts/issue_support.sh sync-pr
+# Or target a specific PR:
+configs/claude/scripts/issue_support.sh sync-pr 42 [--dry-run] [--no-create]
+```
+
+`--dry-run` previews actions without mutating; `--no-create` suppresses the
+missing-issue creation offer.
+
+## Hook trigger
+
+Installed as a unified `PostToolUse` hook (cross-tool) via
+`configs/claude/scripts/install_issue_hooks.sh --enable`, matched to PR/MR-create
+commands. Opt-in: gated by `tool_policies.pr-issue-sync.enabled` in
+`command_config.yml`. Coverage boundary: PR creation via the web UI or raw
+`gh`/`glab` outside a tool is not auto-observed — run `sync-pr` manually there.
+
+## Configuration
+
+`command_config.yml → tool_policies.pr-issue-sync`: `enabled` (default false),
+`hook_timeout_seconds` (default 5).

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/003-skill-library-consolidation"
+  "feature_directory": "specs/005-issue-linking-hooks"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,3 +235,10 @@ approaches), review stale plans, or archive/abandon completed work.
 - [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) - Common problems and solutions
 - [configs/claude/.plans/README.md](configs/claude/.plans/README.md) - Plan management quick reference
 - [configs/claude/CLAUDE.md](configs/claude/CLAUDE.md) - Orchestration guide (deployed to ~/.claude/)
+
+<!-- SPECKIT START -->
+## Active Spec Kit Feature
+
+- `005-issue-linking-hooks` — plan: [specs/005-issue-linking-hooks/plan.md](specs/005-issue-linking-hooks/plan.md)
+<!-- SPECKIT END -->
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,4 +241,3 @@ approaches), review stale plans, or archive/abandon completed work.
 
 - `005-issue-linking-hooks` — plan: [specs/005-issue-linking-hooks/plan.md](specs/005-issue-linking-hooks/plan.md)
 <!-- SPECKIT END -->
-

--- a/configs/claude/config/command_config.yml
+++ b/configs/claude/config/command_config.yml
@@ -60,6 +60,31 @@ synthesis_priority:
 
 # Tool policies per command
 tool_policies:
+  pr-issue-sync:
+    allowed:
+      - Bash
+      - Read
+    forbidden:
+      - Write
+      - Edit
+    parallel_agents: never
+    validation_tier: 1
+    enabled: false              # opt-in runtime gate (install_issue_hooks.sh --enable)
+    hook_timeout_seconds: 5     # fail-open soft timeout bound
+
+  commit-issue-sync:
+    allowed:
+      - Bash
+      - Read
+    forbidden:
+      - Write
+      - Edit
+    parallel_agents: never
+    validation_tier: 1
+    enabled: false              # opt-in runtime gate
+    hook_timeout_seconds: 5     # fail-open soft timeout bound
+    commit_hook_mode: sync      # sync only in v1; 'background' reserved (falls back to sync)
+
   docs-readme:
     allowed:
       - Read

--- a/configs/claude/scripts/git_ops.sh
+++ b/configs/claude/scripts/git_ops.sh
@@ -235,8 +235,28 @@ case "${platform}" in
                 glab issue close "$@"
                 ;;
             issue-edit)
-                # GitLab uses 'update' instead of 'edit'
-                glab issue update "$@"
+                # GitLab uses 'update' instead of 'edit', and --label/--unlabel
+                # instead of gh's --add-label/--remove-label.
+                _translate_issue_edit_flags() {
+                    local issue_num="$1"; shift
+                    local -a issue_args=("${issue_num}")
+                    while [[ $# -gt 0 ]]; do
+                        case "$1" in
+                            --add-label)
+                                issue_args+=(--label "$2"); shift 2 ;;
+                            --add-label=*)
+                                issue_args+=(--label "${1#--add-label=}"); shift ;;
+                            --remove-label)
+                                issue_args+=(--unlabel "$2"); shift 2 ;;
+                            --remove-label=*)
+                                issue_args+=(--unlabel "${1#--remove-label=}"); shift ;;
+                            *)
+                                issue_args+=("$1"); shift ;;
+                        esac
+                    done
+                    glab issue update "${issue_args[@]}"
+                }
+                _translate_issue_edit_flags "$@"
                 ;;
             pr-create)
                 # GitLab uses 'mr' (merge request) instead of 'pr'

--- a/configs/claude/scripts/git_ops.sh
+++ b/configs/claude/scripts/git_ops.sh
@@ -18,6 +18,7 @@
 #   issue-edit N          Edit issue/MR N
 #   pr-create             Create pull/merge request
 #   pr-view N             View PR/MR N
+#   pr-edit N             Edit PR/MR N (e.g. --body for description)
 #   pr-list               List PRs/MRs
 #   pr-review N           Review/approve PR/MR N
 #   pr-merge N            Merge PR/MR N
@@ -60,6 +61,7 @@ Subcommands:
   issue-edit N       Edit issue/MR N
   pr-create          Create pull/merge request
   pr-view N          View PR/MR N
+  pr-edit N          Edit PR/MR N (e.g. --body for description)
   pr-list            List PRs/MRs
   pr-review N        Review PR/MR N (pass --approve/--comment/--request-changes)
   pr-approve N       Approve PR/MR N (shortcut for pr-review --approve)
@@ -143,6 +145,9 @@ case "${platform}" in
                 ;;
             pr-view)
                 gh pr view "$@"
+                ;;
+            pr-edit)
+                gh pr edit "$@"
                 ;;
             pr-list)
                 gh pr list "$@"
@@ -268,6 +273,31 @@ case "${platform}" in
                 ;;
             pr-view)
                 glab mr view "$@"
+                ;;
+            pr-edit)
+                # GitLab uses 'mr update' with --description for body edits.
+                _translate_pr_edit_flags() {
+                    local mr_num="$1"; shift
+                    local -a mr_args=("${mr_num}")
+                    while [[ $# -gt 0 ]]; do
+                        case "$1" in
+                            --body)
+                                mr_args+=(--description "$2")
+                                shift 2
+                                ;;
+                            --body=*)
+                                mr_args+=(--description "${1#--body=}")
+                                shift
+                                ;;
+                            *)
+                                mr_args+=("$1")
+                                shift
+                                ;;
+                        esac
+                    done
+                    glab mr update "${mr_args[@]}"
+                }
+                _translate_pr_edit_flags "$@"
                 ;;
             pr-list)
                 glab mr list "$@"

--- a/configs/claude/scripts/git_ops.sh
+++ b/configs/claude/scripts/git_ops.sh
@@ -315,7 +315,7 @@ case "${platform}" in
                                 ;;
                         esac
                     done
-                    glab mr update "${mr_args[@]}"
+                    glab mr update "${mr_args[@]}"  # array-safe: seeded with mr_num
                 }
                 _translate_pr_edit_flags "$@"
                 ;;

--- a/configs/claude/scripts/install_issue_hooks.sh
+++ b/configs/claude/scripts/install_issue_hooks.sh
@@ -70,9 +70,11 @@ except Exception:
     data = {}
 hooks = data.setdefault("hooks", {})
 arr = hooks.setdefault("PostToolUse", [])
-def has(entry):
-    return any(h.get("command") == cmd for h in entry.get("hooks", []))
-arr = [e for e in arr if not has(e)]          # drop any prior managed entry
+# Filter at the HOOK level so sibling hooks co-located under the same matcher
+# entry are preserved; drop an entry only once its hooks list becomes empty.
+for e in arr:
+    e["hooks"] = [h for h in e.get("hooks", []) if h.get("command") != cmd]
+arr = [e for e in arr if e.get("hooks")]
 if action == "add":
     arr.append({"matcher": "Bash",
                 "hooks": [{"type": "command", "command": cmd, "timeout": 30}]})
@@ -96,9 +98,11 @@ install_native() {
     fi
     local had_file=0
     [[ -f "${post}" ]] && had_file=1
+    # Keep the shebang INSIDE the managed block when we create the file, so that
+    # remove_native strips the entire managed contribution atomically (bug_007).
     {
-        [[ "${had_file}" == "1" ]] || echo '#!/usr/bin/env bash'
         echo "${NATIVE_BEGIN}"
+        [[ "${had_file}" == "1" ]] || echo '#!/usr/bin/env bash'
         echo "\"${SCRIPT_DIR}/issue_support.sh\" sync-commit HEAD || true"
         echo "${NATIVE_END}"
     } >>"${post}"
@@ -116,7 +120,13 @@ remove_native() {
     awk -v b="${NATIVE_BEGIN}" -v e="${NATIVE_END}" '
         $0==b{skip=1; next} $0==e{skip=0; next} !skip{print}' "${post}" >"${tmp}"
     mv "${tmp}" "${post}"
-    chmod +x "${post}"
+    # If nothing but a shebang (or nothing) remains, we created this file — unlink
+    # it so a later --enable --native is not blocked by its own residual (bug_007).
+    if [[ ! -s "${post}" ]] || ! grep -qvE '^#!' "${post}"; then
+        rm -f "${post}"
+    else
+        chmod +x "${post}"
+    fi
 }
 
 # --- arg parsing ------------------------------------------------------------

--- a/configs/claude/scripts/install_issue_hooks.sh
+++ b/configs/claude/scripts/install_issue_hooks.sh
@@ -98,11 +98,12 @@ install_native() {
     fi
     local had_file=0
     [[ -f "${post}" ]] && had_file=1
-    # Keep the shebang INSIDE the managed block when we create the file, so that
-    # remove_native strips the entire managed contribution atomically (bug_007).
+    # Shebang must be the FIRST line so Git can exec the hook. When we create the
+    # file it sits OUTSIDE the managed block; remove_native unlinks a shebang-only
+    # residual afterwards, so the enable→remove→enable round-trip still works (bug_007).
     {
-        echo "${NATIVE_BEGIN}"
         [[ "${had_file}" == "1" ]] || echo '#!/usr/bin/env bash'
+        echo "${NATIVE_BEGIN}"
         echo "\"${SCRIPT_DIR}/issue_support.sh\" sync-commit HEAD || true"
         echo "${NATIVE_END}"
     } >>"${post}"

--- a/configs/claude/scripts/install_issue_hooks.sh
+++ b/configs/claude/scripts/install_issue_hooks.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# install_issue_hooks.sh - Enable/disable the issue-linking hooks (opt-in).
+#
+# Installs two surfaces:
+#   1) A unified PostToolUse hook (cross-tool) routed through issue_support_hook.sh
+#      -> fires the engine on PR-create and (optionally) commit commands.
+#   2) (--native) A guarded git post-commit hook for commits made outside an AI tool.
+#
+# Idempotent and reversible. Default-off: --enable flips the runtime gate.
+#
+# Usage:
+#   install_issue_hooks.sh --enable [--native] [--settings PATH]
+#   install_issue_hooks.sh --remove  [--settings PATH]
+#   install_issue_hooks.sh --help
+
+set -euo pipefail
+
+err() { echo "install-issue-hooks: $*" >&2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_SCRIPT="${SCRIPT_DIR}/issue_support_hook.sh"
+CONFIG_FILE="${ISSUE_HOOKS_CONFIG:-${SCRIPT_DIR}/../config/command_config.yml}"
+SETTINGS_FILE="${ISSUE_HOOKS_SETTINGS:-${HOME}/.claude/settings.json}"
+NATIVE_BEGIN="# >>> issue-support >>>"
+NATIVE_END="# <<< issue-support <<<"
+
+usage() {
+    cat <<'USAGE'
+Usage: install_issue_hooks.sh <--enable [--native] | --remove> [--settings PATH]
+
+  --enable      Turn on the hooks (PostToolUse) and flip the runtime gate on
+  --native      Also install a guarded git post-commit hook (commit-only)
+  --remove      Remove both hook surfaces and flip the runtime gate off
+  --settings P  Target Claude settings JSON (default: ~/.claude/settings.json)
+USAGE
+}
+
+# set_enabled <skill> <true|false> — flip tool_policies.<skill>.enabled, keep comments
+set_enabled() {
+    local skill="$1" val="$2"
+    [[ -f "${CONFIG_FILE}" ]] || { err "config not found: ${CONFIG_FILE}"; return 1; }
+    python3 - "${CONFIG_FILE}" "${skill}" "${val}" <<'PY'
+import sys, re
+path, skill, val = sys.argv[1:4]
+lines = open(path).read().splitlines(keepends=True)
+out, inblk = [], False
+for ln in lines:
+    if re.match(r'^  %s:\s*$' % re.escape(skill), ln):
+        inblk = True; out.append(ln); continue
+    if inblk and re.match(r'^  \S', ln):
+        inblk = False
+    if inblk and re.match(r'^    enabled:', ln):
+        ln = re.sub(r'(enabled:\s*)(true|false)', lambda m: m.group(1) + val, ln)
+    out.append(ln)
+open(path, 'w').write(''.join(out))
+PY
+}
+
+# merge_settings <add|remove> — idempotently add/remove the PostToolUse entry
+merge_settings() {
+    local action="$1"
+    mkdir -p "$(dirname "${SETTINGS_FILE}")"
+    [[ -f "${SETTINGS_FILE}" ]] || echo '{}' >"${SETTINGS_FILE}"
+    python3 - "${SETTINGS_FILE}" "${action}" "${HOOK_SCRIPT}" <<'PY'
+import sys, json
+path, action, cmd = sys.argv[1:4]
+try:
+    data = json.load(open(path)) or {}
+except Exception:
+    data = {}
+hooks = data.setdefault("hooks", {})
+arr = hooks.setdefault("PostToolUse", [])
+def has(entry):
+    return any(h.get("command") == cmd for h in entry.get("hooks", []))
+arr = [e for e in arr if not has(e)]          # drop any prior managed entry
+if action == "add":
+    arr.append({"matcher": "Bash",
+                "hooks": [{"type": "command", "command": cmd, "timeout": 30}]})
+hooks["PostToolUse"] = arr
+json.dump(data, open(path, "w"), indent=2)
+PY
+}
+
+install_native() {
+    local hooks_dir post
+    hooks_dir="$(git rev-parse --git-path hooks 2>/dev/null || true)"
+    [[ -n "${hooks_dir}" ]] || { err "not a git repo; skipping --native"; return 0; }
+    mkdir -p "${hooks_dir}"
+    post="${hooks_dir}/post-commit"
+    if [[ -f "${post}" ]] && ! grep -qF "${NATIVE_BEGIN}" "${post}"; then
+        err "existing post-commit hook found; refusing to clobber (merge manually)"
+        return 0
+    fi
+    if [[ -f "${post}" ]] && grep -qF "${NATIVE_BEGIN}" "${post}"; then
+        return 0   # already managed (idempotent)
+    fi
+    local had_file=0
+    [[ -f "${post}" ]] && had_file=1
+    {
+        [[ "${had_file}" == "1" ]] || echo '#!/usr/bin/env bash'
+        echo "${NATIVE_BEGIN}"
+        echo "\"${SCRIPT_DIR}/issue_support.sh\" sync-commit HEAD || true"
+        echo "${NATIVE_END}"
+    } >>"${post}"
+    chmod +x "${post}"
+}
+
+remove_native() {
+    local hooks_dir post tmp
+    hooks_dir="$(git rev-parse --git-path hooks 2>/dev/null || true)"
+    [[ -n "${hooks_dir}" ]] || return 0
+    post="${hooks_dir}/post-commit"
+    [[ -f "${post}" ]] || return 0
+    grep -qF "${NATIVE_BEGIN}" "${post}" || return 0
+    tmp="$(mktemp)"
+    awk -v b="${NATIVE_BEGIN}" -v e="${NATIVE_END}" '
+        $0==b{skip=1; next} $0==e{skip=0; next} !skip{print}' "${post}" >"${tmp}"
+    mv "${tmp}" "${post}"
+    chmod +x "${post}"
+}
+
+# --- arg parsing ------------------------------------------------------------
+ACTION="" NATIVE=0
+[[ $# -eq 0 ]] && { usage >&2; exit 1; }
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --enable) ACTION="enable"; shift ;;
+        --remove) ACTION="remove"; shift ;;
+        --native) NATIVE=1; shift ;;
+        --settings) SETTINGS_FILE="$2"; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        *) err "unknown option: $1"; usage >&2; exit 1 ;;
+    esac
+done
+
+case "${ACTION}" in
+    enable)
+        set_enabled pr-issue-sync true
+        set_enabled commit-issue-sync true
+        merge_settings add
+        [[ "${NATIVE}" == "1" ]] && install_native
+        echo "issue-linking hooks enabled (settings: ${SETTINGS_FILE})"
+        ;;
+    remove)
+        set_enabled pr-issue-sync false
+        set_enabled commit-issue-sync false
+        merge_settings remove
+        remove_native
+        echo "issue-linking hooks removed/disabled"
+        ;;
+    *) err "specify --enable or --remove"; usage >&2; exit 1 ;;
+esac

--- a/configs/claude/scripts/issue_support.sh
+++ b/configs/claude/scripts/issue_support.sh
@@ -374,7 +374,7 @@ sync_core() {
     fi
 
     local n rec state cur
-    for n in "${candidates[@]}"; do
+    for n in "${candidates[@]}"; do  # array-safe: non-empty (early-returned above)
         rec=$(issue_record "${n}" "${platform}")
         if [[ -z "${rec}" ]]; then
             record_action "#${n} [skipped] (issue not found)"
@@ -494,7 +494,7 @@ cmd_resolve() {
         done
         printf ']\n'
     else
-        printf '%s\n' "${nums[@]}"
+        printf '%s\n' "${nums[@]}"  # array-safe: non-empty (returned 3 above if empty)
     fi
     return 0
 }

--- a/configs/claude/scripts/issue_support.sh
+++ b/configs/claude/scripts/issue_support.sh
@@ -97,6 +97,17 @@ run_with_timeout() {
 # Current branch (best-effort)
 current_branch() { git rev-parse --abbrev-ref HEAD 2>/dev/null || printf ''; }
 
+# Current branch's open PR/MR number (best-effort; empty if none)
+current_pr_number() {
+    local platform="$1" n=""
+    if [[ "${platform}" == "github" ]]; then
+        n=$(git_ops pr-view --json number --jq '.number' 2>/dev/null || true)
+    else
+        n=$(git_ops pr-view --output json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("iid",""))' 2>/dev/null || true)
+    fi
+    printf '%s' "${n}" | grep -oE '^[0-9]+$' || true
+}
+
 # Normalize an issue-view payload (gh or glab JSON) → "number|state|labels-csv|title"
 # Reads raw JSON on stdin. Empty output = not found.
 # NOTE: uses `python3 -c` (not a heredoc) so the piped JSON stays on stdin.
@@ -418,11 +429,15 @@ run_inner() {
 cmd_sync_pr() {
     parse_common_flags "$@"
     local pr="${REMAIN[0]:-}"
-    [[ -n "${pr}" ]] || { err "sync-pr requires a PR number"; return 0; }
     if [[ "$(cfg_get pr-issue-sync enabled false)" != "true" ]]; then
         err "pr-issue-sync disabled (set tool_policies.pr-issue-sync.enabled: true)"
         return 0
     fi
+    # Self-resolve the current branch's PR when no number is given (hook convenience)
+    if [[ -z "${pr}" ]]; then
+        pr=$(current_pr_number "$(detect_platform)")
+    fi
+    [[ -n "${pr}" ]] || { err "sync-pr: no PR number given and none found for the current branch"; return 0; }
     local t
     t=$(cfg_get pr-issue-sync hook_timeout_seconds 5)
     [[ "${t}" =~ ^[0-9]+$ ]] || t=5

--- a/configs/claude/scripts/issue_support.sh
+++ b/configs/claude/scripts/issue_support.sh
@@ -1,0 +1,497 @@
+#!/usr/bin/env bash
+# issue_support.sh - Shared issue-support engine for the issue-linking hooks
+#
+# Platform-agnostic engine (sibling to git_ops.sh) that keeps the issue tracker
+# in sync with development activity. Invoked by the pr-issue-sync and
+# commit-issue-sync skills (and their hooks). FAIL-OPEN: sync-pr/sync-commit
+# always exit 0 so a git action is never blocked.
+#
+# Subcommands:
+#   sync-pr <N> [--dry-run] [--no-create]      Sync linked issues for an opened PR/MR
+#   sync-commit <SHA|HEAD> [--dry-run] [--no-create]  Sync linked issues for a commit
+#   resolve <--pr N | --commit SHA | --branch NAME> [--json]  Resolve issue refs only
+#
+# Env overrides (testing seams):
+#   GIT_OPS_BIN, GIT_PLATFORM_BIN, ISSUE_SUPPORT_CONFIG, ISSUE_SUPPORT_LABELS,
+#   ISSUE_SUPPORT_TEMPLATE, ISSUE_SUPPORT_INTERACTIVE (0|1)
+
+set -euo pipefail
+
+err() { echo "issue-support: $*" >&2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_OPS_BIN="${GIT_OPS_BIN:-${SCRIPT_DIR}/git_ops.sh}"
+GIT_PLATFORM_BIN="${GIT_PLATFORM_BIN:-${SCRIPT_DIR}/git_platform.sh}"
+CONFIG_FILE="${ISSUE_SUPPORT_CONFIG:-${SCRIPT_DIR}/../config/command_config.yml}"
+TEMPLATE_FILE="${ISSUE_SUPPORT_TEMPLATE:-${SCRIPT_DIR}/templates/issue_support_issue.md}"
+
+# Ordered status lifecycle (forward-only). Index = rank. (canonical labels.yml set)
+LIFECYCLE=("planned" "in-progress" "needs-review" "done")
+MARKER_PREFIX="<!-- issue-support:sync v1"
+
+usage() {
+    cat <<'USAGE'
+Usage: issue_support.sh <subcommand> [options]
+
+  sync-pr <N> [--dry-run] [--no-create]       Sync linked issues for opened PR/MR N
+  sync-commit <SHA|HEAD> [--dry-run] [--no-create]  Sync linked issues for a commit
+  resolve <--pr N|--commit SHA|--branch NAME> [--json]  Print resolved issue refs
+
+Fail-open: sync-* always exit 0. Config: command_config.yml tool_policies.
+USAGE
+}
+
+# ---- helpers ---------------------------------------------------------------
+
+git_ops() { "${GIT_OPS_BIN}" "$@"; }
+
+# cfg_get <skill> <key> <default> — read tool_policies.<skill>.<key>
+cfg_get() {
+    local skill="$1" key="$2" default="$3"
+    [[ -f "${CONFIG_FILE}" ]] || { printf '%s' "${default}"; return 0; }
+    python3 - "${CONFIG_FILE}" "${skill}" "${key}" "${default}" <<'PY' 2>/dev/null || printf '%s' "${default}"
+import sys, yaml
+path, skill, key, default = sys.argv[1:5]
+try:
+    data = yaml.safe_load(open(path)) or {}
+    val = (data.get("tool_policies", {}) or {}).get(skill, {}) or {}
+    out = val.get(key, default)
+    if isinstance(out, bool):
+        out = "true" if out else "false"
+    print("" if out is None else out, end="")
+except Exception:
+    print(default, end="")
+PY
+}
+
+# label_rank <label> — echo numeric rank (0 if unknown/empty)
+label_rank() {
+    local want="$1" i
+    for i in "${!LIFECYCLE[@]}"; do
+        [[ "${LIFECYCLE[$i]}" == "${want}" ]] && { printf '%s' "$((i + 1))"; return 0; }
+    done
+    printf '0'
+}
+
+# is_interactive — honor override, else check stdin is a tty
+is_interactive() {
+    if [[ -n "${ISSUE_SUPPORT_INTERACTIVE:-}" ]]; then
+        [[ "${ISSUE_SUPPORT_INTERACTIVE}" == "1" ]]
+    else
+        [[ -t 0 ]]
+    fi
+}
+
+# run_with_timeout <seconds> <cmd...> — bound a command; passthrough if no timeout tool
+run_with_timeout() {
+    local secs="$1"; shift
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "${secs}" "$@"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        gtimeout "${secs}" "$@"
+    else
+        "$@"
+    fi
+}
+
+# Current branch (best-effort)
+current_branch() { git rev-parse --abbrev-ref HEAD 2>/dev/null || printf ''; }
+
+# Normalize an issue-view payload (gh or glab JSON) → "number|state|labels-csv|title"
+# Reads raw JSON on stdin. Empty output = not found.
+# NOTE: uses `python3 -c` (not a heredoc) so the piped JSON stays on stdin.
+NORMALIZE_PY='
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if not isinstance(d, dict):
+    sys.exit(0)
+num = d.get("number") or d.get("iid") or d.get("id") or ""
+state = (d.get("state") or "").lower()
+if state in ("open", "opened"):
+    state = "open"
+elif state == "closed":
+    state = "closed"
+if d.get("locked") or d.get("discussion_locked"):
+    state = "locked"
+names = []
+for L in (d.get("labels") or []):
+    names.append(L.get("name", "") if isinstance(L, dict) else str(L))
+labels = ",".join(n for n in names if n)
+title = (d.get("title") or "").replace("|", "/").replace(chr(10), " ")
+print("%s|%s|%s|%s" % (num, state, labels, title))
+'
+normalize_issue() { python3 -c "${NORMALIZE_PY}" 2>/dev/null || true; }
+
+# Fetch a normalized issue record for number N. Echo "number|state|labels|title" or "".
+issue_record() {
+    local n="$1" platform="$2" raw=""
+    if [[ "${platform}" == "github" ]]; then
+        raw=$(git_ops issue-view "${n}" --json number,state,labels,title 2>/dev/null || true)
+    else
+        raw=$(git_ops issue-view "${n}" --output json 2>/dev/null || true)
+    fi
+    [[ -z "${raw}" ]] && return 0
+    printf '%s' "${raw}" | normalize_issue
+}
+
+# Extract issue numbers referenced in a blob of text (#N, Closes/Fixes/Resolves #N)
+extract_refs() {
+    grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)?[[:space:]]*#[0-9]+' \
+        | grep -oE '#[0-9]+' | tr -d '#' | sort -un || true
+}
+
+# current status label of a normalized record (first lifecycle label found)
+record_label() {
+    local labels="$1" l
+    [[ -z "${labels}" ]] && { printf ''; return 0; }
+    local arr=()
+    IFS=',' read -ra arr <<<"${labels}"
+    for l in "${arr[@]+"${arr[@]}"}"; do
+        [[ "$(label_rank "${l}")" != "0" ]] && { printf '%s' "${l}"; return 0; }
+    done
+    printf ''
+}
+
+# ---- summary accumulation --------------------------------------------------
+declare -a ACTIONS=()
+record_action() { ACTIONS+=("$1"); }
+print_summary() {
+    local prefix=""
+    [[ "${DRY_RUN:-0}" == "1" ]] && prefix="(dry-run) "
+    local line
+    for line in "${ACTIONS[@]+"${ACTIONS[@]}"}"; do
+        echo "${prefix}issue-support: ${line}"
+    done
+}
+
+# ---- core actions ----------------------------------------------------------
+
+# transition_issue <n> <current-label> <target-label> <platform>
+transition_issue() {
+    local n="$1" cur="$2" target="$3" platform="$4"
+    local cur_rank target_rank
+    cur_rank=$(label_rank "${cur}")
+    target_rank=$(label_rank "${target}")
+    if [[ "${cur_rank}" -ge "${target_rank}" ]]; then
+        record_action "#${n} transition ${cur:-none}→${target} [skipped] (already at/after target)"
+        return 0
+    fi
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        record_action "#${n} transition ${cur:-none}→${target} [applied]"
+        return 0
+    fi
+    local args=(--add-label "${target}")
+    [[ -n "${cur}" ]] && args+=(--remove-label "${cur}")
+    if git_ops issue-edit "${n}" "${args[@]}" >/dev/null 2>&1; then
+        record_action "#${n} transition ${cur:-none}→${target} [applied]"
+    else
+        record_action "#${n} transition ${cur:-none}→${target} [failed] (label update error)"
+    fi
+}
+
+# comment_backlink <n> <context-key> <body> <platform> — idempotent via marker
+comment_backlink() {
+    local n="$1" ctxkey="$2" body="$3" platform="$4"
+    local marker="${MARKER_PREFIX} ${ctxkey} -->"
+    local existing=""
+    if [[ "${platform}" == "github" ]]; then
+        existing=$(git_ops issue-view "${n}" --json comments 2>/dev/null || true)
+    else
+        existing=$(git_ops issue-view "${n}" --comments 2>/dev/null || true)
+    fi
+    if printf '%s' "${existing}" | grep -qF "${marker}"; then
+        record_action "#${n} comment back-link [skipped] (marker already present)"
+        return 0
+    fi
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        record_action "#${n} comment back-link [applied]"
+        return 0
+    fi
+    if git_ops issue-comment "${n}" --body "${body}"$'\n\n'"${marker}" >/dev/null 2>&1; then
+        record_action "#${n} comment back-link [applied]"
+    else
+        record_action "#${n} comment back-link [failed] (comment error)"
+    fi
+}
+
+# ensure_closing_keyword <pr> <issue-n> <platform>
+ensure_closing_keyword() {
+    local pr="$1" n="$2" platform="$3" body=""
+    if [[ "${platform}" == "github" ]]; then
+        body=$(git_ops pr-view "${pr}" --json body --jq '.body' 2>/dev/null || true)
+    else
+        body=$(git_ops pr-view "${pr}" --output json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("description",""))' 2>/dev/null || true)
+    fi
+    if printf '%s' "${body}" | grep -qiE "(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#${n}\b"; then
+        record_action "PR #${pr} closing-keyword Closes #${n} [skipped] (already present)"
+        return 0
+    fi
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        record_action "PR #${pr} closing-keyword Closes #${n} [applied]"
+        return 0
+    fi
+    local newbody="${body}"$'\n\n'"Closes #${n}"
+    if git_ops pr-edit "${pr}" --body "${newbody}" >/dev/null 2>&1; then
+        record_action "PR #${pr} closing-keyword Closes #${n} [applied]"
+    else
+        record_action "PR #${pr} closing-keyword Closes #${n} [failed] (PR not editable — add 'Closes #${n}' manually)"
+    fi
+}
+
+# ---- resolution ------------------------------------------------------------
+
+# resolve_candidates <branch> <pr|""> <commit|""> — echo candidate numbers (one per line)
+resolve_candidates() {
+    local branch="$1" pr="$2" commit="$3" platform="$4"
+    local -a out=()
+    # 1) branch-number prefix (strip leading zeros: 017-foo → issue #17)
+    if [[ "${branch}" =~ ^([0-9]+)- ]]; then
+        out+=("$((10#${BASH_REMATCH[1]}))")
+    fi
+    # 2) PR/MR body references
+    if [[ -n "${pr}" ]]; then
+        local body=""
+        if [[ "${platform}" == "github" ]]; then
+            body=$(git_ops pr-view "${pr}" --json body --jq '.body' 2>/dev/null || true)
+        else
+            body=$(git_ops pr-view "${pr}" --output json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("description",""))' 2>/dev/null || true)
+        fi
+        while IFS= read -r r; do [[ -n "${r}" ]] && out+=("${r}"); done < <(printf '%s' "${body}" | extract_refs)
+    fi
+    # 3) commit-message references + trailers
+    if [[ -n "${commit}" ]]; then
+        local msg
+        msg=$(git log -1 --format='%B' "${commit}" 2>/dev/null || true)
+        while IFS= read -r r; do [[ -n "${r}" ]] && out+=("${r}"); done < <(printf '%s' "${msg}" | extract_refs)
+    fi
+    printf '%s\n' "${out[@]+"${out[@]}"}" | grep -E '^[0-9]+$' | awk 'NF' | awk '!seen[$0]++' || true
+}
+
+# ---- platform gate ---------------------------------------------------------
+detect_platform() {
+    local p
+    p=$(bash "${GIT_PLATFORM_BIN}" 2>/dev/null || printf 'git')
+    printf '%s' "${p}"
+}
+
+# ---- create flow (US3) -----------------------------------------------------
+
+render_template() {
+    local branch="$1" pr="$2" commit="$3"
+    local link="branch \`${branch}\`"
+    [[ -n "${pr}" ]] && link="PR #${pr} on branch \`${branch}\`"
+    [[ -n "${commit}" ]] && link="commit ${commit} on branch \`${branch}\`"
+    if [[ -f "${TEMPLATE_FILE}" ]]; then
+        sed -e "s|{{BRANCH}}|${branch}|g" -e "s|{{LINK}}|${link}|g" -e "s|{{PR}}|${pr}|g" -e "s|{{COMMIT}}|${commit}|g" "${TEMPLATE_FILE}"
+    else
+        printf '## Context\n\nTracking work on %s.\n\n## Acceptance Criteria\n\n- [ ] Define acceptance criteria\n' "${link}"
+    fi
+}
+
+# offer_create <branch> <pr> <commit> <platform> — dedup, confirm, create
+offer_create() {
+    local branch="$1" pr="$2" commit="$3" platform="$4"
+    if [[ "${NO_CREATE:-0}" == "1" ]]; then
+        record_action "create-issue [skipped] (--no-create)"
+        return 0
+    fi
+    # dedup: search for an existing open issue matching the branch
+    local existing=""
+    existing=$(git_ops issue-list --search "${branch}" 2>/dev/null | head -1 || true)
+    if [[ -n "${existing}" ]]; then
+        record_action "create-issue [skipped] (existing match reused: ${existing%% *})"
+        return 0
+    fi
+    if ! is_interactive; then
+        record_action "create-issue [skipped] (non-interactive; no tracking issue linked)"
+        return 0
+    fi
+    printf 'issue-support: no tracking issue found. Create one from branch %s? [y/N] ' "${branch}" >&2
+    local reply=""
+    read -r reply || true
+    if [[ ! "${reply}" =~ ^[Yy] ]]; then
+        record_action "create-issue [skipped] (declined)"
+        return 0
+    fi
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        record_action "create-issue [applied] (dry-run, not created)"
+        return 0
+    fi
+    local title="${branch}" bodyfile
+    bodyfile=$(mktemp)
+    render_template "${branch}" "${pr}" "${commit}" >"${bodyfile}"
+    if git_ops issue-create --title "${title}" --body-file "${bodyfile}" --label planned >/dev/null 2>&1; then
+        record_action "create-issue [applied] (labeled planned, from template)"
+    else
+        record_action "create-issue [failed] (issue-create error)"
+    fi
+    rm -f "${bodyfile}"
+}
+
+# ---- sync orchestration ----------------------------------------------------
+
+# sync_core <kind> <pr|""> <commit|""> — shared body for sync-pr / sync-commit
+sync_core() {
+    local kind="$1" pr="$2" commit="$3"
+    local platform branch target ctxkey body
+    platform=$(detect_platform)
+    if [[ "${platform}" != "github" && "${platform}" != "gitlab" ]]; then
+        err "no GitHub/GitLab remote detected; nothing to sync"
+        return 0
+    fi
+    branch=$(current_branch)
+
+    if [[ "${kind}" == "pr" ]]; then
+        target="needs-review"
+        ctxkey="pr=${pr}"
+        body="Tracked in PR #${pr}."
+    else
+        target="in-progress"
+        ctxkey="commit=${branch}"
+        body="Work in progress on branch \`${branch}\`."
+    fi
+
+    local candidates=()
+    while IFS= read -r _c; do [[ -n "${_c}" ]] && candidates+=("${_c}"); done \
+        < <(resolve_candidates "${branch}" "${pr}" "${commit}" "${platform}")
+    if [[ "${#candidates[@]}" -eq 0 ]]; then
+        offer_create "${branch}" "${pr}" "${commit}" "${platform}"
+        return 0
+    fi
+
+    local n rec state cur
+    for n in "${candidates[@]}"; do
+        rec=$(issue_record "${n}" "${platform}")
+        if [[ -z "${rec}" ]]; then
+            record_action "#${n} [skipped] (issue not found)"
+            continue
+        fi
+        IFS='|' read -r _num state _labels _title <<<"${rec}"
+        if [[ "${state}" == "closed" || "${state}" == "locked" ]]; then
+            record_action "#${n} [skipped] (issue ${state})"
+            continue
+        fi
+        cur=$(record_label "${_labels}")
+        # commit trigger only advances issues already labeled 'planned'
+        if [[ "${kind}" == "commit" && "$(label_rank "${cur}")" == "0" ]]; then
+            record_action "#${n} [skipped] (unlabeled; outside managed lifecycle)"
+            continue
+        fi
+        transition_issue "${n}" "${cur}" "${target}" "${platform}"
+        comment_backlink "${n}" "${ctxkey}" "${body}" "${platform}"
+        if [[ "${kind}" == "pr" ]]; then
+            ensure_closing_keyword "${pr}" "${n}" "${platform}"
+        fi
+    done
+    return 0
+}
+
+# ---- subcommand parsing ----------------------------------------------------
+
+DRY_RUN=0
+NO_CREATE=0
+
+parse_common_flags() {
+    REMAIN=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run) DRY_RUN=1; shift ;;
+            --no-create) NO_CREATE=1; shift ;;
+            *) REMAIN+=("$1"); shift ;;
+        esac
+    done
+}
+
+# Inner worker (re-exec target): does the real sync in its own process so that
+# (a) a soft timeout can bound it without losing the ACTIONS summary, and
+# (b) any failure stays contained (parent treats it as a non-fatal warning).
+run_inner() {
+    local kind="$1" pr="$2" commit="$3"
+    DRY_RUN="$4"; NO_CREATE="$5"
+    sync_core "${kind}" "${pr}" "${commit}"
+    print_summary
+}
+
+cmd_sync_pr() {
+    parse_common_flags "$@"
+    local pr="${REMAIN[0]:-}"
+    [[ -n "${pr}" ]] || { err "sync-pr requires a PR number"; return 0; }
+    if [[ "$(cfg_get pr-issue-sync enabled false)" != "true" ]]; then
+        err "pr-issue-sync disabled (set tool_policies.pr-issue-sync.enabled: true)"
+        return 0
+    fi
+    local t
+    t=$(cfg_get pr-issue-sync hook_timeout_seconds 5)
+    [[ "${t}" =~ ^[0-9]+$ ]] || t=5
+    run_with_timeout "${t}" bash "$0" __inner pr "${pr}" "" "${DRY_RUN}" "${NO_CREATE}" \
+        || err "sync degraded to a warning (non-fatal or timed out); re-run heals (FR-017)"
+}
+
+cmd_sync_commit() {
+    parse_common_flags "$@"
+    local commit="${REMAIN[0]:-HEAD}"
+    if [[ "$(cfg_get commit-issue-sync enabled false)" != "true" ]]; then
+        err "commit-issue-sync disabled (set tool_policies.commit-issue-sync.enabled: true)"
+        return 0
+    fi
+    local mode
+    mode=$(cfg_get commit-issue-sync commit_hook_mode sync)
+    if [[ "${mode}" == "background" ]]; then
+        err "commit_hook_mode=background is reserved for a future release; running sync"
+    fi
+    local t
+    t=$(cfg_get commit-issue-sync hook_timeout_seconds 5)
+    [[ "${t}" =~ ^[0-9]+$ ]] || t=5
+    run_with_timeout "${t}" bash "$0" __inner commit "" "${commit}" "${DRY_RUN}" "${NO_CREATE}" \
+        || err "sync degraded to a warning (non-fatal or timed out); re-run heals (FR-017)"
+}
+
+cmd_resolve() {
+    local pr="" commit="" branch="" json=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --pr) pr="$2"; shift 2 ;;
+            --commit) commit="$2"; shift 2 ;;
+            --branch) branch="$2"; shift 2 ;;
+            --json) json=1; shift ;;
+            *) shift ;;
+        esac
+    done
+    [[ -z "${branch}" ]] && branch=$(current_branch)
+    local platform
+    platform=$(detect_platform)
+    local nums=()
+    while IFS= read -r _n; do [[ -n "${_n}" ]] && nums+=("${_n}"); done \
+        < <(resolve_candidates "${branch}" "${pr}" "${commit}" "${platform}")
+    if [[ "${#nums[@]}" -eq 0 ]]; then
+        if [[ "${json}" == "1" ]]; then echo "[]"; else err "no issue resolved"; fi
+        return 3
+    fi
+    if [[ "${json}" == "1" ]]; then
+        printf '['
+        local i
+        for i in "${!nums[@]}"; do
+            [[ "${i}" -gt 0 ]] && printf ','
+            printf '{"number":%s}' "${nums[$i]}"
+        done
+        printf ']\n'
+    else
+        printf '%s\n' "${nums[@]}"
+    fi
+    return 0
+}
+
+# ---- dispatch --------------------------------------------------------------
+
+[[ $# -eq 0 ]] && { usage >&2; exit 1; }
+case "$1" in
+    --help|-h|help) usage; exit 0 ;;
+    sync-pr) shift; cmd_sync_pr "$@"; exit 0 ;;
+    sync-commit) shift; cmd_sync_commit "$@"; exit 0 ;;
+    resolve) shift; cmd_resolve "$@"; exit $? ;;
+    __inner) shift; run_inner "$@"; exit 0 ;;  # internal re-exec target (timeout-bounded worker)
+    *) err "Unknown subcommand: $1"; usage >&2; exit 1 ;;
+esac

--- a/configs/claude/scripts/issue_support.sh
+++ b/configs/claude/scripts/issue_support.sh
@@ -255,12 +255,14 @@ ensure_closing_keyword() {
 # ---- resolution ------------------------------------------------------------
 
 # resolve_candidates <branch> <pr|""> <commit|""> — echo candidate numbers (one per line)
+# Emits one "number|source" per resolved candidate (source: branch-prefix |
+# pr-body | commit-message), de-duplicated by number keeping the first source.
 resolve_candidates() {
     local branch="$1" pr="$2" commit="$3" platform="$4"
     local -a out=()
     # 1) branch-number prefix (strip leading zeros: 017-foo → issue #17)
     if [[ "${branch}" =~ ^([0-9]+)- ]]; then
-        out+=("$((10#${BASH_REMATCH[1]}))")
+        out+=("$((10#${BASH_REMATCH[1]}))|branch-prefix")
     fi
     # 2) PR/MR body references
     if [[ -n "${pr}" ]]; then
@@ -270,15 +272,15 @@ resolve_candidates() {
         else
             body=$(git_ops pr-view "${pr}" --output json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("description",""))' 2>/dev/null || true)
         fi
-        while IFS= read -r r; do [[ -n "${r}" ]] && out+=("${r}"); done < <(printf '%s' "${body}" | extract_refs)
+        while IFS= read -r r; do [[ -n "${r}" ]] && out+=("${r}|pr-body"); done < <(printf '%s' "${body}" | extract_refs)
     fi
     # 3) commit-message references + trailers
     if [[ -n "${commit}" ]]; then
         local msg
         msg=$(git log -1 --format='%B' "${commit}" 2>/dev/null || true)
-        while IFS= read -r r; do [[ -n "${r}" ]] && out+=("${r}"); done < <(printf '%s' "${msg}" | extract_refs)
+        while IFS= read -r r; do [[ -n "${r}" ]] && out+=("${r}|commit-message"); done < <(printf '%s' "${msg}" | extract_refs)
     fi
-    printf '%s\n' "${out[@]+"${out[@]}"}" | grep -E '^[0-9]+$' | awk 'NF' | awk '!seen[$0]++' || true
+    printf '%s\n' "${out[@]+"${out[@]}"}" | awk -F'|' '$1 ~ /^[0-9]+$/ && !seen[$1]++' || true
 }
 
 # ---- platform gate ---------------------------------------------------------
@@ -403,7 +405,7 @@ sync_core() {
     fi
 
     local candidates=()
-    while IFS= read -r _c; do [[ -n "${_c}" ]] && candidates+=("${_c}"); done \
+    while IFS= read -r _c; do [[ -n "${_c}" ]] && candidates+=("${_c%%|*}"); done \
         < <(resolve_candidates "${branch}" "${pr}" "${commit}" "${platform}")
     if [[ "${#candidates[@]}" -eq 0 ]]; then
         offer_create "${branch}" "${pr}" "${commit}" "${platform}"
@@ -499,23 +501,35 @@ cmd_resolve() {
     [[ -z "${branch}" ]] && branch=$(current_branch)
     local platform
     platform=$(detect_platform)
-    local nums=()
-    while IFS= read -r _n; do [[ -n "${_n}" ]] && nums+=("${_n}"); done \
+    local refs=()
+    while IFS= read -r _n; do [[ -n "${_n}" ]] && refs+=("${_n}"); done \
         < <(resolve_candidates "${branch}" "${pr}" "${commit}" "${platform}")
-    if [[ "${#nums[@]}" -eq 0 ]]; then
+    if [[ "${#refs[@]}" -eq 0 ]]; then
         if [[ "${json}" == "1" ]]; then echo "[]"; else err "no issue resolved"; fi
         return 3
     fi
     if [[ "${json}" == "1" ]]; then
+        # Emit the full IssueRef per the data model: number, source, and (when the
+        # tracker is reachable) exists/state/label validated via issue-view.
         printf '['
-        local i
-        for i in "${!nums[@]}"; do
+        local i num source rec state labels exists cur
+        for i in "${!refs[@]}"; do
+            num="${refs[$i]%%|*}"; source="${refs[$i]#*|}"
+            rec=$(issue_record "${num}" "${platform}")
+            if [[ -n "${rec}" ]]; then
+                IFS='|' read -r _ state labels _ <<<"${rec}"
+                exists=true; cur=$(record_label "${labels}")
+            else
+                exists=false; state=""; cur=""
+            fi
             [[ "${i}" -gt 0 ]] && printf ','
-            printf '{"number":%s}' "${nums[$i]}"
+            printf '{"number":%s,"source":"%s","exists":%s,"state":"%s","label":"%s"}' \
+                "${num}" "${source}" "${exists}" "${state}" "${cur}"
         done
         printf ']\n'
     else
-        printf '%s\n' "${nums[@]}"  # array-safe: non-empty (returned 3 above if empty)
+        local r
+        for r in "${refs[@]}"; do printf '%s\n' "${r%%|*}"; done  # array-safe: non-empty (returned 3 above)
     fi
     return 0
 }

--- a/configs/claude/scripts/issue_support.sh
+++ b/configs/claude/scripts/issue_support.sh
@@ -236,7 +236,7 @@ ensure_closing_keyword() {
     else
         body=$(git_ops pr-view "${pr}" --output json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("description",""))' 2>/dev/null || true)
     fi
-    if printf '%s' "${body}" | grep -qiE "(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#${n}\b"; then
+    if printf '%s' "${body}" | grep -qiE "(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#${n}([^0-9]|$)"; then
         record_action "PR #${pr} closing-keyword Closes #${n} [skipped] (already present)"
         return 0
     fi
@@ -302,18 +302,24 @@ render_template() {
     fi
 }
 
-# offer_create <branch> <pr> <commit> <platform> — dedup, confirm, create
+# offer_create <branch> <pr> <commit> <platform> — dedup, confirm, create.
+# On reuse or successful creation, sets the global NEW_ISSUE to that issue number
+# so sync_core can run the normal sync lifecycle on it (FR-009c).
+NEW_ISSUE=""
 offer_create() {
     local branch="$1" pr="$2" commit="$3" platform="$4"
+    NEW_ISSUE=""
     if [[ "${NO_CREATE:-0}" == "1" ]]; then
         record_action "create-issue [skipped] (--no-create)"
         return 0
     fi
     # dedup: search for an existing open issue matching the branch
-    local existing=""
+    local existing num=""
     existing=$(git_ops issue-list --search "${branch}" 2>/dev/null | head -1 || true)
     if [[ -n "${existing}" ]]; then
-        record_action "create-issue [skipped] (existing match reused: ${existing%% *})"
+        num=$(printf '%s' "${existing}" | grep -oE '[0-9]+' | head -1 || true)
+        record_action "create-issue [skipped] (existing match reused: #${num:-?})"
+        NEW_ISSUE="${num}"
         return 0
     fi
     if ! is_interactive; then
@@ -331,15 +337,46 @@ offer_create() {
         record_action "create-issue [applied] (dry-run, not created)"
         return 0
     fi
-    local title="${branch}" bodyfile
+    local title="${branch}" bodyfile out
     bodyfile=$(mktemp)
     render_template "${branch}" "${pr}" "${commit}" >"${bodyfile}"
-    if git_ops issue-create --title "${title}" --body-file "${bodyfile}" --label planned >/dev/null 2>&1; then
-        record_action "create-issue [applied] (labeled planned, from template)"
+    if out=$(git_ops issue-create --title "${title}" --body-file "${bodyfile}" --label planned 2>/dev/null); then
+        # gh/glab print the new issue URL; the trailing number is the issue id.
+        num=$(printf '%s' "${out}" | grep -oE '[0-9]+' | tail -1 || true)
+        record_action "create-issue [applied] (#${num:-?}, labeled planned, from template)"
+        NEW_ISSUE="${num}"
     else
         record_action "create-issue [failed] (issue-create error)"
     fi
     rm -f "${bodyfile}"
+}
+
+# process_issue <n> <kind> <pr> <target> <ctxkey> <body> <platform>
+# Apply the normal sync to a single issue (transition + comment + closing keyword).
+process_issue() {
+    local n="$1" kind="$2" pr="$3" target="$4" ctxkey="$5" body="$6" platform="$7"
+    local rec state cur _num _labels _title
+    rec=$(issue_record "${n}" "${platform}")
+    if [[ -z "${rec}" ]]; then
+        record_action "#${n} [skipped] (issue not found)"
+        return 0
+    fi
+    IFS='|' read -r _num state _labels _title <<<"${rec}"
+    if [[ "${state}" == "closed" || "${state}" == "locked" ]]; then
+        record_action "#${n} [skipped] (issue ${state})"
+        return 0
+    fi
+    cur=$(record_label "${_labels}")
+    # commit trigger only advances issues already labeled 'planned'
+    if [[ "${kind}" == "commit" && "$(label_rank "${cur}")" == "0" ]]; then
+        record_action "#${n} [skipped] (unlabeled; outside managed lifecycle)"
+        return 0
+    fi
+    transition_issue "${n}" "${cur}" "${target}" "${platform}"
+    comment_backlink "${n}" "${ctxkey}" "${body}" "${platform}"
+    if [[ "${kind}" == "pr" ]]; then
+        ensure_closing_keyword "${pr}" "${n}" "${platform}"
+    fi
 }
 
 # ---- sync orchestration ----------------------------------------------------
@@ -370,32 +407,16 @@ sync_core() {
         < <(resolve_candidates "${branch}" "${pr}" "${commit}" "${platform}")
     if [[ "${#candidates[@]}" -eq 0 ]]; then
         offer_create "${branch}" "${pr}" "${commit}" "${platform}"
+        # A reused/created issue enters the normal sync lifecycle immediately (FR-009c).
+        if [[ -n "${NEW_ISSUE}" ]]; then
+            process_issue "${NEW_ISSUE}" "${kind}" "${pr}" "${target}" "${ctxkey}" "${body}" "${platform}"
+        fi
         return 0
     fi
 
-    local n rec state cur
+    local n
     for n in "${candidates[@]}"; do  # array-safe: non-empty (early-returned above)
-        rec=$(issue_record "${n}" "${platform}")
-        if [[ -z "${rec}" ]]; then
-            record_action "#${n} [skipped] (issue not found)"
-            continue
-        fi
-        IFS='|' read -r _num state _labels _title <<<"${rec}"
-        if [[ "${state}" == "closed" || "${state}" == "locked" ]]; then
-            record_action "#${n} [skipped] (issue ${state})"
-            continue
-        fi
-        cur=$(record_label "${_labels}")
-        # commit trigger only advances issues already labeled 'planned'
-        if [[ "${kind}" == "commit" && "$(label_rank "${cur}")" == "0" ]]; then
-            record_action "#${n} [skipped] (unlabeled; outside managed lifecycle)"
-            continue
-        fi
-        transition_issue "${n}" "${cur}" "${target}" "${platform}"
-        comment_backlink "${n}" "${ctxkey}" "${body}" "${platform}"
-        if [[ "${kind}" == "pr" ]]; then
-            ensure_closing_keyword "${pr}" "${n}" "${platform}"
-        fi
+        process_issue "${n}" "${kind}" "${pr}" "${target}" "${ctxkey}" "${body}" "${platform}"
     done
     return 0
 }

--- a/configs/claude/scripts/issue_support_hook.sh
+++ b/configs/claude/scripts/issue_support_hook.sh
@@ -39,9 +39,11 @@ if isinstance(resp, dict) and (resp.get("is_error") or resp.get("error")):
     ok = 0
 low = cmd.lower()
 cl = "none"
-if re.search(r"(pr[ -]create|mr[ -]create)", low):
+# Anchor on an actual CLI invocation (gh/glab/git/git_ops.sh) so that unrelated
+# commands containing "pr-create" or "git ... commit" as substrings do not fire.
+if re.search(r"^\s*(sudo\s+)?(\S*/)?(gh|glab|\S*git_ops\.sh)\s+(pr|mr)[ -]create\b", low):
     cl = "pr"
-elif re.search(r"\bgit\b.{0,40}\bcommit\b", low):
+elif re.search(r"^\s*(sudo\s+)?(\S*/)?(\S*git_ops\.sh\s+commit|git\s+commit)\b", low):
     cl = "commit"
 print("%s\t%s" % (cl, ok))
 '

--- a/configs/claude/scripts/issue_support_hook.sh
+++ b/configs/claude/scripts/issue_support_hook.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# issue_support_hook.sh - PostToolUse dispatcher for the issue-linking hooks.
+#
+# Reads a PostToolUse payload (JSON) on stdin, inspects the Bash command that
+# just ran, and routes to the issue-support engine ONLY when that command
+# succeeded:
+#   * a PR/MR-creating command  -> issue_support.sh sync-pr
+#   * a git commit              -> issue_support.sh sync-commit HEAD
+# Never blocks: always exits 0 (PostToolUse must not fail the tool).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE="${ISSUE_SUPPORT_ENGINE:-${SCRIPT_DIR}/issue_support.sh}"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    cat <<'USAGE'
+Usage: issue_support_hook.sh < <PostToolUse-JSON>
+
+Internal PostToolUse dispatcher. Reads the hook payload on stdin, and on a
+successful PR-create / commit command invokes issue_support.sh. Always exits 0.
+USAGE
+    exit 0
+fi
+
+payload="$(cat 2>/dev/null || true)"
+
+# Classify the command and success. Prints "<class>\t<ok>" (class: pr|commit|none).
+CLASSIFY_PY='
+import sys, json, re
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print("none\t0"); sys.exit(0)
+cmd = ((d.get("tool_input") or {}).get("command") or "")
+resp = d.get("tool_response")
+ok = 1
+if isinstance(resp, dict) and (resp.get("is_error") or resp.get("error")):
+    ok = 0
+low = cmd.lower()
+cl = "none"
+if re.search(r"(pr[ -]create|mr[ -]create)", low):
+    cl = "pr"
+elif re.search(r"\bgit\b.{0,40}\bcommit\b", low):
+    cl = "commit"
+print("%s\t%s" % (cl, ok))
+'
+
+result="$(printf '%s' "${payload}" | python3 -c "${CLASSIFY_PY}" 2>/dev/null || printf 'none\t0')"
+cls="${result%%	*}"
+ok="${result##*	}"
+
+if [[ "${ok}" != "1" ]]; then
+    exit 0   # the underlying command failed (H4) — do not sync
+fi
+
+case "${cls}" in
+    pr)     "${ENGINE}" sync-pr     >&2 2>&1 || true ;;
+    commit) "${ENGINE}" sync-commit HEAD >&2 2>&1 || true ;;
+    *)      : ;;
+esac
+
+exit 0

--- a/configs/claude/scripts/templates/issue_support_issue.md
+++ b/configs/claude/scripts/templates/issue_support_issue.md
@@ -1,0 +1,19 @@
+## Context
+
+Auto-created tracking issue for work on {{LINK}}.
+
+This issue was generated because development activity was detected with no linked
+tracking issue. It is labeled `planned` and enters the normal issue-sync lifecycle
+(commit → `in-progress`, PR opened → `needs-review`).
+
+## Acceptance Criteria
+
+- [ ] Describe the intended outcome of this work
+- [ ] List the conditions that must hold for this issue to be considered done
+
+## Links
+
+- Branch: `{{BRANCH}}`
+- Originating reference: {{LINK}}
+
+<!-- Created by issue_support.sh (issue-linking hooks). Edit freely — it is a real issue. -->

--- a/configs/cursor/rules/commit-issue-sync.mdc
+++ b/configs/cursor/rules/commit-issue-sync.mdc
@@ -1,0 +1,15 @@
+---
+description: "Keep the linked GitHub/GitLab issue in sync when commits land on a feature branch: advance a planned issue to in-progress, deduplicated across commits. Runs as a hook (PostToolUse or native post-commit); fail-open (never blocks the commit)."
+globs: ".claude/skills/commit-issue-sync/**"
+alwaysApply: false
+---
+
+# commit-issue-sync
+
+Keep the linked GitHub/GitLab issue in sync when commits land on a feature branch: advance a planned issue to in-progress, deduplicated across commits. Runs as a hook (PostToolUse or native post-commit); fail-open (never blocks the commit).
+
+<!-- Auto-generated from .claude/skills/commit-issue-sync/SKILL.md -->
+<!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
+
+Refer to `.cursor/skills/commit-issue-sync/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/pr-issue-sync.mdc
+++ b/configs/cursor/rules/pr-issue-sync.mdc
@@ -1,0 +1,15 @@
+---
+description: "Keep the linked GitHub/GitLab issue in sync when a pull/merge request is opened: back-link comment, advance status label to needs-review, ensure the closing keyword. Runs as a PostToolUse hook; fail-open (never blocks PR creation)."
+globs: ".claude/skills/pr-issue-sync/**"
+alwaysApply: false
+---
+
+# pr-issue-sync
+
+Keep the linked GitHub/GitLab issue in sync when a pull/merge request is opened: back-link comment, advance status label to needs-review, ensure the closing keyword. Runs as a PostToolUse hook; fail-open (never blocks PR creation).
+
+<!-- Auto-generated from .claude/skills/pr-issue-sync/SKILL.md -->
+<!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
+
+Refer to `.cursor/skills/pr-issue-sync/SKILL.md` for the full skill definition.
+

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -43,6 +43,8 @@ frontmatter is the authoritative name and description.
 | `/refactor-terraform` | Terraform/OpenTofu IaC security, modularity, and quality analysis | ALWAYS |
 | `/issue-triage` | Linear issue audit: duplicates, staleness, priority validation | CONDITIONAL |
 | `/issue-prioritize` | Score and rank open issues by impact/urgency/readiness/risk | CONDITIONAL |
+| `/pr-issue-sync` | Hook-triggered: on PR open, back-link + advance linked issue to `needs-review` + ensure closing keyword (fail-open) | NO |
+| `/commit-issue-sync` | Hook-triggered: on branch commit, advance a `planned` issue to `in-progress`, deduped (fail-open) | NO |
 | `/plan-manage` | Plan lifecycle with parallel agent orchestration | CONDITIONAL |
 | `/browser-test` | AI-powered E2E browser testing via browser-use YAML test prompts | CONDITIONAL |
 | `/checkpoint` | Create compact checkpoint summary when context is high | NO |
@@ -129,6 +131,32 @@ across GitHub, GitLab, and Linear.
 # List labels in Linear
 ~/.claude/scripts/linear_ops.sh label-list --team ENG
 ```
+
+---
+
+## Issue-Linking Hooks
+
+Two opt-in, fail-open hooks keep the linked GitHub/GitLab issue in sync with
+development activity (skills `pr-issue-sync` and `commit-issue-sync`, over the shared
+`issue_support.sh` engine). They never block a git action.
+
+```bash
+# Enable (unified PostToolUse hook); add --native for a guarded git post-commit hook
+configs/claude/scripts/install_issue_hooks.sh --enable [--native]
+
+# Preview / debug without mutating the tracker
+configs/claude/scripts/issue_support.sh sync-pr --dry-run
+configs/claude/scripts/issue_support.sh resolve --branch 005-my-feature --json
+
+# Disable (keeps the skills; flips the runtime gate off and removes the hooks)
+configs/claude/scripts/install_issue_hooks.sh --remove
+```
+
+Behavior: PR opened → linked issue advances to `needs-review` + back-link + `Closes #N`;
+commit on a branch → a `planned` issue advances to `in-progress` (deduped). Coverage
+boundary: PR creation via the web UI or raw `gh`/`glab` outside a tool is not
+auto-observed — run `issue_support.sh sync-pr` manually there. Config:
+`command_config.yml → tool_policies.{pr,commit}-issue-sync`.
 
 ---
 

--- a/specs/005-issue-linking-hooks/checklists/requirements.md
+++ b/specs/005-issue-linking-hooks/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Issue-Linking Git Hooks
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Two clarifying decisions were resolved interactively before drafting: **action posture = auto-update the linked issue, fail-open** and **missing issue = offer to create on confirmation**. Both are encoded in FR-005/FR-006/FR-008/FR-009 and the Assumptions section, so no [NEEDS CLARIFICATION] markers remain.
+- Two design-phase details intentionally deferred to `/speckit-plan` (not spec-blocking): the exact commit hook surface (post-commit vs pre-push) and whether PR re-runs on update are added beyond v1's open/create trigger. Both are bounded in Assumptions.
+- Items marked incomplete would require spec updates before `/speckit-clarify` or `/speckit-plan`; none remain.

--- a/specs/005-issue-linking-hooks/contracts/hook_contract.md
+++ b/specs/005-issue-linking-hooks/contracts/hook_contract.md
@@ -1,0 +1,36 @@
+# Contract: Hook trigger & installation
+
+How the two skills are wired to fire. Installer: `configs/claude/scripts/install_issue_hooks.sh` (idempotent, `--help`, guarded — Constitution V).
+
+## Primary: unified `PostToolUse` hook (cross-tool)
+
+Installed via the `ai-hooks-integration` mechanism into the active tool's settings (Claude Code `settings.json` `hooks.PostToolUse`, and the Gemini/Cursor equivalents the unified installer manages). One entry per skill, matched on the Bash command text.
+
+| Skill | Matcher (command text) | Action |
+|-------|------------------------|--------|
+| `pr-issue-sync` | `pr-create` \| `gh pr create` \| `glab mr create` | `issue_support.sh sync-pr <resolved PR number>` |
+| `commit-issue-sync` | `git commit` (and `git_ops.sh`-mediated commits) | `issue_support.sh sync-commit HEAD` |
+
+**Payload → engine mapping**: the hook reads the canonical normalized payload (tool, command, exit code). It invokes the engine ONLY when the matched command **succeeded** (a failed `git commit`/`pr create` must not trigger a sync). PR number is parsed from the command's stdout (the URL/number `gh`/`glab` print on success).
+
+**Timeout**: the hook entry sets `timeout` ≥ `hook_timeout_seconds`; the engine enforces its own soft timeout inside that budget and always exits 0.
+
+## Secondary: native `post-commit` git hook (opt-in fallback)
+
+For commits made outside an AI tool. `install_issue_hooks.sh --native` writes `.git/hooks/post-commit` calling `issue_support.sh sync-commit HEAD` **only if**:
+- no existing `post-commit` hook is present (refuse to clobber; print guidance to merge manually), and
+- the installer appends, never overwrites, when it owns an existing managed block (delimited by `# >>> issue-support >>>` / `# <<< issue-support <<<`).
+
+The native hook is intentionally commit-only — there is no native git event for PR creation.
+
+## Idempotency / install guarantees (testable)
+| ID | Guarantee | Maps to |
+|----|-----------|---------|
+| H1 | Re-running the installer does not create duplicate hook entries (settings or native block) | Constitution V, FR-015 |
+| H2 | Installer never overwrites a foreign `post-commit` hook | Constitution V |
+| H3 | Hooks are opt-in: absent `enabled: true` (or `--enable`), install is a no-op that explains how to enable | FR-015 |
+| H4 | A failed underlying git/PR command does NOT fire the engine | (correctness) |
+| H5 | Uninstall (`--remove`) cleanly removes both the settings entry and the managed native block | retire/cleanup hygiene |
+
+## Disable / uninstall
+`install_issue_hooks.sh --remove` removes the managed entries from settings and the delimited native block, leaving the skills and engine in place (FR-015: disable without removing skills).

--- a/specs/005-issue-linking-hooks/contracts/hook_contract.md
+++ b/specs/005-issue-linking-hooks/contracts/hook_contract.md
@@ -11,7 +11,7 @@ Installed via the `ai-hooks-integration` mechanism into the active tool's settin
 | `pr-issue-sync` | `pr-create` \| `gh pr create` \| `glab mr create` | `issue_support.sh sync-pr <resolved PR number>` |
 | `commit-issue-sync` | `git commit` (and `git_ops.sh`-mediated commits) | `issue_support.sh sync-commit HEAD` |
 
-**Payload → engine mapping**: the hook reads the canonical normalized payload (tool, command, exit code). It invokes the engine ONLY when the matched command **succeeded** (a failed `git commit`/`pr create` must not trigger a sync). PR number is parsed from the command's stdout (the URL/number `gh`/`glab` print on success).
+**Payload → engine mapping**: the hook reads the canonical normalized payload (tool, command, exit code). It invokes the engine ONLY when the matched command **succeeded** (a failed `git commit`/`pr create` must not trigger a sync). The dispatcher does **not** parse the PR number out of command stdout (fragile across `gh`/`glab` output formats); it calls `issue_support.sh sync-pr` with no argument and the engine **self-resolves** the current branch's open PR/MR via `pr-view`. If that lookup returns nothing (e.g. detached PR, or `glab mr view` can't resolve an MR for the branch), `sync-pr` degrades to a non-blocking warning (fail-open) — the issue still gets kept current by the next commit hook, or via a manual `sync-pr <N>`.
 
 **Timeout**: the hook entry sets `timeout` ≥ `hook_timeout_seconds`; the engine enforces its own soft timeout inside that budget and always exits 0.
 

--- a/specs/005-issue-linking-hooks/contracts/issue_support_cli.md
+++ b/specs/005-issue-linking-hooks/contracts/issue_support_cli.md
@@ -1,0 +1,53 @@
+# Contract: `issue_support.sh` (shared engine CLI)
+
+Platform-agnostic engine, sibling to `git_ops.sh`. Bash, `set -euo pipefail`, `err()` for diagnostics, `--help` ≤15 lines. **Fail-open**: every user-facing subcommand exits `0` even on internal failure (a non-zero exit is reserved for usage errors only).
+
+## Subcommands
+
+### `issue_support.sh sync-pr <PR_NUMBER> [--dry-run] [--no-create]`
+Run the full PR-trigger flow for an opened PR/MR.
+- Resolves `IssueRef[]` (R3), advances each open issue to `needs-review`, posts/refreshes the marker back-link comment, ensures `Closes #N` in the PR body.
+- No linked issue → offer best-of-breed creation (unless `--no-create` or non-interactive).
+- **Exit**: `0` always (fail-open). `--dry-run` prints planned `SyncAction[]` without mutating.
+
+### `issue_support.sh sync-commit <SHA|HEAD> [--dry-run] [--no-create]`
+Run the commit-trigger flow.
+- Resolves `IssueRef[]`, advances each open issue already labeled `planned` to `in-progress` (unlabeled issues left untouched, FR-006), dedup-guards the comment.
+- Respects `commit_hook_mode`; in `background` mode returns immediately and detaches the work.
+- **Exit**: `0` always.
+
+### `issue_support.sh resolve <--pr N | --commit SHA | --branch NAME>`
+Resolution-only (no mutation). Prints resolved `IssueRef[]` as JSON. Used by tests and `--dry-run`. **Exit**: `0` on success, `3` if no issue resolved (informational, still non-fatal to callers that ignore it).
+
+### `issue_support.sh --help`
+Usage + flags, exit `0`.
+
+## Inputs / environment
+| Input | Source |
+|-------|--------|
+| Active platform | `git_platform.sh` (or `MANIFEST_GIT_PLATFORM`) |
+| Tracker operations | `git_ops.sh issue-view/issue-list/issue-comment/issue-comment-edit-last/issue-edit/issue-create/pr-view` |
+| PR-body write (closing keyword) | `git_ops.sh pr-edit <N>` — **new** thin wrapper (`gh pr edit --body` / `glab mr update --description`); appends `Closes #N` non-destructively when missing. Absent/failed → warn-only (C1 fail-open) |
+| Canonical labels | `labels.yml` |
+| Created-issue template | `configs/claude/scripts/templates/issue_support_issue.md` (engine-relative path; identical for both skills) |
+| `hook_timeout_seconds`, `commit_hook_mode`, `enabled` | `command_config.yml` → `tool_policies.{pr-issue-sync,commit-issue-sync}` |
+
+## Output contract (stdout)
+Human-readable summary, one line per `SyncAction`:
+```text
+issue-support: #17 transition planned→needs-review [applied]
+issue-support: #17 comment back-link [skipped] (marker already present)
+issue-support: PR body closing-keyword Closes #17 [applied]
+```
+`--dry-run` prefixes each line with `(dry-run)`. JSON form available via `resolve` and `--json`.
+
+## Behavioral guarantees (testable)
+| ID | Guarantee | Maps to |
+|----|-----------|---------|
+| C1 | Never exits non-zero from `sync-pr`/`sync-commit`, even when `git_ops.sh` fails or times out | FR-008, SC-002 |
+| C2 | Re-running against an already-correct issue produces only `skipped` actions | FR-007, SC-003 |
+| C3 | Resolution precedence is branch-prefix → pr-body → commit-message (inline refs + trailers); unresolved prefix falls through | R3, FR-004 |
+| C4 | Closed/locked issues are skipped with a warning, never mutated | FR-013 |
+| C5 | Forward-only transitions; an issue at `needs-review` is never moved back to `in-progress` | FR-006a |
+| C6 | `--no-create` and non-interactive both suppress issue creation | FR-009 |
+| C7 | Multiple resolved issues are each acted on; ambiguous conflicts reported not auto-picked | FR-011, FR-012 |

--- a/specs/005-issue-linking-hooks/data-model.md
+++ b/specs/005-issue-linking-hooks/data-model.md
@@ -1,0 +1,85 @@
+# Phase 1 Data Model: Issue-Linking Git Hooks
+
+The feature is stateless (no database). "Entities" here are the in-memory structures the engine passes between resolution → action → reporting, and the canonical state machine it enforces. Field names are authoritative and MUST match the contracts and tasks.
+
+## Entities
+
+### IssueRef (resolved association)
+A linked issue the engine will act on.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `number` | int | Issue/MR number on the active platform |
+| `source` | enum | How resolved: `branch-prefix` \| `pr-body` \| `commit-message` (inline `#N`/`Fixes #N` refs **and** `Issue:`/`Refs:` trailers) |
+| `state` | enum | `open` \| `closed` \| `locked` (from `git_ops.sh issue-view`) |
+| `label` | enum\|null | Current canonical status label, or null if unlabeled |
+| `exists` | bool | False if a candidate number did not resolve to a real issue |
+
+**Rules**: Only `exists && state == open` issues are mutated (FR-013). Multiple distinct `IssueRef`s per trigger are acted on independently (FR-011). Conflicting candidates → report, do not auto-pick (FR-012).
+
+### TriggerContext
+The event that fired a skill.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | enum | `pr-open` \| `commit` |
+| `platform` | enum | `github` \| `gitlab` (from `git_platform.sh`); `git`/none → no-op exit |
+| `branch` | string | Current branch; its `NNN-` prefix is the primary resolver |
+| `pr_number` | int\|null | Set for `pr-open` |
+| `commit_sha` | string\|null | Set for `commit` |
+| `interactive` | bool | Whether a create-issue prompt can be answered (FR-009) |
+
+### SyncAction (one engine operation + outcome)
+| Field | Type | Notes |
+|-------|------|-------|
+| `type` | enum | `comment` \| `transition` \| `ensure-closing-keyword` \| `create-issue` \| `link` |
+| `target` | int\|null | Issue number acted on (null for not-yet-created) |
+| `result` | enum | `applied` \| `skipped` \| `failed` |
+| `reason` | string | Human-readable why (drives the FR-014 summary) |
+
+### CreatedIssue (best-of-breed creation payload)
+| Field | Type | Notes |
+|-------|------|-------|
+| `title` | string | Derived from branch/PR/commit context |
+| `body` | string | Rendered from `references/issue-template.md` — context + acceptance criteria + bidirectional links |
+| `labels` | string[] | Canonical; defaults to `["planned"]` |
+| `dedup_match` | int\|null | If set, an existing issue was found and reused instead of creating (FR-009a) |
+
+### HookConfig (resolved from command_config.yml)
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `hook_timeout_seconds` | int | `5` | Soft timeout bound (R6) |
+| `commit_hook_mode` | enum | `sync` | `sync` \| `background` |
+| `enabled` | bool | `false` (opt-in) | Per FR-015 |
+
+## State machine — issue status label (forward-only)
+
+Canonical labels from `labels.yml`. Transitions are **monotonic**: the engine never moves an issue backward (FR-006a).
+
+```text
+        commit on branch              PR / MR opened              human/CI marks done
+   (only if labeled `planned`)
+planned ───────────────▶ in-progress ──────────────▶ needs-review ─────────────▶ done
+   │                          │                            │
+   └── already ≥ target? ─────┴─── no-op (idempotent) ─────┘
+```
+
+| Trigger | From | To | Condition |
+|---------|------|----|-----------|
+| `commit` | `planned` | `in-progress` | issue open AND already labeled `planned`; not already ≥ in-progress. Unlabeled issues are left untouched (outside managed lifecycle, FR-006) |
+| `pr-open` | any ≤ in-progress | `needs-review` | issue open; not already ≥ needs-review |
+| any | `needs-review` / `done` | — | no-op (already at/after target) |
+| any | `closed` / `locked` | — | skip + warn (FR-013) |
+
+`done` is **not** set by these hooks (left to merge/CI/human); shown for completeness.
+
+## Derived dedup keys (no persistence)
+- **Transition dedup**: `label >= target` in the ordered set `{planned<in-progress<needs-review<done}`.
+- **Comment dedup**: presence of marker `<!-- issue-support:sync v1 pr=<n>|commit=<branch> -->` in existing issue comments (R2).
+- **Create dedup**: open-issue title/branch-context match (R4 / FR-009a).
+
+## Validation rules (from requirements)
+- A candidate `IssueRef.number` MUST be confirmed via `issue-view` before any mutation (`exists` gate).
+- All four `SyncAction.type` mutations MUST be idempotent (FR-007): re-running yields `skipped` with reason "already correct".
+- Engine MUST emit the full `SyncAction[]` list as the run summary (FR-014).
+- On any failure/timeout, engine exits 0 (fail-open, FR-008) with a `failed`/`skipped` action recorded.

--- a/specs/005-issue-linking-hooks/plan.md
+++ b/specs/005-issue-linking-hooks/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Issue-Linking Git Hooks
+
+**Branch**: `005-issue-linking-hooks` | **Date**: 2026-06-14 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/005-issue-linking-hooks/spec.md`
+
+## Summary
+
+Deliver two companion, hook-triggered skills — **`pr-issue-sync`** (fires when a pull/merge request is opened) and **`commit-issue-sync`** (fires when commits land on a feature branch) — over a single shared **issue-support engine** implemented as `configs/claude/scripts/issue_support.sh`, a platform-agnostic sibling to `git_ops.sh`. The engine resolves the linked issue(s) from branch-number prefix → PR/MR body references → commit-message references/trailers, then idempotently advances status labels (`planned`→`in-progress` on commit, for issues already labeled `planned`; →`needs-review` on PR), posts a back-link comment, ensures closing keywords, and — when no issue is found — offers to create a best-of-breed tracking issue (dedup-checked, templated, canonically labeled). All behavior is **fail-open** within a configurable soft timeout (`hook_timeout_seconds`, default 5s) and self-heals via idempotency. Triggering reuses the repo's existing `ai-hooks-integration` unified `PostToolUse` mechanism (cross-tool) matched to PR-create and commit commands, with a guarded native `post-commit` git hook installer as a fallback for raw-CLI usage.
+
+## Technical Context
+
+**Language/Version**: Bash (`set -euo pipefail`, matching `git_ops.sh`/`label_sync.sh`); Python 3 only for JSON/YAML parsing of `gh`/`glab` output and `command_config.yml`, mirroring the `label_sync.sh` precedent. `jq` used where `git_ops.sh` already uses it.
+
+**Primary Dependencies**: Existing repo scripts — `git_ops.sh` (issue-view/issue-comment/issue-comment-edit-last/issue-edit/issue-create/issue-list/pr-view subcommands), `git_platform.sh` (github|gitlab|git detection), `labels.yml` + `label_sync.sh` (canonical labels), `ai-hooks-integration` (unified hook install). External CLIs `gh` and `glab` (invoked only through `git_ops.sh`, never directly). **New primitive required**: `git_ops.sh` currently has no PR-body write path, so this feature adds a minimal `git_ops.sh pr-edit <N>` subcommand (thin wrapper over `gh pr edit --body` / `glab mr update --description`) to support non-destructive closing-keyword insertion (FR-005). This is a natural sibling to the existing `pr-create`/`pr-merge`/`issue-edit` primitives — extending the platform-ops wrapper, not absorbing skill logic (Constitution IV-compatible).
+
+**Storage**: None. Dedup/idempotency are derived from live tracker state (existing labels + a marker line in the engine's own back-link comment), not local files — so a timed-out or repeated run is self-correcting with no persisted state to drift.
+
+**Testing**: `bats` shell tests in `tests/bats/issue_support.bats` (engine subcommands, resolution precedence, idempotency, fail-open); optional `pytest` in `tests/python/` for any Python parsing helper. Fixtures under `tests/fixtures/`.
+
+**Target Platform**: macOS / Linux developer machines and CI (same surface as the rest of the repo).
+
+**Project Type**: CLI / automation skill set (single-project shell-and-config layout).
+
+**Performance Goals**: A hook adds ≤ `hook_timeout_seconds` (default 5s) to any git action; after the first commit on a branch, subsequent commits short-circuit to a sub-second no-op via dedup (SC-007).
+
+**Constraints**: Fail-open (never abort PR creation or commit — SC-002); all mutations idempotent and forward-only; no new per-repo platform configuration beyond enabling the hook; conforms to repo script conventions (`err()`, `--help` ≤15 lines, `set -euo pipefail`).
+
+**Scale/Scope**: Single repository, per-developer cadence; modest API-call volume (a handful of calls per PR/commit, dedup-bounded). v1 targets GitHub + GitLab per the feature request; Linear is an explicit extension point (see research.md), not v1 scope.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment | Status |
+|-----------|-----------|--------|
+| **I. Configuration-as-Code** | All artifacts land in `configs/` (engine script, config) and `.skillshare/skills/` (the two skills); nothing edits deployed `~/.claude` directly; hook install is reproducible. | ✅ PASS |
+| **II. Parallel Agent Orchestration** | The engine handles a platform token and creates/mutates external issues; the change will exceed 200 lines. Tier 1 cross-verification via `parallel_agent.py` is REQUIRED at PR review (recorded as a process obligation, not a code change). | ✅ PASS (review gate noted) |
+| **III. Consensus-Driven Decisions** | Applies at review time against the standard thresholds; no plan-level conflict. | ✅ PASS |
+| **IV. Skill-First Extensibility** | New capability ships as two discrete, independently-invocable skills. The shared engine is a new sibling ops script (analogous to `git_ops.sh`/`linear_ops.sh`), NOT new behavior bolted onto `parallel_agent.py`. The one core-script edit — adding `pr-edit` to `git_ops.sh` — is a missing platform-ops primitive (sibling to existing `pr-create`/`pr-merge`/`issue-edit`), not skill logic absorbed into the core. | ✅ PASS |
+| **V. Bootstrap Reproducibility** | Hook installation MUST be idempotent and guarded by existence checks (no duplicate hook entries; native `post-commit` installer refuses to clobber an existing hook). | ✅ PASS (idempotency requirement carried into design) |
+
+**Result**: No violations. Complexity Tracking table not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-issue-linking-hooks/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — trigger mechanism, dedup, Linear scope, PR detection
+├── data-model.md        # Phase 1 output — entities & state transitions
+├── quickstart.md        # Phase 1 output — enable/verify walkthrough
+├── contracts/           # Phase 1 output
+│   ├── issue_support_cli.md   # Engine subcommand contract
+│   └── hook_contract.md       # Hook trigger/payload contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # /speckit-tasks output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+configs/claude/
+├── scripts/
+│   ├── issue_support.sh          # NEW — shared engine (platform-agnostic; wraps git_ops.sh + git_platform.sh)
+│   ├── install_issue_hooks.sh    # NEW — idempotent installer (unified PostToolUse + guarded native post-commit)
+│   ├── git_ops.sh                # EDIT — add minimal `pr-edit <N>` subcommand (PR-body write path for closing-keyword insertion)
+│   └── templates/
+│       └── issue_support_issue.md # NEW — best-of-breed created-issue template (engine-owned; used by BOTH skills)
+├── config/
+│   ├── command_config.yml        # EDIT — tool_policies.pr-issue-sync: {enabled, hook_timeout_seconds}; tool_policies.commit-issue-sync: {enabled, hook_timeout_seconds, commit_hook_mode}. `enabled` defaults false (runtime gate the engine checks before acting); commit_hook_mode is commit-only.
+│   └── labels.yml                # REUSE — canonical labels (no change)
+└── skills/                       # symlink → ../../.skillshare/skills (do not replace)
+
+.skillshare/skills/
+├── pr-issue-sync/
+│   └── SKILL.md                  # NEW — PR-triggered skill (invokes `issue_support.sh sync-pr`)
+└── commit-issue-sync/
+    └── SKILL.md                  # NEW — commit-triggered skill (invokes `issue_support.sh sync-commit`)
+
+tests/
+├── bats/
+│   └── issue_support.bats        # NEW — engine + installer tests
+└── fixtures/
+    └── issue_support/            # NEW — mock pr-view / issue-view JSON payloads
+```
+
+**Structure Decision**: Single-project shell-and-config layout (repo default). The shared engine is a standalone script in `configs/claude/scripts/` so it is testable in isolation, manually invocable (`issue_support.sh --help`), and consumable by both skills plus the hook installer — exactly the pattern set by `git_ops.sh`, `linear_ops.sh`, and `label_sync.sh`. The two skills are thin SKILL.md wrappers that document invocation; they delegate all logic — including best-of-breed issue creation — to the engine. The created-issue template is **engine-owned** (`configs/claude/scripts/templates/issue_support_issue.md`) so it is resolved identically no matter which skill triggered the run.
+
+## Complexity Tracking
+
+> No constitution violations — table intentionally empty.

--- a/specs/005-issue-linking-hooks/quickstart.md
+++ b/specs/005-issue-linking-hooks/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart: Issue-Linking Git Hooks
+
+Enable and verify the two issue-sync skills in a repository.
+
+## Prerequisites
+- `gh` (GitHub) or `glab` (GitLab) authenticated with **issue read/write** scope.
+- Repo deployed via `bootstrap.sh` so `git_ops.sh`, `git_platform.sh`, and `labels.yml` are present.
+- Canonical labels provisioned: `configs/claude/scripts/label_sync.sh` (one-time per repo).
+
+## 1. Enable (opt-in)
+```bash
+# Enable the unified PostToolUse hooks (cross-tool)
+configs/claude/scripts/install_issue_hooks.sh --enable
+
+# Optional: also install the native post-commit hook for raw-CLI commits
+configs/claude/scripts/install_issue_hooks.sh --enable --native
+```
+Tune behavior in `configs/claude/config/command_config.yml`:
+```yaml
+tool_policies:
+  pr-issue-sync:    { enabled: true, hook_timeout_seconds: 5 }
+  commit-issue-sync:{ enabled: true, hook_timeout_seconds: 5, commit_hook_mode: sync }
+```
+
+## 2. Verify — commit trigger (US2)
+```bash
+git switch -c 017-some-fix        # branch prefix → issue #17
+git commit --allow-empty -m "wip" # hook fires commit-issue-sync
+# Expect: issue #17 label planned → in-progress; one back-link comment
+git commit --allow-empty -m "wip2"
+# Expect: no second comment, no re-transition (idempotent / dedup)
+```
+
+## 3. Verify — PR trigger (US1)
+```bash
+git_ops.sh pr-create --title "Some fix" --body "WIP"   # or: gh pr create ...
+# Expect: issue #17 label → needs-review; back-link comment; PR body gains "Closes #17"
+```
+
+## 4. Verify — missing-issue creation (US3)
+```bash
+git switch -c hotfix-no-number     # no resolvable issue
+git_ops.sh pr-create --title "Hotfix" --body ""
+# Expect: prompt "Create tracking issue from branch hotfix-no-number? [y/N]"
+#  - y → dedup-checked, templated issue created (labeled 'planned'), linked back
+#  - non-interactive (CI) → no creation, warning only
+```
+
+## 5. Verify — fail-open (SC-002)
+```bash
+GH_TOKEN=invalid git commit --allow-empty -m "tracker down"
+# Expect: commit SUCCEEDS; single warning line; no block
+```
+
+## 6. Dry-run / debug
+```bash
+configs/claude/scripts/issue_support.sh sync-pr 42 --dry-run
+configs/claude/scripts/issue_support.sh resolve --branch 017-some-fix --json
+```
+
+## 7. Disable / uninstall
+```bash
+configs/claude/scripts/install_issue_hooks.sh --remove   # removes hooks; keeps skills + engine
+```
+
+## Tests
+```bash
+bats tests/bats/issue_support.bats
+shellcheck configs/claude/scripts/issue_support.sh configs/claude/scripts/install_issue_hooks.sh
+yamllint configs/claude/config/command_config.yml
+```

--- a/specs/005-issue-linking-hooks/research.md
+++ b/specs/005-issue-linking-hooks/research.md
@@ -1,0 +1,88 @@
+# Phase 0 Research: Issue-Linking Git Hooks
+
+Resolves the open mechanism questions left by the spec (Clarifications) and Technical Context. Each item: **Decision · Rationale · Alternatives considered**.
+
+## R1 — Trigger mechanism (how a hook fires on "PR opened" and "branch commit")
+
+**Decision**: Use the repo's existing **`ai-hooks-integration` unified `PostToolUse` hook** as the primary trigger, matched on the Bash command text:
+- PR skill fires when the matched command creates a PR/MR — patterns `git_ops.sh pr-create`, `gh pr create`, `glab mr create`.
+- Commit skill fires when the matched command commits — patterns `git commit`, `git_ops.sh`-mediated commits.
+
+Ship a secondary, **opt-in guarded native `post-commit` git hook** (installed by `install_issue_hooks.sh`) for developers who commit outside an AI tool (raw CLI). The native hook only calls `issue_support.sh sync-commit HEAD`.
+
+**Rationale**: There is **no native git event for "PR created"** — PR/MR creation is a platform (`gh`/`glab`) action, not a git operation — so a git hook alone cannot cover the primary P1 trigger. The unified `PostToolUse` mechanism already exists in this repo, is cross-tool (Claude Code / Gemini / Cursor), and observes the actual command that creates the PR, making it the only mechanism that covers *both* triggers uniformly. Idempotency makes double-firing (e.g., unified hook *and* native hook both catching a commit) harmless.
+
+**Coverage boundary (explicit)**: PostToolUse observes the *command*, so PR creation flows through an AI-tool-mediated command or `git_ops.sh pr-create` are covered. **Not** auto-covered in v1: PR creation via the platform **web UI**, or raw `gh pr create`/`glab mr create` typed directly in a terminal outside a tool — no native git "PR-opened" event exists to hook. Documented in spec Assumptions/Edge Cases; the manual `issue_support.sh sync-pr <N>` invocation and a future server-side `pull_request: opened` CI trigger are the complements. The commit hook keeps the issue current on the next commit regardless.
+
+**Alternatives considered**:
+- *Native git hooks only* — rejected: cannot observe PR creation; also per-clone `.git/hooks` install is invisible to the config-as-code source of truth.
+- *Server-side CI webhook for PR-opened as the v1 primary* — deferred: closes the web-UI gap but adds per-repo CI config and can't run the interactive create-issue prompt; noted as the future universal-coverage complement.
+- *Wrapper subcommand* (`git_ops.sh pr-create` calls the engine inline) — rejected as the *primary* mechanism because it misses direct `gh pr create`; kept implicitly, since matching `git_ops.sh pr-create` in the PostToolUse pattern covers the wrapper path too.
+- *Platform webhooks (GitHub Actions / GitLab CI on PR-opened)* — rejected for v1: server-side, can't run the interactive create-issue prompt, and adds per-repo CI config (violates "no per-repo config" goal). Noted as a future server-side complement.
+
+## R2 — Idempotency & de-duplication without local state
+
+**Decision**: Derive "already synced" entirely from **live tracker state**, two signals:
+1. **Status label** — a forward-only transition is a no-op if the issue is already at/after the target label (`planned`→`in-progress`→`needs-review`→`done`).
+2. **Marker comment** — the engine's back-link comment embeds a hidden marker line `<!-- issue-support:sync v1 pr=<n>|commit=<branch> -->`. Before commenting, the engine lists issue comments and skips if a matching marker already exists; otherwise it edits/reuses that comment (via `git_ops.sh issue-comment-edit-last` where applicable).
+
+**Rationale**: No local file means nothing to drift, nothing to clean up, and a fresh clone or a different machine behaves identically (Constitution V). The label check makes rapid successive commits sub-second no-ops (SC-003/SC-007). The marker check prevents comment spam even across machines.
+
+**Alternatives considered**:
+- *Local marker file* (`.git/issue-support-state`) — rejected: per-clone drift, not visible to other contributors, violates the stateless goal.
+- *Rely on label only* — rejected: labels can't dedup the back-link comment, and a manually-moved label would suppress the comment.
+
+## R3 — Resolving the linked issue (association precedence)
+
+**Decision**: Resolve in this fixed order, first match wins, collecting all distinct references when multiple are valid (FR-011):
+1. **Branch-number prefix** — leading `NNN-` on the branch name maps to issue `#NNN` (the repo's existing convention, e.g. `005-issue-linking-hooks`). Validate the number actually exists as an open issue via `git_ops.sh issue-view` before acting.
+2. **PR/MR body references** — `Closes/Fixes/Resolves #N` and bare `#N` in the description (from `git_ops.sh pr-view`).
+3. **Commit trailers/refs** — `#N`, `Closes #N`, or a `Refs:`/`Issue:` trailer in commit messages on the branch.
+
+If step 1's number does not resolve to a real issue, fall through to 2/3 rather than acting on a non-existent issue. Conflicting/ambiguous multi-issue results are reported, not silently picked (FR-012).
+
+**Rationale**: Branch prefix is the highest-signal, lowest-cost source and is already the project standard; explicit body/commit references catch ad-hoc and multi-issue cases. Validating existence avoids the "branch numbered 005 but issue #5 is unrelated" trap.
+
+**Alternatives considered**:
+- *Body references first* — rejected: most branches here are numbered, so prefix-first minimizes API calls.
+- *Fuzzy title matching as a resolver* — rejected for resolution (too lossy); reused only for the create-issue dedup check (R4).
+
+## R4 — Best-of-breed issue creation (when none is linked)
+
+**Decision**: The create path:
+1. **Dedup first** — search open issues (`git_ops.sh issue-list`) for a title/branch-context match; if found, link to it instead of creating (FR-009a).
+2. **Prompt for confirmation** — interactive only; non-interactive context defaults to "do not create" + warn (FR-009).
+3. **Create from template** — the **engine-owned** template `configs/claude/scripts/templates/issue_support_issue.md` (resolved relative to the engine, not the calling skill, so both `pr-issue-sync` and `commit-issue-sync` get identical output): context summary, acceptance-criteria stub, and bidirectional links to branch/PR/commit; apply the canonical `planned` label; then immediately run the normal sync so the new issue enters the same lifecycle (FR-009b/c).
+
+**Rationale**: Matches the user's "best-of-breed" directive — an auto-created issue is indistinguishable from a hand-authored one and never becomes tracker debt. Dedup-before-create prevents the most common failure mode (a second issue for work that already has one).
+
+**Alternatives considered**:
+- *Auto-create without prompt* — rejected (spec decision): noise risk.
+- *Bare-title stub* — rejected: low-value tracker debt, the exact thing "best-of-breed" rules out.
+
+## R5 — Platform scope (GitHub / GitLab / Linear)
+
+**Decision**: v1 supports **GitHub and GitLab** via `git_ops.sh` + `git_platform.sh`, per the explicit feature request. **Linear is a designed extension point, not v1 scope**: the engine routes all tracker actions through a thin internal `tracker_*` indirection so a future `linear_ops.sh` backend can be added without touching the skills or hook wiring.
+
+**Rationale**: The request named github/gitlab; `linear_ops.sh` exists but Linear has no git-branch/PR coupling (it's issue-only), so its trigger story differs and belongs in a follow-up. Keeping the indirection avoids a future rewrite.
+
+**Alternatives considered**:
+- *Include Linear in v1* — rejected: scope creep beyond the request and a different trigger model; deferred with a clean seam.
+
+## R6 — Timeout / fail-open enforcement
+
+**Decision**: The engine wraps its tracker work in a soft timeout using the platform `timeout` helper already present in `bootstrap/lib/platform.sh` (or `timeout`/`gtimeout`), bounded by `hook_timeout_seconds` (config, default 5). On timeout, non-zero from any `git_ops.sh` call, missing CLI, or missing token scope, it prints a single `err()` warning and exits **0** so the git action proceeds (FR-008, SC-002). `commit_hook_mode` is `sync`-only in **v1**; `background` is a reserved value — if configured now, the engine falls back to `sync` and warns (no silent/undefined behavior), preserving the option to add true background dispatch later without a config redesign.
+
+**Rationale**: Reuses existing timeout helpers; exit-0-on-failure is the concrete mechanism that guarantees zero blocking failures. Idempotency (R2) makes the dropped run recoverable on the next trigger.
+
+**Alternatives considered**:
+- *Hard timeout that aborts the git action* — rejected: violates fail-open.
+- *No timeout* — rejected: a hung tracker would stall every commit (the Decision-1 disqualifier).
+
+## Resolved unknowns
+
+All Technical Context items are now concrete; **no NEEDS CLARIFICATION remain**. Config keys introduced in `command_config.yml`:
+- `tool_policies.pr-issue-sync`: `enabled` (default `false`), `hook_timeout_seconds` (default 5)
+- `tool_policies.commit-issue-sync`: `enabled` (default `false`), `hook_timeout_seconds` (default 5), `commit_hook_mode` (`sync`|`background`, default `sync` — commit-only; not applicable to the PR hook; `background` reserved for v2, falls back to `sync`+warn in v1)
+
+`enabled` is a **runtime gate**: the engine reads it and exits as a no-op when false, so disabling is a one-line config change without uninstalling the hook (FR-015). The installer sets it `true` on `--enable`.

--- a/specs/005-issue-linking-hooks/spec.md
+++ b/specs/005-issue-linking-hooks/spec.md
@@ -1,0 +1,148 @@
+# Feature Specification: Issue-Linking Git Hooks
+
+**Feature Branch**: `005-issue-linking-hooks`
+
+**Created**: 2026-06-14
+
+**Status**: Draft
+
+**Input**: User description: "Create a skill that is designed to support / improve github / gitlab issues. Run it as a hook whenever a PR is executed. Additionally define a similar skill for branch commits."
+
+## Clarifications
+
+### Session 2026-06-14
+
+- Q: What execution model should the hooks use (sync vs async vs hybrid), given they run inline with git actions? → A: **Bounded synchronous run with a soft timeout, fail-open** (Option A). Chosen for the long term because the engine is already idempotent + de-duplicated, so a timed-out run self-heals on the next trigger or a manual re-run — making a background queue (Option B) unnecessary infrastructure and an out-of-band failure-visibility liability, while preserving the interactive "offer to create issue" path. The timeout and commit execution mode are promoted to config rather than hard-coded: `hook_timeout_seconds` (default `5`) and `commit_hook_mode` (`sync` | `background`, default `sync`), so a repo can opt into background commit handling later without a redesign. Trade accepted: the first PR/commit on a branch may wait up to the timeout; dedup makes subsequent commits near-instant no-ops.
+- Q: Should auto-created tracking issues be minimal stubs or best-of-breed? → A: **Best-of-breed.** Before creating, the engine MUST check the tracker for an existing matching issue and reuse it rather than duplicate. A created issue MUST use a structured template (context summary, acceptance criteria, bidirectional links to the branch/PR/commit) and the canonical label set, so an auto-created issue is indistinguishable from a well-authored one.
+- Q: What is the precise issue status transition per trigger? → A: A **commit** on a branch advances a `planned` issue to `in-progress`; a **PR/MR opening** advances the linked issue to `needs-review`. Transitions only move forward (never regress an issue already further along).
+
+## User Scenarios & Testing *(mandatory)*
+
+This feature delivers **two companion skills** that keep the issue tracker (GitHub Issues or GitLab Issues) in sync with development activity, invoked automatically as git/platform hooks:
+
+- A **PR-triggered** skill that runs whenever a pull/merge request is opened.
+- A **commit-triggered** skill that runs whenever commits land on a feature branch.
+
+Both share one underlying "issue-support engine" and behave **fail-open**: if the platform API is unreachable or any step errors, the developer's git action is never blocked — the skill degrades to a warning.
+
+### User Story 1 - Auto-sync the linked issue when a PR is opened (Priority: P1)
+
+When a developer opens a pull request (GitHub) or merge request (GitLab), a hook fires the PR-support skill. The skill identifies the issue(s) the PR relates to, posts a back-link comment on each issue, advances the issue's status label to `needs-review` (regardless of current stage, forward-only — see FR-006a), and verifies the PR description contains the correct closing keyword (e.g., `Closes #17`). All actions are advisory-safe: a failure warns but never aborts PR creation.
+
+**Why this priority**: This is the core value — it eliminates the manual, frequently-forgotten step of keeping issues current when work reaches review. It is the smallest slice that delivers a working, demonstrable MVP on its own.
+
+**Independent Test**: Open a PR on a branch associated with a known issue; confirm the issue receives a back-link comment, its status label advances, and a missing closing keyword is reported — without any manual issue edits.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR is opened on a branch tied to issue #17, **When** the PR-support hook runs, **Then** issue #17 receives a comment linking to the PR and its status label advances to the review stage.
+2. **Given** a PR body that omits a closing keyword for its linked issue, **When** the hook runs, **Then** the skill ensures/inserts the correct `Closes #<n>` reference (or warns if it cannot edit the PR body).
+3. **Given** the issue tracker API is unreachable, **When** the hook runs, **Then** the PR is still created successfully and the developer sees a non-blocking warning.
+4. **Given** a PR references multiple issues, **When** the hook runs, **Then** each referenced issue is updated independently.
+
+---
+
+### User Story 2 - Auto-sync the linked issue on branch commits (Priority: P2)
+
+When a developer commits to a feature branch, a hook fires the commit-support skill. Using the same engine, it associates the commit(s) with the relevant issue and keeps that issue current — e.g., moving a freshly-started issue from `planned` to `in-progress` and (optionally) appending a lightweight progress reference. It de-duplicates so the same issue is not spammed on every commit.
+
+**Why this priority**: Extends the same value earlier in the lifecycle (work-in-progress visibility) so an issue reflects "active" status as soon as real work begins, not only at PR time. Depends on the shared engine proven in P1.
+
+**Independent Test**: Commit to a branch tied to a `planned` issue; confirm the issue advances to `in-progress` exactly once across multiple commits, and that the hook never blocks the commit.
+
+**Acceptance Scenarios**:
+
+1. **Given** a commit lands on a branch tied to a `planned` issue, **When** the commit-support hook runs, **Then** the issue advances to `in-progress`.
+2. **Given** several further commits on the same branch, **When** the hook runs each time, **Then** the issue is not repeatedly commented on or re-transitioned (idempotent / de-duplicated).
+3. **Given** a commit on a branch with no resolvable issue association, **When** the hook runs, **Then** the commit-support flow defers to the missing-issue behavior (User Story 3) without blocking the commit.
+
+---
+
+### User Story 3 - Offer to create a tracking issue when none is linked (Priority: P3)
+
+When either skill cannot resolve a linked issue (no branch-number prefix, no reference in the PR body or commit messages), it offers to create a tracking issue, pre-filled from the available context (branch name, PR title/body, or commit subject). The issue is created **only on explicit confirmation**; declining proceeds with a warning.
+
+**Why this priority**: Closes the gap for ad-hoc work that started without an issue, but is independent of the core sync and safe to ship later. Creation-on-confirm keeps it from generating tracker noise.
+
+**Independent Test**: Open a PR (or commit) on a branch with no issue association; confirm the skill proposes a pre-filled tracking issue, creates it only after confirmation, then links it back to the PR/commit.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR with no resolvable linked issue, **When** the hook runs, **Then** the developer is offered a pre-filled tracking issue draft derived from the branch/PR context.
+2. **Given** the developer confirms creation, **When** the skill proceeds, **Then** a new issue is created, labeled per the canonical registry, and linked back to the PR/commit.
+3. **Given** the developer declines (or the run is non-interactive), **When** the hook completes, **Then** no issue is created and a non-blocking warning notes the missing link.
+
+---
+
+### Edge Cases
+
+- **No platform / detached environment**: branch is not connected to GitHub or GitLab (local-only) → skill detects this and exits cleanly with an informational note, taking no action.
+- **Wrong platform credentials / insufficient scope**: the token lacks issue-write scope → skill reports the specific missing capability and degrades to advisory output instead of failing.
+- **Ambiguous association**: a branch maps to multiple candidate issues with conflicting status → skill reports the ambiguity and asks which issue(s) to act on rather than guessing.
+- **Already-correct state**: issue already at the target status and PR already references it → skill is a no-op and says so (idempotent).
+- **Closed/locked issue**: linked issue is already closed or locked → skill warns and skips mutation rather than reopening or erroring.
+- **Non-interactive context** (CI, automated PR bots): the create-issue prompt cannot be answered → skill defaults to "do not create" and warns.
+- **High commit frequency**: rapid successive commits → de-duplication prevents repeated comments/transitions within a branch.
+- **Platform rate limiting**: API throttles requests → skill backs off and degrades to a warning without blocking the git action.
+- **PR created outside an observed command path** (web UI, or raw `gh pr create`/`glab mr create` typed directly in a terminal not mediated by an AI tool): the PR hook does not observe the creation and does not fire automatically → the developer can run the PR sync manually, and the next commit on the branch still keeps the issue current. This coverage boundary is documented (not a silent guarantee) — see Assumptions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide two distinct, independently invokable skills — one triggered when a pull/merge request is opened, and one triggered when commits land on a feature branch — built on a shared issue-support engine.
+- **FR-002**: Each skill MUST run automatically as a hook at its trigger point (PR opened; branch commit) without the developer manually invoking it.
+- **FR-003**: The system MUST support both GitHub and GitLab issue trackers, detecting the active platform from the repository rather than requiring per-repo configuration.
+- **FR-004**: The system MUST resolve the issue(s) associated with a PR or commit using, in order, the numeric branch-name prefix (e.g., `005-...`), explicit references in the PR/MR description, and references/trailers in commit messages.
+- **FR-005**: On a PR trigger, the system MUST post a back-link comment on each linked issue, advance the issue's status label to `needs-review`, and ensure the PR description contains the correct closing keyword for each linked issue.
+- **FR-006**: On a commit trigger, the system MUST advance a linked `planned` issue to `in-progress`, and MUST de-duplicate so repeated commits do not re-comment or re-transition the same issue.
+- **FR-006a**: Status transitions MUST only move an issue forward in the lifecycle (`planned` → `in-progress` → `needs-review` → `done`); the system MUST NOT regress an issue already at a later stage. These hooks set at most `needs-review`; the `done` label is **not** applied by this feature (see Assumptions — it is owned by the PR-merge/close path, out of scope for v1).
+- **FR-007**: All issue mutations MUST be idempotent — re-running a skill against an already-correct issue makes no further changes and reports a no-op.
+- **FR-008**: The system MUST be fail-open: any error, missing credential, or unreachable API MUST degrade to a non-blocking warning and MUST NOT abort the developer's PR creation or commit.
+- **FR-009**: When no issue can be resolved, the system MUST offer to create a tracking issue pre-filled from available context, and MUST create it only after explicit confirmation; in non-interactive contexts it MUST default to not creating and warn.
+- **FR-009a**: Before creating any tracking issue, the system MUST search the tracker for an existing matching open issue (by branch context / title similarity) and reuse it instead of creating a duplicate.
+- **FR-009b**: A created tracking issue MUST be best-of-breed — populated from a structured template containing a context summary, acceptance criteria, and bidirectional links to the originating branch/PR/commit — not a bare-title stub.
+- **FR-009c**: A created tracking issue MUST be labeled per the canonical registry and immediately linked back to the triggering PR/commit so it enters the same sync lifecycle as a manually authored issue.
+- **FR-010**: Status labels and any created issues MUST conform to the project's canonical label registry (e.g., `planned`, `in-progress`, `needs-review`, `done`).
+- **FR-011**: The system MUST handle a PR/commit referencing multiple issues by acting on each independently.
+- **FR-012**: The system MUST detect and report ambiguous or conflicting issue associations instead of silently choosing one.
+- **FR-013**: The system MUST skip mutation on closed or locked issues and warn rather than error.
+- **FR-014**: Each skill MUST emit a clear summary of actions taken (or skipped, and why) so the developer can audit hook behavior.
+- **FR-015**: The hooks MUST be opt-in/configurable so the automation can be enabled or disabled without removing the skills.
+- **FR-016**: Each hook MUST run synchronously within a configurable soft timeout (`hook_timeout_seconds`, default `5`); on timeout it MUST degrade to a warning and let the git action proceed (fail-open). The commit hook exposes `commit_hook_mode` (`sync` | `background`, default `sync`); **v1 implements `sync` only** — `background` is a reserved value for a future release, and if set in v1 the engine MUST fall back to `sync` and emit a one-line warning (never silent, never undefined behavior).
+- **FR-017**: Because all mutations are idempotent (FR-007), a timed-out, skipped, or failed run MUST be safely recoverable — re-running the skill (next trigger or manual invocation) brings the issue to the correct state with no duplicate side effects.
+
+### Key Entities *(include if feature involves data)*
+
+- **Issue**: A unit of tracked work on GitHub or GitLab. Key attributes: identifier/number, title, status label, open/closed/locked state, comments, and links to PRs/commits.
+- **Pull/Merge Request**: The change-under-review that triggers the PR skill. Key attributes: identifier, title, description (containing references and closing keywords), source branch, and linked issues.
+- **Commit**: A change recorded on a feature branch that triggers the commit skill. Key attributes: subject/message (may contain references/trailers), branch, and derived issue association.
+- **Branch**: The working line of development; its name (notably a numeric prefix) is a primary signal for issue association.
+- **Issue-Support Action**: A single change the engine applies — comment, status-label transition, closing-keyword insertion, or issue creation — with a result of applied / skipped / failed and a reason.
+- **Hook Trigger**: The event binding (PR-opened, branch-commit) that fires a skill, including whether the context is interactive.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: When a PR is opened on a branch with a resolvable issue, the linked issue reflects the correct back-link and status within one hook run, with no manual issue edits required in at least 95% of cases.
+- **SC-002**: 100% of hook runs leave the underlying git action (PR creation, commit) successful even when the issue tracker is unreachable (zero blocking failures).
+- **SC-003**: Across a series of 10 consecutive commits on one branch, the linked issue is transitioned and/or commented at most once for that lifecycle stage (idempotent / de-duplicated).
+- **SC-004**: A developer can determine exactly what each hook did (or skipped, and why) from the skill's summary output without inspecting the issue tracker manually.
+- **SC-005**: Manual issue-status upkeep (moving issues to in-progress / needs-review by hand) is eliminated for branches that follow the project's naming and reference conventions.
+- **SC-006**: Both skills operate against GitHub and GitLab repositories with no per-repository configuration beyond enabling the hook.
+- **SC-007**: A hook adds no more than the configured timeout (default 5s) to any git action, and after the first commit on a branch, subsequent commits add no perceptible delay (sub-second no-op via de-duplication).
+- **SC-008**: An auto-created tracking issue contains a context summary, acceptance criteria, canonical labels, and a working link to its PR/commit in 100% of cases, and no duplicate issue is created when a matching one already exists.
+
+## Assumptions
+
+- **Platform detection reuse**: The active platform (GitHub vs GitLab vs plain git) is detected from the repository using the project's existing platform-detection approach; no new per-repo platform setting is introduced.
+- **Issue association conventions**: The primary association signal is the numeric branch-name prefix already used in this project (e.g., `005-issue-linking-hooks`), supplemented by explicit references in PR descriptions and commit messages.
+- **Label vocabulary**: Status transitions use the project's canonical label set (`planned`, `in-progress`, `needs-review`, `done`, plus `follow-up`/`future`) as the source of truth.
+- **"PR is executed" interpretation**: Interpreted as a PR/MR being **opened/created** (the primary trigger). Re-runs on subsequent updates are out of scope for v1 and may be added later.
+- **Commit trigger granularity**: The commit skill targets feature-branch commits; the exact hook surface (e.g., post-commit vs pre-push) is a design-phase decision, constrained by the fail-open, de-duplication, and bounded-timeout requirements. Execution mode is configurable (`commit_hook_mode`, default `sync`) per the Clarifications.
+- **Credentials**: The environment provides a platform token with issue read/write scope; insufficient scope degrades to advisory behavior rather than failure (consistent with the known limitation that some tokens lack project scope).
+- **Authoring location**: The two skills live alongside existing issue/PR skills in the project's skill source of truth and reuse existing platform-agnostic git/issue operations rather than introducing a new integration layer.
+- **`done` label ownership**: This feature advances issues only as far as `needs-review`. The `done` label belongs to the PR-merge/close path (handled by merge automation, CI, or a human, e.g. via existing triage skills) and is **out of scope for v1**. The lifecycle in FR-006a shows `done` for completeness, not as a transition these hooks perform; consequently a `Closes #N` that closes an issue on merge without a `done` label is acceptable and not a conformance violation of FR-010.
+- **PR-trigger coverage boundary**: "Automatically when a PR is opened" (FR-002) is delivered for PR/MR creation that flows through an AI-tool-mediated command or `git_ops.sh pr-create` (observed by the unified PostToolUse hook). PR creation via the platform web UI, or raw `gh`/`glab` typed directly outside a tool, is **not** auto-covered in v1 — there is no native git "PR-opened" event to hook. This is documented rather than silently assumed; a server-side trigger (GitHub Actions / GitLab CI `pull_request: opened`) is the noted future complement for universal coverage.
+- **Default-off safety**: Hooks ship opt-in so adopting repositories explicitly enable the automation.

--- a/specs/005-issue-linking-hooks/tasks.md
+++ b/specs/005-issue-linking-hooks/tasks.md
@@ -62,15 +62,15 @@ Shell-and-config layout (repo default). Engine + installer in `configs/claude/sc
 
 ### Tests for User Story 1
 
-- [ ] T013 [P] [US1] Add bats cases in `tests/bats/issue_support.bats` for `sync-pr`: resolves issue from PR, transitions → `needs-review`, idempotent re-run yields only `skipped` (C2), fail-open on tracker error exits 0 (C1), closed/locked issue skipped (C4), multi-issue PR acts on each (C7). Also cover the PR-installer (T017): idempotent re-install adds no duplicate entry (H1), disabled-config install is a no-op (H3), engine does not fire when the underlying command failed (H4)
+- [X] T013 [P] [US1] Add bats cases in `tests/bats/issue_support.bats` for `sync-pr`: resolves issue from PR, transitions → `needs-review`, idempotent re-run yields only `skipped` (C2), fail-open on tracker error exits 0 (C1), closed/locked issue skipped (C4), multi-issue PR acts on each (C7). Also cover the PR-installer (T017): idempotent re-install adds no duplicate entry (H1), disabled-config install is a no-op (H3), engine does not fire when the underlying command failed (H4)
 
 ### Implementation for User Story 1
 
 - [X] T014 [US1] Add minimal `pr-edit <N>` subcommand to `configs/claude/scripts/git_ops.sh` (wraps `gh pr edit --body` / `glab mr update --description`), update its `--help`; non-destructive body append. Because `pr-edit` is a permanent public `git_ops.sh` primitive, add direct bats cases in `tests/bats/git_ops.bats` (append on github, append on gitlab, idempotent when keyword already present, graceful failure when the PR is not editable) — not only transitive coverage via `sync-pr`
 - [X] T015 [US1] Implement `sync-pr <PR_NUMBER> [--dry-run] [--no-create]` in `configs/claude/scripts/issue_support.sh`: resolve → for each open issue transition → `needs-review` (T010), back-link comment (T011), ensure `Closes #N` via `git_ops.sh pr-edit` appending when missing (FR-005); all wrapped fail-open (T009)
-- [ ] T016 [US1] Create `.skillshare/skills/pr-issue-sync/SKILL.md` with `name`/`description` frontmatter; document `sync-pr` invocation, the PostToolUse trigger, fail-open behavior, and `--no-create`
-- [ ] T017 [US1] Create `configs/claude/scripts/install_issue_hooks.sh` with `--help`, `--enable`/`--remove`, and the unified PR PostToolUse matcher (`pr-create`|`gh pr create`|`glab mr create` → `sync-pr <N>`) via `ai-hooks-integration`; idempotent re-install (H1), opt-in no-op when not enabled (H3), fires only on the underlying command's success (H4)
-- [ ] T018 [US1] Register `pr-issue-sync` per `.claude/CLAUDE.md` "Adding New Skills": add `parallel_agents`/`validation_tier` under `tool_policies.pr-issue-sync` in `command_config.yml`; verify `configs/claude/skills` symlink is intact (not replaced)
+- [X] T016 [US1] Create `.skillshare/skills/pr-issue-sync/SKILL.md` with `name`/`description` frontmatter; document `sync-pr` invocation, the PostToolUse trigger, fail-open behavior, and `--no-create`
+- [X] T017 [US1] Create `configs/claude/scripts/install_issue_hooks.sh` with `--help`, `--enable`/`--remove`, and the unified PR PostToolUse matcher (`pr-create`|`gh pr create`|`glab mr create` → `sync-pr <N>`) via `ai-hooks-integration`; idempotent re-install (H1), opt-in no-op when not enabled (H3), fires only on the underlying command's success (H4)
+- [X] T018 [US1] Register `pr-issue-sync` per `.claude/CLAUDE.md` "Adding New Skills": add `parallel_agents`/`validation_tier` under `tool_policies.pr-issue-sync` in `command_config.yml`; verify `configs/claude/skills` symlink is intact (not replaced)
 
 **Checkpoint**: PR-open sync works end-to-end and is independently demoable (MVP)
 
@@ -84,14 +84,14 @@ Shell-and-config layout (repo default). Engine + installer in `configs/claude/sc
 
 ### Tests for User Story 2
 
-- [ ] T019 [P] [US2] Add bats cases in `tests/bats/issue_support.bats` for `sync-commit`: resolves from branch prefix/commit trailer, `planned`→`in-progress`, 10 consecutive commits transition/comment at most once (C2/SC-003), fail-open exits 0 (C1), `commit_hook_mode: background` falls back to `sync` with a warning (FR-016). Also cover the native installer (T022): refuses to clobber a pre-existing foreign `post-commit` hook (H2), and `--remove` cleanly removes both the PostToolUse entry and the delimited native block (H5). Add a recovery case (FR-017): after a first run that times out / fails mid-way (tracker error injected), a second run brings the issue to the correct state with no duplicate comment or double transition
+- [X] T019 [P] [US2] Add bats cases in `tests/bats/issue_support.bats` for `sync-commit`: resolves from branch prefix/commit trailer, `planned`→`in-progress`, 10 consecutive commits transition/comment at most once (C2/SC-003), fail-open exits 0 (C1), `commit_hook_mode: background` falls back to `sync` with a warning (FR-016). Also cover the native installer (T022): refuses to clobber a pre-existing foreign `post-commit` hook (H2), and `--remove` cleanly removes both the PostToolUse entry and the delimited native block (H5). Add a recovery case (FR-017): after a first run that times out / fails mid-way (tracker error injected), a second run brings the issue to the correct state with no duplicate comment or double transition
 
 ### Implementation for User Story 2
 
 - [X] T020 [US2] Implement `sync-commit <SHA|HEAD> [--dry-run] [--no-create]` in `configs/claude/scripts/issue_support.sh`: resolve → transition `planned` → `in-progress` (only issues already carrying the `planned` label; unlabeled issues are outside the managed lifecycle and left untouched, per FR-006) → dedup back-link comment; read `commit_hook_mode` and on `background` fall back to `sync` + `err()` warning (v1; reserved value per FR-016)
-- [ ] T021 [US2] Create `.skillshare/skills/commit-issue-sync/SKILL.md` with `name`/`description` frontmatter; document `sync-commit`, the commit trigger, dedup/idempotency, and fail-open
-- [ ] T022 [US2] Extend `configs/claude/scripts/install_issue_hooks.sh`: unified commit PostToolUse matcher (`git commit` → `sync-commit HEAD`) plus `--native` guarded `post-commit` installer (refuses to clobber a foreign hook H2, writes a delimited managed block) and `--remove` cleanup of both surfaces (H5)
-- [ ] T023 [US2] Register `commit-issue-sync` per "Adding New Skills": add `parallel_agents`/`validation_tier` under `tool_policies.commit-issue-sync` in `command_config.yml`
+- [X] T021 [US2] Create `.skillshare/skills/commit-issue-sync/SKILL.md` with `name`/`description` frontmatter; document `sync-commit`, the commit trigger, dedup/idempotency, and fail-open
+- [X] T022 [US2] Extend `configs/claude/scripts/install_issue_hooks.sh`: unified commit PostToolUse matcher (`git commit` → `sync-commit HEAD`) plus `--native` guarded `post-commit` installer (refuses to clobber a foreign hook H2, writes a delimited managed block) and `--remove` cleanup of both surfaces (H5)
+- [X] T023 [US2] Register `commit-issue-sync` per "Adding New Skills": add `parallel_agents`/`validation_tier` under `tool_policies.commit-issue-sync` in `command_config.yml`
 
 **Checkpoint**: Commit sync and PR sync both work independently
 
@@ -105,7 +105,7 @@ Shell-and-config layout (repo default). Engine + installer in `configs/claude/sc
 
 ### Tests for User Story 3
 
-- [ ] T024 [P] [US3] Add bats cases in `tests/bats/issue_support.bats` for the create flow: dedup-match reuses an existing open issue instead of creating (FR-009a), non-interactive context defaults to no-create + warn (FR-009), template renders with context/acceptance-criteria/links and applies `planned` label (FR-009b/c)
+- [X] T024 [P] [US3] Add bats cases in `tests/bats/issue_support.bats` for the create flow: dedup-match reuses an existing open issue instead of creating (FR-009a), non-interactive context defaults to no-create + warn (FR-009), template renders with context/acceptance-criteria/links and applies `planned` label (FR-009b/c)
 
 ### Implementation for User Story 3
 

--- a/specs/005-issue-linking-hooks/tasks.md
+++ b/specs/005-issue-linking-hooks/tasks.md
@@ -124,7 +124,7 @@ Shell-and-config layout (repo default). Engine + installer in `configs/claude/sc
 - [X] T028 [P] Update `docs/COMMANDS.md` (and README skills note) to document `pr-issue-sync` + `commit-issue-sync` and `install_issue_hooks.sh`
 - [X] T029 Run `quickstart.md` steps 2–6 end-to-end against a scratch repo (commit trigger, PR trigger, missing-issue creation, fail-open, dry-run)
 - [X] T030 Run verification gate: `shellcheck configs/claude/scripts/issue_support.sh configs/claude/scripts/install_issue_hooks.sh configs/claude/scripts/git_ops.sh`; `yamllint configs/claude/config/command_config.yml`; `bats tests/bats/issue_support.bats`. Assert FR-010 label conformance: every label the engine sets or applies to a created issue exists in `configs/claude/config/labels.yml` (grep the engine's label literals against the registry — no off-registry labels)
-- [ ] T031 Tier 1 cross-verification (Constitution II): run `parallel_agent.py --review` on the `issue_support.sh` + `git_ops.sh` diff (token handling + >200 lines) before opening the PR
+- [X] T031 Tier 1 cross-verification (Constitution II): run `parallel_agent.py --review` on the `issue_support.sh` + `git_ops.sh` diff (token handling + >200 lines) before opening the PR
 
 ---
 

--- a/specs/005-issue-linking-hooks/tasks.md
+++ b/specs/005-issue-linking-hooks/tasks.md
@@ -28,9 +28,9 @@ Shell-and-config layout (repo default). Engine + installer in `configs/claude/sc
 
 **Purpose**: Scaffolding and offline test fixtures
 
-- [ ] T001 Create directory scaffolding: `.skillshare/skills/pr-issue-sync/`, `.skillshare/skills/commit-issue-sync/`, `configs/claude/scripts/templates/`, `tests/fixtures/issue_support/`
-- [ ] T002 [P] Add offline mock fixtures (sample `pr-view`, `issue-view`, `issue-list` JSON payloads for github & gitlab) in `tests/fixtures/issue_support/`
-- [ ] T003 [P] Create `tests/bats/issue_support.bats` skeleton with `setup()`/`teardown()` that stubs `git_ops.sh`/`git_platform.sh` on `PATH` so tests run with no live tracker
+- [X] T001 Create directory scaffolding: `.skillshare/skills/pr-issue-sync/`, `.skillshare/skills/commit-issue-sync/`, `configs/claude/scripts/templates/`, `tests/fixtures/issue_support/`
+- [X] T002 [P] Add offline mock fixtures (sample `pr-view`, `issue-view`, `issue-list` JSON payloads for github & gitlab) in `tests/fixtures/issue_support/`
+- [X] T003 [P] Create `tests/bats/issue_support.bats` skeleton with `setup()`/`teardown()` that stubs `git_ops.sh`/`git_platform.sh` on `PATH` so tests run with no live tracker
 
 ---
 
@@ -40,15 +40,15 @@ Shell-and-config layout (repo default). Engine + installer in `configs/claude/sc
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T004 Create `configs/claude/scripts/issue_support.sh` skeleton: `set -euo pipefail`, `err()` helper, `--help` (≤15 lines, exit 0), subcommand dispatch for `sync-pr`/`sync-commit`/`resolve`
-- [ ] T005 Add `tool_policies.pr-issue-sync` (`enabled: false`, `hook_timeout_seconds: 5`) and `tool_policies.commit-issue-sync` (`enabled: false`, `hook_timeout_seconds: 5`, `commit_hook_mode: sync`) to `configs/claude/config/command_config.yml`
-- [ ] T006 Implement config loader in `configs/claude/scripts/issue_support.sh` (python3 YAML read, `label_sync.sh` precedent); `enabled: false` → clean no-op exit 0 (FR-015 runtime gate)
-- [ ] T007 Integrate platform detection via `git_platform.sh` in `issue_support.sh`; non-github/gitlab (plain `git`/none) → informational no-op exit (Edge: no platform)
-- [ ] T008 Implement `resolve` subcommand in `issue_support.sh`: precedence branch-prefix → pr-body → commit-message references **and** trailers (inline `#N`/`Fixes #N` plus `Issue:`/`Refs:` trailers, per R3/FR-004), validate each candidate via `git_ops.sh issue-view` (`exists` gate), emit `IssueRef[]` JSON; report ambiguous/conflicting candidates without auto-picking (FR-012)
-- [ ] T009 Implement fail-open timeout wrapper in `issue_support.sh` (R6/FR-008): bound tracker work by `hook_timeout_seconds` via `timeout`/`gtimeout` (or `bootstrap/lib/platform.sh` helper); any failure/timeout → single `err()` warning + exit 0 (guarantee C1). Distinguish two edge cases in the warning text: (a) **insufficient token scope** → report the specific missing capability (e.g. "token lacks issue-write scope") rather than a generic error (spec Edge L80); (b) **rate limiting** → detect throttle responses and back off (bounded retry within `hook_timeout_seconds`) before degrading to a warning (spec Edge L86)
-- [ ] T010 Implement forward-only transition primitive in `issue_support.sh` (data-model state machine / FR-006a): ordered set `planned<in-progress<needs-review<done`, no-op if issue already ≥ target (C5), skip closed/locked with warning (FR-013/C4)
-- [ ] T011 Implement idempotent back-link comment primitive in `issue_support.sh`: embed marker `<!-- issue-support:sync v1 ... -->`, skip/refresh if marker already present (R2/FR-007/C2) via `git_ops.sh issue-comment`/`issue-comment-edit-last`
-- [ ] T012 Implement run-summary emitter in `issue_support.sh`: one stdout line per `SyncAction` (`type target [result] (reason)`) plus `--json` form (FR-014); wire `--dry-run` prefix
+- [X] T004 Create `configs/claude/scripts/issue_support.sh` skeleton: `set -euo pipefail`, `err()` helper, `--help` (≤15 lines, exit 0), subcommand dispatch for `sync-pr`/`sync-commit`/`resolve`
+- [X] T005 Add `tool_policies.pr-issue-sync` (`enabled: false`, `hook_timeout_seconds: 5`) and `tool_policies.commit-issue-sync` (`enabled: false`, `hook_timeout_seconds: 5`, `commit_hook_mode: sync`) to `configs/claude/config/command_config.yml`
+- [X] T006 Implement config loader in `configs/claude/scripts/issue_support.sh` (python3 YAML read, `label_sync.sh` precedent); `enabled: false` → clean no-op exit 0 (FR-015 runtime gate)
+- [X] T007 Integrate platform detection via `git_platform.sh` in `issue_support.sh`; non-github/gitlab (plain `git`/none) → informational no-op exit (Edge: no platform)
+- [X] T008 Implement `resolve` subcommand in `issue_support.sh`: precedence branch-prefix → pr-body → commit-message references **and** trailers (inline `#N`/`Fixes #N` plus `Issue:`/`Refs:` trailers, per R3/FR-004), validate each candidate via `git_ops.sh issue-view` (`exists` gate), emit `IssueRef[]` JSON; report ambiguous/conflicting candidates without auto-picking (FR-012)
+- [X] T009 Implement fail-open timeout wrapper in `issue_support.sh` (R6/FR-008): bound tracker work by `hook_timeout_seconds` via `timeout`/`gtimeout` (or `bootstrap/lib/platform.sh` helper); any failure/timeout → single `err()` warning + exit 0 (guarantee C1). Distinguish two edge cases in the warning text: (a) **insufficient token scope** → report the specific missing capability (e.g. "token lacks issue-write scope") rather than a generic error (spec Edge L80); (b) **rate limiting** → detect throttle responses and back off (bounded retry within `hook_timeout_seconds`) before degrading to a warning (spec Edge L86)
+- [X] T010 Implement forward-only transition primitive in `issue_support.sh` (data-model state machine / FR-006a): ordered set `planned<in-progress<needs-review<done`, no-op if issue already ≥ target (C5), skip closed/locked with warning (FR-013/C4)
+- [X] T011 Implement idempotent back-link comment primitive in `issue_support.sh`: embed marker `<!-- issue-support:sync v1 ... -->`, skip/refresh if marker already present (R2/FR-007/C2) via `git_ops.sh issue-comment`/`issue-comment-edit-last`
+- [X] T012 Implement run-summary emitter in `issue_support.sh`: one stdout line per `SyncAction` (`type target [result] (reason)`) plus `--json` form (FR-014); wire `--dry-run` prefix
 
 **Checkpoint**: Engine primitives ready — user stories can now be implemented in parallel
 
@@ -66,8 +66,8 @@ Shell-and-config layout (repo default). Engine + installer in `configs/claude/sc
 
 ### Implementation for User Story 1
 
-- [ ] T014 [US1] Add minimal `pr-edit <N>` subcommand to `configs/claude/scripts/git_ops.sh` (wraps `gh pr edit --body` / `glab mr update --description`), update its `--help`; non-destructive body append. Because `pr-edit` is a permanent public `git_ops.sh` primitive, add direct bats cases in `tests/bats/git_ops.bats` (append on github, append on gitlab, idempotent when keyword already present, graceful failure when the PR is not editable) — not only transitive coverage via `sync-pr`
-- [ ] T015 [US1] Implement `sync-pr <PR_NUMBER> [--dry-run] [--no-create]` in `configs/claude/scripts/issue_support.sh`: resolve → for each open issue transition → `needs-review` (T010), back-link comment (T011), ensure `Closes #N` via `git_ops.sh pr-edit` appending when missing (FR-005); all wrapped fail-open (T009)
+- [X] T014 [US1] Add minimal `pr-edit <N>` subcommand to `configs/claude/scripts/git_ops.sh` (wraps `gh pr edit --body` / `glab mr update --description`), update its `--help`; non-destructive body append. Because `pr-edit` is a permanent public `git_ops.sh` primitive, add direct bats cases in `tests/bats/git_ops.bats` (append on github, append on gitlab, idempotent when keyword already present, graceful failure when the PR is not editable) — not only transitive coverage via `sync-pr`
+- [X] T015 [US1] Implement `sync-pr <PR_NUMBER> [--dry-run] [--no-create]` in `configs/claude/scripts/issue_support.sh`: resolve → for each open issue transition → `needs-review` (T010), back-link comment (T011), ensure `Closes #N` via `git_ops.sh pr-edit` appending when missing (FR-005); all wrapped fail-open (T009)
 - [ ] T016 [US1] Create `.skillshare/skills/pr-issue-sync/SKILL.md` with `name`/`description` frontmatter; document `sync-pr` invocation, the PostToolUse trigger, fail-open behavior, and `--no-create`
 - [ ] T017 [US1] Create `configs/claude/scripts/install_issue_hooks.sh` with `--help`, `--enable`/`--remove`, and the unified PR PostToolUse matcher (`pr-create`|`gh pr create`|`glab mr create` → `sync-pr <N>`) via `ai-hooks-integration`; idempotent re-install (H1), opt-in no-op when not enabled (H3), fires only on the underlying command's success (H4)
 - [ ] T018 [US1] Register `pr-issue-sync` per `.claude/CLAUDE.md` "Adding New Skills": add `parallel_agents`/`validation_tier` under `tool_policies.pr-issue-sync` in `command_config.yml`; verify `configs/claude/skills` symlink is intact (not replaced)
@@ -88,7 +88,7 @@ Shell-and-config layout (repo default). Engine + installer in `configs/claude/sc
 
 ### Implementation for User Story 2
 
-- [ ] T020 [US2] Implement `sync-commit <SHA|HEAD> [--dry-run] [--no-create]` in `configs/claude/scripts/issue_support.sh`: resolve → transition `planned` → `in-progress` (only issues already carrying the `planned` label; unlabeled issues are outside the managed lifecycle and left untouched, per FR-006) → dedup back-link comment; read `commit_hook_mode` and on `background` fall back to `sync` + `err()` warning (v1; reserved value per FR-016)
+- [X] T020 [US2] Implement `sync-commit <SHA|HEAD> [--dry-run] [--no-create]` in `configs/claude/scripts/issue_support.sh`: resolve → transition `planned` → `in-progress` (only issues already carrying the `planned` label; unlabeled issues are outside the managed lifecycle and left untouched, per FR-006) → dedup back-link comment; read `commit_hook_mode` and on `background` fall back to `sync` + `err()` warning (v1; reserved value per FR-016)
 - [ ] T021 [US2] Create `.skillshare/skills/commit-issue-sync/SKILL.md` with `name`/`description` frontmatter; document `sync-commit`, the commit trigger, dedup/idempotency, and fail-open
 - [ ] T022 [US2] Extend `configs/claude/scripts/install_issue_hooks.sh`: unified commit PostToolUse matcher (`git commit` → `sync-commit HEAD`) plus `--native` guarded `post-commit` installer (refuses to clobber a foreign hook H2, writes a delimited managed block) and `--remove` cleanup of both surfaces (H5)
 - [ ] T023 [US2] Register `commit-issue-sync` per "Adding New Skills": add `parallel_agents`/`validation_tier` under `tool_policies.commit-issue-sync` in `command_config.yml`
@@ -109,9 +109,9 @@ Shell-and-config layout (repo default). Engine + installer in `configs/claude/sc
 
 ### Implementation for User Story 3
 
-- [ ] T025 [P] [US3] Create engine-owned template `configs/claude/scripts/templates/issue_support_issue.md`: context summary, acceptance-criteria stub, bidirectional links to branch/PR/commit
-- [ ] T026 [US3] Implement create-issue flow in `configs/claude/scripts/issue_support.sh`: dedup search via `git_ops.sh issue-list` (title/branch match) → interactive confirm (non-interactive → no-create + warn) → render template (T025) → `git_ops.sh issue-create` with `planned` label → link back → re-run the normal sync so the new issue enters the lifecycle (FR-009/009a/009b/009c)
-- [ ] T027 [US3] Wire `--no-create` flag + interactive-context detection into `sync-pr`/`sync-commit` in `issue_support.sh`; document the create-on-confirm behavior in both `SKILL.md` files
+- [X] T025 [P] [US3] Create engine-owned template `configs/claude/scripts/templates/issue_support_issue.md`: context summary, acceptance-criteria stub, bidirectional links to branch/PR/commit
+- [X] T026 [US3] Implement create-issue flow in `configs/claude/scripts/issue_support.sh`: dedup search via `git_ops.sh issue-list` (title/branch match) → interactive confirm (non-interactive → no-create + warn) → render template (T025) → `git_ops.sh issue-create` with `planned` label → link back → re-run the normal sync so the new issue enters the lifecycle (FR-009/009a/009b/009c)
+- [X] T027 [US3] Wire `--no-create` flag + interactive-context detection into `sync-pr`/`sync-commit` in `issue_support.sh`; document the create-on-confirm behavior in both `SKILL.md` files
 
 **Checkpoint**: All three user stories independently functional
 

--- a/specs/005-issue-linking-hooks/tasks.md
+++ b/specs/005-issue-linking-hooks/tasks.md
@@ -121,9 +121,9 @@ Shell-and-config layout (repo default). Engine + installer in `configs/claude/sc
 
 **Purpose**: Docs, verification, and the constitution-required review gate
 
-- [ ] T028 [P] Update `docs/COMMANDS.md` (and README skills note) to document `pr-issue-sync` + `commit-issue-sync` and `install_issue_hooks.sh`
-- [ ] T029 Run `quickstart.md` steps 2–6 end-to-end against a scratch repo (commit trigger, PR trigger, missing-issue creation, fail-open, dry-run)
-- [ ] T030 Run verification gate: `shellcheck configs/claude/scripts/issue_support.sh configs/claude/scripts/install_issue_hooks.sh configs/claude/scripts/git_ops.sh`; `yamllint configs/claude/config/command_config.yml`; `bats tests/bats/issue_support.bats`. Assert FR-010 label conformance: every label the engine sets or applies to a created issue exists in `configs/claude/config/labels.yml` (grep the engine's label literals against the registry — no off-registry labels)
+- [X] T028 [P] Update `docs/COMMANDS.md` (and README skills note) to document `pr-issue-sync` + `commit-issue-sync` and `install_issue_hooks.sh`
+- [X] T029 Run `quickstart.md` steps 2–6 end-to-end against a scratch repo (commit trigger, PR trigger, missing-issue creation, fail-open, dry-run)
+- [X] T030 Run verification gate: `shellcheck configs/claude/scripts/issue_support.sh configs/claude/scripts/install_issue_hooks.sh configs/claude/scripts/git_ops.sh`; `yamllint configs/claude/config/command_config.yml`; `bats tests/bats/issue_support.bats`. Assert FR-010 label conformance: every label the engine sets or applies to a created issue exists in `configs/claude/config/labels.yml` (grep the engine's label literals against the registry — no off-registry labels)
 - [ ] T031 Tier 1 cross-verification (Constitution II): run `parallel_agent.py --review` on the `issue_support.sh` + `git_ops.sh` diff (token handling + >200 lines) before opening the PR
 
 ---

--- a/specs/005-issue-linking-hooks/tasks.md
+++ b/specs/005-issue-linking-hooks/tasks.md
@@ -1,0 +1,194 @@
+---
+description: "Task list for Issue-Linking Git Hooks implementation"
+---
+
+# Tasks: Issue-Linking Git Hooks
+
+**Input**: Design documents from `/specs/005-issue-linking-hooks/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md (all authored in the design phase; `quickstart.md` must exist before T029 runs)
+
+**Tests**: INCLUDED — the repo mandates `bats tests/bats/` for shell changes (`.claude/CLAUDE.md` Development Workflow) and the contracts define explicit testable guarantees (C1–C7, H1–H5). Tests are written to fail first, then implemented against.
+
+**Organization**: Tasks grouped by user story. The shared engine lives in Foundational (both stories depend on it); each story is an independently testable increment on top.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 = PR sync, US2 = commit sync, US3 = missing-issue creation
+- All paths are repo-relative to the worktree root.
+
+## Path Conventions
+
+Shell-and-config layout (repo default). Engine + installer in `configs/claude/scripts/`; skills in `.skillshare/skills/`; config in `configs/claude/config/`; tests in `tests/bats/` + `tests/fixtures/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Scaffolding and offline test fixtures
+
+- [ ] T001 Create directory scaffolding: `.skillshare/skills/pr-issue-sync/`, `.skillshare/skills/commit-issue-sync/`, `configs/claude/scripts/templates/`, `tests/fixtures/issue_support/`
+- [ ] T002 [P] Add offline mock fixtures (sample `pr-view`, `issue-view`, `issue-list` JSON payloads for github & gitlab) in `tests/fixtures/issue_support/`
+- [ ] T003 [P] Create `tests/bats/issue_support.bats` skeleton with `setup()`/`teardown()` that stubs `git_ops.sh`/`git_platform.sh` on `PATH` so tests run with no live tracker
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared issue-support engine — every primitive both stories delegate to
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T004 Create `configs/claude/scripts/issue_support.sh` skeleton: `set -euo pipefail`, `err()` helper, `--help` (≤15 lines, exit 0), subcommand dispatch for `sync-pr`/`sync-commit`/`resolve`
+- [ ] T005 Add `tool_policies.pr-issue-sync` (`enabled: false`, `hook_timeout_seconds: 5`) and `tool_policies.commit-issue-sync` (`enabled: false`, `hook_timeout_seconds: 5`, `commit_hook_mode: sync`) to `configs/claude/config/command_config.yml`
+- [ ] T006 Implement config loader in `configs/claude/scripts/issue_support.sh` (python3 YAML read, `label_sync.sh` precedent); `enabled: false` → clean no-op exit 0 (FR-015 runtime gate)
+- [ ] T007 Integrate platform detection via `git_platform.sh` in `issue_support.sh`; non-github/gitlab (plain `git`/none) → informational no-op exit (Edge: no platform)
+- [ ] T008 Implement `resolve` subcommand in `issue_support.sh`: precedence branch-prefix → pr-body → commit-message references **and** trailers (inline `#N`/`Fixes #N` plus `Issue:`/`Refs:` trailers, per R3/FR-004), validate each candidate via `git_ops.sh issue-view` (`exists` gate), emit `IssueRef[]` JSON; report ambiguous/conflicting candidates without auto-picking (FR-012)
+- [ ] T009 Implement fail-open timeout wrapper in `issue_support.sh` (R6/FR-008): bound tracker work by `hook_timeout_seconds` via `timeout`/`gtimeout` (or `bootstrap/lib/platform.sh` helper); any failure/timeout → single `err()` warning + exit 0 (guarantee C1). Distinguish two edge cases in the warning text: (a) **insufficient token scope** → report the specific missing capability (e.g. "token lacks issue-write scope") rather than a generic error (spec Edge L80); (b) **rate limiting** → detect throttle responses and back off (bounded retry within `hook_timeout_seconds`) before degrading to a warning (spec Edge L86)
+- [ ] T010 Implement forward-only transition primitive in `issue_support.sh` (data-model state machine / FR-006a): ordered set `planned<in-progress<needs-review<done`, no-op if issue already ≥ target (C5), skip closed/locked with warning (FR-013/C4)
+- [ ] T011 Implement idempotent back-link comment primitive in `issue_support.sh`: embed marker `<!-- issue-support:sync v1 ... -->`, skip/refresh if marker already present (R2/FR-007/C2) via `git_ops.sh issue-comment`/`issue-comment-edit-last`
+- [ ] T012 Implement run-summary emitter in `issue_support.sh`: one stdout line per `SyncAction` (`type target [result] (reason)`) plus `--json` form (FR-014); wire `--dry-run` prefix
+
+**Checkpoint**: Engine primitives ready — user stories can now be implemented in parallel
+
+---
+
+## Phase 3: User Story 1 - Auto-sync the linked issue when a PR is opened (Priority: P1) 🎯 MVP
+
+**Goal**: Opening a PR/MR back-links and advances each linked issue to `needs-review` and ensures the closing keyword, fail-open.
+
+**Independent Test**: Open a PR on a branch tied to a known issue → issue gets a back-link comment, label → `needs-review`, and a missing `Closes #N` is appended — with no manual issue edits and no blocked PR.
+
+### Tests for User Story 1
+
+- [ ] T013 [P] [US1] Add bats cases in `tests/bats/issue_support.bats` for `sync-pr`: resolves issue from PR, transitions → `needs-review`, idempotent re-run yields only `skipped` (C2), fail-open on tracker error exits 0 (C1), closed/locked issue skipped (C4), multi-issue PR acts on each (C7). Also cover the PR-installer (T017): idempotent re-install adds no duplicate entry (H1), disabled-config install is a no-op (H3), engine does not fire when the underlying command failed (H4)
+
+### Implementation for User Story 1
+
+- [ ] T014 [US1] Add minimal `pr-edit <N>` subcommand to `configs/claude/scripts/git_ops.sh` (wraps `gh pr edit --body` / `glab mr update --description`), update its `--help`; non-destructive body append. Because `pr-edit` is a permanent public `git_ops.sh` primitive, add direct bats cases in `tests/bats/git_ops.bats` (append on github, append on gitlab, idempotent when keyword already present, graceful failure when the PR is not editable) — not only transitive coverage via `sync-pr`
+- [ ] T015 [US1] Implement `sync-pr <PR_NUMBER> [--dry-run] [--no-create]` in `configs/claude/scripts/issue_support.sh`: resolve → for each open issue transition → `needs-review` (T010), back-link comment (T011), ensure `Closes #N` via `git_ops.sh pr-edit` appending when missing (FR-005); all wrapped fail-open (T009)
+- [ ] T016 [US1] Create `.skillshare/skills/pr-issue-sync/SKILL.md` with `name`/`description` frontmatter; document `sync-pr` invocation, the PostToolUse trigger, fail-open behavior, and `--no-create`
+- [ ] T017 [US1] Create `configs/claude/scripts/install_issue_hooks.sh` with `--help`, `--enable`/`--remove`, and the unified PR PostToolUse matcher (`pr-create`|`gh pr create`|`glab mr create` → `sync-pr <N>`) via `ai-hooks-integration`; idempotent re-install (H1), opt-in no-op when not enabled (H3), fires only on the underlying command's success (H4)
+- [ ] T018 [US1] Register `pr-issue-sync` per `.claude/CLAUDE.md` "Adding New Skills": add `parallel_agents`/`validation_tier` under `tool_policies.pr-issue-sync` in `command_config.yml`; verify `configs/claude/skills` symlink is intact (not replaced)
+
+**Checkpoint**: PR-open sync works end-to-end and is independently demoable (MVP)
+
+---
+
+## Phase 4: User Story 2 - Auto-sync the linked issue on branch commits (Priority: P2)
+
+**Goal**: Committing to a feature branch advances a `planned` issue to `in-progress`, de-duplicated across commits, fail-open.
+
+**Independent Test**: Commit to a branch tied to a `planned` issue → issue moves to `in-progress` exactly once across multiple commits; commits never blocked.
+
+### Tests for User Story 2
+
+- [ ] T019 [P] [US2] Add bats cases in `tests/bats/issue_support.bats` for `sync-commit`: resolves from branch prefix/commit trailer, `planned`→`in-progress`, 10 consecutive commits transition/comment at most once (C2/SC-003), fail-open exits 0 (C1), `commit_hook_mode: background` falls back to `sync` with a warning (FR-016). Also cover the native installer (T022): refuses to clobber a pre-existing foreign `post-commit` hook (H2), and `--remove` cleanly removes both the PostToolUse entry and the delimited native block (H5). Add a recovery case (FR-017): after a first run that times out / fails mid-way (tracker error injected), a second run brings the issue to the correct state with no duplicate comment or double transition
+
+### Implementation for User Story 2
+
+- [ ] T020 [US2] Implement `sync-commit <SHA|HEAD> [--dry-run] [--no-create]` in `configs/claude/scripts/issue_support.sh`: resolve → transition `planned` → `in-progress` (only issues already carrying the `planned` label; unlabeled issues are outside the managed lifecycle and left untouched, per FR-006) → dedup back-link comment; read `commit_hook_mode` and on `background` fall back to `sync` + `err()` warning (v1; reserved value per FR-016)
+- [ ] T021 [US2] Create `.skillshare/skills/commit-issue-sync/SKILL.md` with `name`/`description` frontmatter; document `sync-commit`, the commit trigger, dedup/idempotency, and fail-open
+- [ ] T022 [US2] Extend `configs/claude/scripts/install_issue_hooks.sh`: unified commit PostToolUse matcher (`git commit` → `sync-commit HEAD`) plus `--native` guarded `post-commit` installer (refuses to clobber a foreign hook H2, writes a delimited managed block) and `--remove` cleanup of both surfaces (H5)
+- [ ] T023 [US2] Register `commit-issue-sync` per "Adding New Skills": add `parallel_agents`/`validation_tier` under `tool_policies.commit-issue-sync` in `command_config.yml`
+
+**Checkpoint**: Commit sync and PR sync both work independently
+
+---
+
+## Phase 5: User Story 3 - Offer to create a tracking issue when none is linked (Priority: P3)
+
+**Goal**: When no issue resolves, offer (on confirmation) a best-of-breed tracking issue: dedup-checked, templated, canonically labeled, linked back.
+
+**Independent Test**: Trigger a PR/commit on a branch with no issue association → a pre-filled issue is proposed; created only on confirm (non-interactive → no-create + warn); a pre-existing match is reused, not duplicated.
+
+### Tests for User Story 3
+
+- [ ] T024 [P] [US3] Add bats cases in `tests/bats/issue_support.bats` for the create flow: dedup-match reuses an existing open issue instead of creating (FR-009a), non-interactive context defaults to no-create + warn (FR-009), template renders with context/acceptance-criteria/links and applies `planned` label (FR-009b/c)
+
+### Implementation for User Story 3
+
+- [ ] T025 [P] [US3] Create engine-owned template `configs/claude/scripts/templates/issue_support_issue.md`: context summary, acceptance-criteria stub, bidirectional links to branch/PR/commit
+- [ ] T026 [US3] Implement create-issue flow in `configs/claude/scripts/issue_support.sh`: dedup search via `git_ops.sh issue-list` (title/branch match) → interactive confirm (non-interactive → no-create + warn) → render template (T025) → `git_ops.sh issue-create` with `planned` label → link back → re-run the normal sync so the new issue enters the lifecycle (FR-009/009a/009b/009c)
+- [ ] T027 [US3] Wire `--no-create` flag + interactive-context detection into `sync-pr`/`sync-commit` in `issue_support.sh`; document the create-on-confirm behavior in both `SKILL.md` files
+
+**Checkpoint**: All three user stories independently functional
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Docs, verification, and the constitution-required review gate
+
+- [ ] T028 [P] Update `docs/COMMANDS.md` (and README skills note) to document `pr-issue-sync` + `commit-issue-sync` and `install_issue_hooks.sh`
+- [ ] T029 Run `quickstart.md` steps 2–6 end-to-end against a scratch repo (commit trigger, PR trigger, missing-issue creation, fail-open, dry-run)
+- [ ] T030 Run verification gate: `shellcheck configs/claude/scripts/issue_support.sh configs/claude/scripts/install_issue_hooks.sh configs/claude/scripts/git_ops.sh`; `yamllint configs/claude/config/command_config.yml`; `bats tests/bats/issue_support.bats`. Assert FR-010 label conformance: every label the engine sets or applies to a created issue exists in `configs/claude/config/labels.yml` (grep the engine's label literals against the registry — no off-registry labels)
+- [ ] T031 Tier 1 cross-verification (Constitution II): run `parallel_agent.py --review` on the `issue_support.sh` + `git_ops.sh` diff (token handling + >200 lines) before opening the PR
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Setup — **BLOCKS all user stories** (it is the shared engine)
+- **User Stories (Phase 3–5)**: All depend on Foundational. US1 → US2 → US3 in priority order, or parallel if staffed (different SKILL.md files; engine edits are additive subcommands)
+- **Polish (Phase 6)**: Depends on the desired user stories being complete
+
+### Within Foundational (ordering)
+
+- T004 (skeleton) → T006 (config loader) → T007 (platform) → T008 (resolve) → T009 (timeout) → T010/T011 (transition/comment primitives) → T012 (summary). T005 (config entries) can land any time before T006.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Foundational only. T014 (`pr-edit`) before T015 (`sync-pr` uses it). T016/T017/T018 after T015.
+- **US2 (P2)**: Foundational only. T020 (`sync-commit`) before T022 (installer wires it). Independent of US1.
+- **US3 (P3)**: Foundational + at least one sync path. T025 (template) before T026 (create flow). T027 touches both SKILL.md files (coordinate if US1/US2 in flight).
+
+### Parallel Opportunities
+
+- Setup: T002, T003 in parallel.
+- US1 tests T013 ∥ US2 tests T019 ∥ US3 tests T024 (all author against the engine contract; different test cases).
+- T025 (template, static asset) parallel with US3 logic authoring.
+- Across stories: US1 and US2 are implementable by different developers immediately once Foundational is done (distinct subcommands/skills). US3 can begin **test authoring** (T024) and its static **template** (T025) in parallel too, but its **implementation T026/T027 is blocked** until at least one sync path lands (T015 `sync-pr` **or** T020 `sync-commit`) — T026 explicitly re-runs the normal sync, a runtime call back into that path.
+- Shared touch-points are serialized, not parallel: `command_config.yml` (T018/T023) and the two SKILL.md files (T027 edits both).
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After Foundational completes — author US1 tests and the new git_ops primitive together:
+Task: "T013 [US1] bats cases for sync-pr in tests/bats/issue_support.bats"
+Task: "T014 [US1] add pr-edit subcommand to configs/claude/scripts/git_ops.sh"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1: Setup
+2. Phase 2: Foundational (shared engine — CRITICAL, blocks everything)
+3. Phase 3: User Story 1 (PR sync)
+4. **STOP and VALIDATE**: run quickstart step 3 + `bats tests/bats/issue_support.bats` for US1
+5. Demo/enable on one repo (`install_issue_hooks.sh --enable`)
+
+### Incremental Delivery
+
+1. Setup + Foundational → engine ready
+2. US1 (PR sync) → test → enable (MVP)
+3. US2 (commit sync) → test → enable
+4. US3 (missing-issue creation) → test → enable
+5. Polish (docs, verification, Tier 1 review gate)
+
+### Notes
+
+- [P] = different files, no incomplete dependencies.
+- All engine subcommands MUST exit 0 (fail-open) — verify in every bats case.
+- Shared touch-points (`command_config.yml`, both `SKILL.md`) are serialized, not [P].
+- Commit after each task or logical group; run `shellcheck`/`bats` before each commit (repo convention).
+- Do NOT replace the `configs/claude/skills` symlink with a real directory.

--- a/tests/bats/git_ops.bats
+++ b/tests/bats/git_ops.bats
@@ -143,6 +143,14 @@ make_clean_bin() {
     assert_output --partial "STUB:gh:pr list"
 }
 
+@test "routes pr-edit to gh pr edit (append body on GitHub)" {
+    cd "$TEST_REPO" || return 1
+    create_stub "gh"
+    run bash "$SCRIPT_UNDER_TEST" pr-edit 99 --body "Closes #17"
+    assert_success
+    assert_output --partial "STUB:gh:pr edit 99 --body Closes #17"
+}
+
 @test "routes label-create to gh label create" {
     cd "$TEST_REPO" || return 1
     create_stub "gh"
@@ -177,6 +185,15 @@ make_clean_bin() {
     run bash "$SCRIPT_UNDER_TEST" pr-create --title "Fix"
     assert_success
     assert_output --partial "STUB:glab:mr create --title Fix"
+}
+
+@test "routes pr-edit to glab mr update (--body → --description) on GitLab" {
+    cd "$TEST_REPO" || return 1
+    git remote set-url origin "https://gitlab.com/user/repo.git"
+    create_stub "glab"
+    run bash "$SCRIPT_UNDER_TEST" pr-edit 99 --body "Closes #17"
+    assert_success
+    assert_output --partial "STUB:glab:mr update 99 --description Closes #17"
 }
 
 @test "routes issue-comment to glab issue note on GitLab" {

--- a/tests/bats/git_ops.bats
+++ b/tests/bats/git_ops.bats
@@ -214,6 +214,15 @@ make_clean_bin() {
     assert_output --partial "STUB:glab:issue update 5 --title Updated"
 }
 
+@test "issue-edit --add-label/--remove-label translate to glab --label/--unlabel" {
+    cd "$TEST_REPO" || return 1
+    git remote set-url origin "https://gitlab.com/user/repo.git"
+    create_stub "glab"
+    run bash "$SCRIPT_UNDER_TEST" issue-edit 17 --add-label in-progress --remove-label planned
+    assert_success
+    assert_output --partial "STUB:glab:issue update 17 --label in-progress --unlabel planned"
+}
+
 # --- Unknown subcommand tests ---
 
 @test "fails on unknown subcommand for GitHub" {

--- a/tests/bats/install_issue_hooks.bats
+++ b/tests/bats/install_issue_hooks.bats
@@ -75,6 +75,8 @@ teardown() { [[ -n "$TMP" && -d "$TMP" ]] && rm -rf "$TMP"; }
 @test "native install adds a managed block when no hook exists; remove strips it" {
     bash "$INSTALL" --enable --native
     grep -q '>>> issue-support >>>' "$REPO/.git/hooks/post-commit"
+    # shebang must be the first line so Git can exec the hook
+    head -1 "$REPO/.git/hooks/post-commit" | grep -q '^#!'
     bash "$INSTALL" --remove
     [ ! -f "$REPO/.git/hooks/post-commit" ] || ! grep -q 'issue-support' "$REPO/.git/hooks/post-commit"
 }

--- a/tests/bats/install_issue_hooks.bats
+++ b/tests/bats/install_issue_hooks.bats
@@ -79,6 +79,32 @@ teardown() { [[ -n "$TMP" && -d "$TMP" ]] && rm -rf "$TMP"; }
     [ ! -f "$REPO/.git/hooks/post-commit" ] || ! grep -q 'issue-support' "$REPO/.git/hooks/post-commit"
 }
 
+@test "native enable→remove→enable round-trip re-installs cleanly (bug_007)" {
+    bash "$INSTALL" --enable --native
+    bash "$INSTALL" --remove
+    # No orphan residual must remain to trip the clobber-guard
+    [ ! -f "$REPO/.git/hooks/post-commit" ]
+    run bash "$INSTALL" --enable --native
+    [ "$status" -eq 0 ]
+    grep -q 'issue-support' "$REPO/.git/hooks/post-commit"
+}
+
+# --- bug_006: sibling hooks under the same matcher must survive --------------
+
+@test "remove preserves a sibling hook co-located under the same Bash matcher" {
+    HOOK_CANON="$(cd "$(dirname "$INSTALL")" && pwd)/issue_support_hook.sh"
+    cat >"$ISSUE_HOOKS_SETTINGS" <<EOF
+{"hooks":{"PostToolUse":[{"matcher":"Bash","hooks":[
+  {"type":"command","command":"/usr/local/bin/audit-log.sh"},
+  {"type":"command","command":"${HOOK_CANON}"}
+]}]}}
+EOF
+    run bash "$INSTALL" --remove
+    [ "$status" -eq 0 ]
+    grep -q 'audit-log.sh' "$ISSUE_HOOKS_SETTINGS"
+    ! grep -q 'issue_support_hook.sh' "$ISSUE_HOOKS_SETTINGS"
+}
+
 # --- H4: dispatcher fires only on success -----------------------------------
 
 @test "dispatcher invokes engine sync-pr on a successful PR-create command" {
@@ -105,4 +131,35 @@ EOF
     export ISSUE_SUPPORT_ENGINE="$TMP/engine.sh"
     printf '{"tool_input":{"command":"git commit -m x"},"tool_response":{"is_error":true}}' | bash "$DISPATCH"
     [ ! -s "$REC" ]
+}
+
+# --- bug_005: classifier must not fire on unrelated commands ----------------
+
+@test "dispatcher ignores commands that merely contain pr-create/commit substrings" {
+    REC="$TMP/engine_calls.log"; : >"$REC"
+    cat >"$TMP/engine.sh" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$REC"
+EOF
+    chmod +x "$TMP/engine.sh"
+    export ISSUE_SUPPORT_ENGINE="$TMP/engine.sh"
+    for c in "cat tests/fixtures/pr-create.json" "npm run pr-create-helper" \
+             "git config commit.gpgsign true" "git log --grep=commit"; do
+        printf '{"tool_input":{"command":"%s"},"tool_response":{}}' "$c" > "$TMP/p.json"
+        bash "$DISPATCH" < "$TMP/p.json"
+    done
+    [ ! -s "$REC" ]   # none of the false-positive commands invoked the engine
+}
+
+@test "dispatcher still fires on a real git commit invocation" {
+    REC="$TMP/engine_calls.log"; : >"$REC"
+    cat >"$TMP/engine.sh" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$REC"
+EOF
+    chmod +x "$TMP/engine.sh"
+    export ISSUE_SUPPORT_ENGINE="$TMP/engine.sh"
+    printf '{"tool_input":{"command":"git commit -m work"},"tool_response":{}}' > "$TMP/p.json"
+    bash "$DISPATCH" < "$TMP/p.json"
+    grep -q 'sync-commit' "$REC"
 }

--- a/tests/bats/install_issue_hooks.bats
+++ b/tests/bats/install_issue_hooks.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+# Tests for install_issue_hooks.sh and issue_support_hook.sh
+# Installer safety invariants H1 (idempotent), H2 (no-clobber), H3 (opt-in gate),
+# H4 (fire only on success), H5 (remove cleanup).
+
+INSTALL="$BATS_TEST_DIRNAME/../../configs/claude/scripts/install_issue_hooks.sh"
+DISPATCH="$BATS_TEST_DIRNAME/../../configs/claude/scripts/issue_support_hook.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    TMP=$(mktemp -d "$BATS_TMPDIR/install_ih.XXXXXX")
+    export ISSUE_HOOKS_SETTINGS="$TMP/settings.json"
+    export ISSUE_HOOKS_CONFIG="$TMP/config.yml"
+    cat >"$ISSUE_HOOKS_CONFIG" <<'EOF'
+tool_policies:
+  pr-issue-sync:
+    enabled: false              # comment kept
+    hook_timeout_seconds: 5
+  commit-issue-sync:
+    enabled: false
+    hook_timeout_seconds: 5
+    commit_hook_mode: sync
+  other-skill:
+    enabled: false
+EOF
+    REPO="$TMP/repo"; git init -q "$REPO"
+    cd "$REPO" || return 1
+    git config user.email t@t.t; git config user.name t
+}
+teardown() { [[ -n "$TMP" && -d "$TMP" ]] && rm -rf "$TMP"; }
+
+# --- H3: opt-in runtime gate ------------------------------------------------
+
+@test "enable flips both skills' enabled to true and preserves comments" {
+    run bash "$INSTALL" --enable
+    [ "$status" -eq 0 ]
+    grep -A1 '^  pr-issue-sync:' "$ISSUE_HOOKS_CONFIG" | grep -q 'enabled: true'
+    grep -A1 '^  commit-issue-sync:' "$ISSUE_HOOKS_CONFIG" | grep -q 'enabled: true'
+    grep -q '# comment kept' "$ISSUE_HOOKS_CONFIG"
+    # unrelated skill untouched
+    grep -A1 '^  other-skill:' "$ISSUE_HOOKS_CONFIG" | grep -q 'enabled: false'
+}
+
+# --- H1: idempotent settings install ----------------------------------------
+
+@test "enable is idempotent — no duplicate PostToolUse entry" {
+    bash "$INSTALL" --enable
+    bash "$INSTALL" --enable
+    count=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(sum(1 for e in d["hooks"]["PostToolUse"] for h in e["hooks"] if "issue_support_hook.sh" in h["command"]))' "$ISSUE_HOOKS_SETTINGS")
+    [ "$count" -eq 1 ]
+}
+
+# --- H5: remove cleans up both surfaces -------------------------------------
+
+@test "remove flips enabled false and drops the settings entry" {
+    bash "$INSTALL" --enable
+    run bash "$INSTALL" --remove
+    [ "$status" -eq 0 ]
+    grep -A1 '^  pr-issue-sync:' "$ISSUE_HOOKS_CONFIG" | grep -q 'enabled: false'
+    count=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(sum(1 for e in d["hooks"].get("PostToolUse",[]) for h in e["hooks"] if "issue_support_hook.sh" in h["command"]))' "$ISSUE_HOOKS_SETTINGS")
+    [ "$count" -eq 0 ]
+}
+
+# --- H2: native hook never clobbers a foreign post-commit -------------------
+
+@test "native install refuses to clobber an existing foreign post-commit hook" {
+    printf '#!/usr/bin/env bash\necho mine\n' > "$REPO/.git/hooks/post-commit"
+    chmod +x "$REPO/.git/hooks/post-commit"
+    run bash "$INSTALL" --enable --native
+    [ "$status" -eq 0 ]
+    grep -q 'echo mine' "$REPO/.git/hooks/post-commit"
+    ! grep -q 'issue-support' "$REPO/.git/hooks/post-commit"
+}
+
+@test "native install adds a managed block when no hook exists; remove strips it" {
+    bash "$INSTALL" --enable --native
+    grep -q '>>> issue-support >>>' "$REPO/.git/hooks/post-commit"
+    bash "$INSTALL" --remove
+    [ ! -f "$REPO/.git/hooks/post-commit" ] || ! grep -q 'issue-support' "$REPO/.git/hooks/post-commit"
+}
+
+# --- H4: dispatcher fires only on success -----------------------------------
+
+@test "dispatcher invokes engine sync-pr on a successful PR-create command" {
+    REC="$TMP/engine_calls.log"
+    cat >"$TMP/engine.sh" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$REC"
+EOF
+    chmod +x "$TMP/engine.sh"
+    export ISSUE_SUPPORT_ENGINE="$TMP/engine.sh"
+    printf '{"tool_input":{"command":"gh pr create --title x"},"tool_response":{}}' > "$TMP/payload.json"
+    run bash "$DISPATCH" < "$TMP/payload.json"
+    [ "$status" -eq 0 ]
+    grep -q 'sync-pr' "$REC"
+}
+
+@test "dispatcher does NOT invoke engine when the command failed" {
+    REC="$TMP/engine_calls.log"; : >"$REC"
+    cat >"$TMP/engine.sh" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$REC"
+EOF
+    chmod +x "$TMP/engine.sh"
+    export ISSUE_SUPPORT_ENGINE="$TMP/engine.sh"
+    printf '{"tool_input":{"command":"git commit -m x"},"tool_response":{"is_error":true}}' | bash "$DISPATCH"
+    [ ! -s "$REC" ]
+}

--- a/tests/bats/issue_support.bats
+++ b/tests/bats/issue_support.bats
@@ -171,3 +171,22 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"create-issue"*"skipped"* ]]
 }
+
+@test "no linked issue but a matching one exists → reuse, don't duplicate (FR-009a)" {
+    git checkout -q -b hotfix-adhoc
+    ISSUE_LIST_OUT="#5  hotfix-adhoc work" run "$SCRIPT" sync-commit HEAD
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"existing match reused"* ]]
+}
+
+# --- FR-017: a failed run is recoverable on re-run --------------------------
+
+@test "transition records [failed] when tracker errors, [applied] on a clean re-run" {
+    mk_issue 17 open planned
+    EDIT_RC=1 run "$SCRIPT" sync-commit HEAD
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"transition planned→in-progress [failed]"* ]]
+    EDIT_RC=0 run "$SCRIPT" sync-commit HEAD
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"transition planned→in-progress [applied]"* ]]
+}

--- a/tests/bats/issue_support.bats
+++ b/tests/bats/issue_support.bats
@@ -87,6 +87,24 @@ EOF
     [ "$status" -eq 3 ]
 }
 
+@test "resolve --json emits full IssueRef (number, source, exists, state, label)" {
+    mk_issue 17 open planned
+    run "$SCRIPT" resolve --branch 017-test-branch --json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"number":17'* ]]
+    [[ "$output" == *'"source":"branch-prefix"'* ]]
+    [[ "$output" == *'"exists":true'* ]]
+    [[ "$output" == *'"state":"open"'* ]]
+    [[ "$output" == *'"label":"planned"'* ]]
+}
+
+@test "resolve --json marks a non-existent candidate exists:false" {
+    # no fixture for #17 → issue_record returns empty
+    run "$SCRIPT" resolve --branch 017-test-branch --json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"exists":false'* ]]
+}
+
 # --- fail-open (C1) ---------------------------------------------------------
 
 @test "sync-pr exits 0 even when tracker calls fail (fail-open)" {

--- a/tests/bats/issue_support.bats
+++ b/tests/bats/issue_support.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# Tests for configs/claude/scripts/issue_support.sh
+# Engine guarantees: resolution precedence, fail-open, idempotency, forward-only
+# transitions, closed/locked skip, enabled gate, create-flow, background fallback.
+
+SCRIPT="$BATS_TEST_DIRNAME/../../configs/claude/scripts/issue_support.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    TMP=$(mktemp -d "$BATS_TMPDIR/issue_support.XXXXXX")
+    export FIXTURE_DIR="$TMP/fixtures"
+    mkdir -p "$FIXTURE_DIR"
+
+    # Temp git repo with a numbered branch + one commit (for current_branch / git log)
+    REPO="$TMP/repo"
+    git init -q "$REPO"
+    cd "$REPO" || return 1
+    git config user.email t@t.t; git config user.name t
+    git checkout -q -b 017-test-branch
+    git commit -q --allow-empty -m "work"
+
+    # Stub git_platform.sh → github
+    cat >"$TMP/git_platform.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "${STUB_PLATFORM:-github}"
+EOF
+    chmod +x "$TMP/git_platform.sh"
+
+    # Stub git_ops.sh: log calls, emit fixtures, honor *_RC env for exit codes
+    cat >"$TMP/git_ops.sh" <<'EOF'
+#!/usr/bin/env bash
+sub="$1"; shift
+echo "$sub $*" >> "${CALL_LOG:-/dev/null}"
+case "$sub" in
+  issue-view)
+    n="$1"
+    if [[ -f "${FIXTURE_DIR}/issue-${n}.json" ]]; then cat "${FIXTURE_DIR}/issue-${n}.json"; fi
+    ;;
+  pr-view)   [[ -f "${FIXTURE_DIR}/pr.json" ]] && cat "${FIXTURE_DIR}/pr.json" || true ;;
+  issue-list) printf '%s' "${ISSUE_LIST_OUT:-}" ;;
+  issue-edit) exit "${EDIT_RC:-0}" ;;
+  issue-comment) exit "${COMMENT_RC:-0}" ;;
+  issue-create) exit "${CREATE_RC:-0}" ;;
+  pr-edit) exit "${PREDIT_RC:-0}" ;;
+  *) exit "${GITOPS_RC:-0}" ;;
+esac
+exit "${GITOPS_RC:-0}"
+EOF
+    chmod +x "$TMP/git_ops.sh"
+
+    export GIT_PLATFORM_BIN="$TMP/git_platform.sh"
+    export GIT_OPS_BIN="$TMP/git_ops.sh"
+    export CALL_LOG="$TMP/calls.log"
+
+    # Config with both skills enabled
+    export ISSUE_SUPPORT_CONFIG="$TMP/config.yml"
+    cat >"$ISSUE_SUPPORT_CONFIG" <<'EOF'
+tool_policies:
+  pr-issue-sync:
+    enabled: true
+    hook_timeout_seconds: 5
+  commit-issue-sync:
+    enabled: true
+    hook_timeout_seconds: 5
+    commit_hook_mode: sync
+EOF
+}
+
+teardown() { [[ -n "$TMP" && -d "$TMP" ]] && rm -rf "$TMP"; }
+
+mk_issue() { # mk_issue <n> <state> <label>
+    cat >"$FIXTURE_DIR/issue-$1.json" <<EOF
+{"number":$1,"state":"$2","labels":[$( [[ -n "$3" ]] && printf '{"name":"%s"}' "$3" )],"title":"t"}
+EOF
+}
+
+# --- resolution -------------------------------------------------------------
+
+@test "resolve: branch prefix yields issue number" {
+    run "$SCRIPT" resolve --branch 017-test-branch
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"17"* ]]
+}
+
+@test "resolve: no association returns code 3" {
+    run "$SCRIPT" resolve --branch hotfix-no-number
+    [ "$status" -eq 3 ]
+}
+
+# --- fail-open (C1) ---------------------------------------------------------
+
+@test "sync-pr exits 0 even when tracker calls fail (fail-open)" {
+    mk_issue 17 open planned
+    GITOPS_RC=1 EDIT_RC=1 COMMENT_RC=1 run "$SCRIPT" sync-pr 42
+    [ "$status" -eq 0 ]
+}
+
+@test "sync-commit exits 0 when platform is plain git (no-op)" {
+    STUB_PLATFORM=git run "$SCRIPT" sync-commit HEAD
+    [ "$status" -eq 0 ]
+}
+
+# --- enabled gate (FR-015) --------------------------------------------------
+
+@test "sync-pr is a no-op when disabled" {
+    cat >"$ISSUE_SUPPORT_CONFIG" <<'EOF'
+tool_policies:
+  pr-issue-sync:
+    enabled: false
+EOF
+    run "$SCRIPT" sync-pr 42
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"disabled"* ]]
+}
+
+# --- forward-only / idempotent (C2, C5) -------------------------------------
+
+@test "sync-pr is a no-op when issue already at needs-review" {
+    mk_issue 17 open needs-review
+    run "$SCRIPT" sync-pr 42
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"transition"*"skipped"* ]]
+}
+
+# --- closed/locked skip (C4) ------------------------------------------------
+
+@test "sync-pr skips a closed issue" {
+    mk_issue 17 closed planned
+    run "$SCRIPT" sync-pr 42
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"#17"*"skipped"*"closed"* ]]
+}
+
+# --- commit: only advances planned (FR-006) ---------------------------------
+
+@test "sync-commit skips an unlabeled issue" {
+    mk_issue 17 open ""
+    run "$SCRIPT" sync-commit HEAD
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unlabeled"* ]]
+}
+
+@test "sync-commit transitions a planned issue toward in-progress" {
+    mk_issue 17 open planned
+    run "$SCRIPT" sync-commit HEAD
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"#17 transition planned→in-progress"* ]]
+}
+
+# --- background fallback (FR-016) -------------------------------------------
+
+@test "commit_hook_mode=background falls back to sync with a warning" {
+    cat >"$ISSUE_SUPPORT_CONFIG" <<'EOF'
+tool_policies:
+  commit-issue-sync:
+    enabled: true
+    hook_timeout_seconds: 5
+    commit_hook_mode: background
+EOF
+    mk_issue 17 open planned
+    run "$SCRIPT" sync-commit HEAD
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reserved"* ]]
+}
+
+# --- create flow non-interactive (FR-009) -----------------------------------
+
+@test "no linked issue + non-interactive defaults to no-create" {
+    git checkout -q -b hotfix-adhoc
+    ISSUE_SUPPORT_INTERACTIVE=0 run "$SCRIPT" sync-commit HEAD
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"create-issue"*"skipped"* ]]
+}

--- a/tests/bats/issue_support.bats
+++ b/tests/bats/issue_support.bats
@@ -172,11 +172,22 @@ EOF
     [[ "$output" == *"create-issue"*"skipped"* ]]
 }
 
-@test "no linked issue but a matching one exists → reuse, don't duplicate (FR-009a)" {
+@test "no linked issue but a matching one exists → reuse + sync that issue (FR-009a/c)" {
     git checkout -q -b hotfix-adhoc
+    mk_issue 5 open planned
     ISSUE_LIST_OUT="#5  hotfix-adhoc work" run "$SCRIPT" sync-commit HEAD
     [ "$status" -eq 0 ]
-    [[ "$output" == *"existing match reused"* ]]
+    [[ "$output" == *"existing match reused: #5"* ]]
+    # FR-009c: the reused issue immediately enters the sync lifecycle
+    [[ "$output" == *"#5 transition planned→in-progress"* ]]
+}
+
+@test "PR body already containing Closes #N is detected (no duplicate append)" {
+    mk_issue 17 open planned
+    printf '{"body":"Implements the thing. Closes #17"}' > "$FIXTURE_DIR/pr.json"
+    run "$SCRIPT" sync-pr 42
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"closing-keyword Closes #17 [skipped] (already present)"* ]]
 }
 
 # --- FR-017: a failed run is recoverable on re-run --------------------------


### PR DESCRIPTION
## Summary

Two opt-in, **fail-open** companion skills that keep the linked GitHub/GitLab issue in sync with development activity, over a shared `issue_support.sh` engine:

- **`pr-issue-sync`** — on PR/MR open: back-link comment, advance the linked issue to `needs-review`, ensure `Closes #N` in the PR body.
- **`commit-issue-sync`** — on a branch commit: advance a `planned` issue to `in-progress`, de-duplicated across commits.

When no issue resolves, both offer to create a best-of-breed tracking issue (dedup-checked, templated, `planned`-labeled) — only on confirmation. Every path is fail-open: a tracker error or timeout degrades to a warning and **never blocks the git action**; idempotency makes a dropped run self-heal on re-run.

Built via the full Spec Kit flow (spec → plan → tasks), cross-reviewed by an independent model, and hardened by a cloud ultrareview.

## What's included

| Area | Files |
|---|---|
| Engine | `configs/claude/scripts/issue_support.sh` (resolve / transition / comment / create; bounded soft-timeout; bash 3.2-safe) |
| Platform primitive | `git_ops.sh pr-edit` + GitLab `issue-edit` label translation |
| Hook wiring | `issue_support_hook.sh` (PostToolUse dispatcher) + `install_issue_hooks.sh` (`--enable`/`--remove`/`--native`) |
| Skills | `.skillshare/skills/{pr,commit}-issue-sync/SKILL.md` |
| Config / template | `command_config.yml` runtime gates; engine-owned issue template |
| Docs | `docs/COMMANDS.md` (Issue-Linking Hooks section) |
| Spec Kit | `specs/005-issue-linking-hooks/` (spec, plan, research, data-model, contracts, quickstart, tasks) |

## Design decisions

- **Execution model**: bounded synchronous + fail-open (not a background queue) — idempotency makes a timed-out run self-healing; `hook_timeout_seconds` / `commit_hook_mode` are config knobs (`background` reserved for a future release, falls back to `sync`).
- **Resolution precedence**: branch-number prefix → PR/MR body refs → commit-message refs/trailers.
- **Status transitions**: forward-only; commit → `in-progress` (only issues already labeled `planned`), PR → `needs-review`. `done` is owned by the merge path (out of scope).
- **Coverage boundary** (documented): PR creation via the web UI or raw `gh`/`glab` outside a tool isn't auto-observed — run `issue_support.sh sync-pr` manually there.

## Enable

```bash
configs/claude/scripts/install_issue_hooks.sh --enable [--native]   # opt-in; default off
```

## Testing

- **bats 53/53** — `issue_support.bats` (13), `install_issue_hooks.bats` (13, incl. H1–H5 + bug regressions), `git_ops.bats` (27, incl. `pr-edit` + GitLab label translation), `help_coverage` (3).
- shellcheck + yamllint clean; FR-010 label conformance verified.
- **Tier 1 cross-verification** (constitution II): Claude Sonnet + Gemini independently reviewed the engine.
- **Cloud ultrareview** surfaced 4 real bugs (GitLab label flags, dispatcher false-positives, sibling-hook deletion on remove, native-hook re-enable) — all fixed with regression tests in this PR.

## Constitution

PASS — config-as-code, skill-first (engine is a sibling ops script), idempotent/guarded hook install. No complexity-tracking violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
