### PR TITLE
🛠️ Forge: Explicitly route JS catch block errors in OpenCode plugin templates

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,11 +1,35 @@
 ## 2025-06-10 - ai-hooks-integration
-**Learning:** `merge_hooks.py` completely dropped the `--command` parameter for `opencode` tools, meaning OpenCode plugins were generated without any actual hooked logic. This occurred because OpenCode generated a template string instead of parsing JSON, bypassing the core command injection logic.
-**Action:** Always verify that CLI parameters are not conditionally bypassed for newer or alternative runtime tools. For templates targeting Node/JS runtimes, ensure we inject the command dynamically via format strings and execute it gracefully with robust `try/catch` wrappers.
+
+**Learning:** `merge_hooks.py` completely dropped the `--command` parameter for `opencode` tools, meaning OpenCode
+plugins were generated without any actual hooked logic. This occurred because OpenCode generated a template string
+instead of parsing JSON, bypassing the core command injection logic.
+**Action:** Always verify that CLI parameters are not conditionally bypassed for newer or alternative runtime tools. For
+templates targeting Node/JS runtimes, ensure we inject the command dynamically via format strings and execute it
+gracefully with robust `try/catch` wrappers.
 
 ## 2026-06-07 - issue-triage
-**Learning:** Python scripts often format output as shell variable assignments intended to be sourced. Executing this output dynamically via `eval` introduces command injection risks in bash scripts if the python code or input files are altered.
-**Action:** Configure automated checks to flag `eval "$(..."` or `eval \`...\`` patterns, especially those consuming output from other commands. Use a `while IFS=` loop combined with a `case` whitelist to securely parse key-value configuration directly into the shell environment without dynamic evaluation.
+
+**Learning:** Python scripts often format output as shell variable assignments intended to be sourced. Executing this
+output dynamically via `eval` introduces command injection risks in bash scripts if the python code or input files are
+altered.
+**Action:** Configure automated checks to flag `eval "$(..."` or `eval \`...\`` patterns, especially those consuming
+output from other commands. Use a `while IFS=` loop combined with a `case` whitelist to securely parse key-value
+configuration directly into the shell environment without dynamic evaluation.
 
 ## 2026-06-12 - command-injection-eval
-**Learning:** Hardcoding string replacements based on expected dynamic output (like `brew shellenv`) introduces brittleness and is unsafe under `set -u` contexts. Variables like `MANPATH` may be unbound, causing a script crash.
-**Action:** Prefer native bash process substitution (e.g. `source <(cmd)`) over manual string parsing or `eval "$(cmd)"` when integrating system environment configs: it avoids brittle parsing/double-evaluation and `set -u` unbound-variable crashes. Note `source <(cmd)` still executes whatever `cmd` outputs — the trust boundary is the same as `eval`, so only use it with trusted producers.
+
+**Learning:** Hardcoding string replacements based on expected dynamic output (like `brew shellenv`) introduces
+brittleness and is unsafe under `set -u` contexts. Variables like `MANPATH` may be unbound, causing a script crash.
+**Action:** Prefer native bash process substitution (e.g. `source <(cmd)`) over manual string parsing or `eval "$(cmd)"`
+when integrating system environment configs: it avoids brittle parsing/double-evaluation and `set -u` unbound-variable
+crashes. Note `source <(cmd)` still executes whatever `cmd` outputs — the trust boundary is the same as `eval`, so only
+use it with trusted producers.
+
+## 2026-06-14 - ai-hooks-integration
+
+**Learning:** Empty JavaScript optional catch bindings (like `catch { ... }`) silently swallow exceptions during hook
+execution. This obscures critical failures (like WebSocket initialization or event delivery) in generated plugins and
+violates our explicit routing and graceful degradation constraints.
+**Action:** Configure automated checks to flag empty or bindingless `catch` blocks in generated JavaScript templates.
+Ensure all catch statements explicitly capture the error object (e.g. `catch (e) { ... }`) and either log the error
+message or correctly fallback/propagate it.

--- a/.skillshare/skills/ai-hooks-integration/scripts/install_opencode_plugin.py
+++ b/.skillshare/skills/ai-hooks-integration/scripts/install_opencode_plugin.py
@@ -78,8 +78,8 @@ async function sendEvent(eventType, payload) {{
 
       ws.on("error", () => {{ clearTimeout(timeout); resolve(); }});
     }});
-  }} catch {{
-    // Silent fail if ws module not available
+  }} catch (e) {{
+    console.error("WebSocket init failed:", e.message);
   }}
 }}
 
@@ -187,7 +187,8 @@ async function sendHttp(event) {{
       signal: AbortSignal.timeout(1000),
     }});
     return response.ok;
-  }} catch {{
+  }} catch (e) {{
+    console.error("HTTP send failed:", e.message);
     return false;
   }}
 }}
@@ -200,7 +201,9 @@ async function sendWs(event) {{
         ws.send(JSON.stringify(event));
         resolve(true);
         return;
-      }} catch {{}}
+      }} catch (e) {{
+        console.error("WebSocket send failed:", e.message);
+      }}
     }}
 
     // Try to connect
@@ -231,7 +234,8 @@ async function sendWs(event) {{
         ws = null;
         resolve(false);
       }});
-    }} catch {{
+    }} catch (e) {{
+      console.error("WebSocket connect failed:", e.message);
       resolve(false);
     }}
   }});


### PR DESCRIPTION
🛠️ Forge: Replace empty catch bindings in generated JS to prevent swallowed errors

💡 What:
Replaced empty `catch {}` and `catch` blocks in `install_opencode_plugin.py` JS templates with explicit `catch (e) { console.error(...); }`.

🎯 Why:
Empty JS optional catch bindings silently swallow exceptions during hook execution. This obscures critical failures (like WebSocket initialization or event delivery) in generated OpenCode plugins, which violates our observability constraints and prevents graceful error routing.

🔒 Safety & Impact:
Added `console.error` logs without altering the existing fallback/degradation behavior (e.g. still returning `false` or resolving on error). All 70 Python tests pass and journal entry added strictly adhering to markdown constraints.

---
*PR created automatically by Jules for task [2312330794195257386](https://jules.google.com/task/2312330794195257386) started by @RB-chrismandich*