### PR TITLE
feat: Jules bot trigger workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners — require owner review for security-sensitive automation.
+# Pairs with branch protection on `main` ("Require review from Code Owners"):
+# changes to these paths cannot be merged without @RB-chrismandich's approval.
+
+# All CI/CD and trigger workflows — includes the Jules trigger gate
+# (.github/workflows/jules-trigger.yml). The gate's author_association check is
+# the security boundary; it must not be weakened without owner review.
+/.github/workflows/   @RB-chrismandich
+
+# The ownership rules themselves must not change without owner review.
+/.github/CODEOWNERS   @RB-chrismandich

--- a/.github/workflows/jules-trigger.yml
+++ b/.github/workflows/jules-trigger.yml
@@ -1,0 +1,79 @@
+name: Jules Trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: jules-${{ github.event.issue.number }}
+  cancel-in-progress: false  # let an in-flight Jules run finish; new invocations queue
+
+jobs:
+  invoke:
+    # Security boundary: only a deliberate mention from a trusted, non-bot
+    # commenter ever reaches the JULES_API_KEY step. issue_comment runs with the
+    # base repo's secrets even for fork PRs, so author_association (set server-side
+    # by GitHub, not spoofable) is what blocks outside contributors (CONTRIBUTOR/
+    # NONE). A non-Bot machine account held by a trusted collaborator is within
+    # this boundary by design.
+    if: >-
+      contains(github.event.comment.body, '@google-labs-jules') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR') &&
+      github.event.comment.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge with reaction
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Resolve start branch
+        id: branch
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            let ref = 'main';
+            if (context.payload.issue.pull_request) {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number,
+              });
+              ref = pr.data.head.ref;
+            }
+            core.setOutput('ref', ref);
+
+      - name: Invoke Jules
+        uses: google-labs-code/jules-action@bff7875eaa123cac6742b7cfc51005b95ba4d566  # v1.0.0
+        with:
+          # Raw comment body; jules-action declares this input type:string and does
+          # not re-evaluate it. Quoted to signal it is a deliberate string input.
+          prompt: "${{ github.event.comment.body }}"
+          jules_api_key: ${{ secrets.JULES_API_KEY }}
+          starting_branch: ${{ steps.branch.outputs.ref }}
+
+      - name: Report failure
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `⚠️ The Jules trigger workflow failed — see the [workflow run](${runUrl}).`,
+            });

--- a/.github/workflows/jules-trigger.yml
+++ b/.github/workflows/jules-trigger.yml
@@ -15,12 +15,11 @@ concurrency:
 
 jobs:
   invoke:
-    # Security boundary: only a deliberate mention from a trusted, non-bot
-    # commenter ever reaches the JULES_API_KEY step. issue_comment runs with the
-    # base repo's secrets even for fork PRs, so author_association (set server-side
-    # by GitHub, not spoofable) is what blocks outside contributors (CONTRIBUTOR/
-    # NONE). A non-Bot machine account held by a trusted collaborator is within
-    # this boundary by design.
+    # Cheap pre-filter only — NOT the security boundary. author_association is
+    # set server-side (not spoofable) but is NOT a write-access check: it admits
+    # read-only/triage collaborators and read-only org members. The real gate is
+    # the "Verify commenter has write access" step below, which fails closed; the
+    # `if:` just avoids spinning up the job for unrelated comments.
     if: >-
       contains(github.event.comment.body, '@google-labs-jules') &&
       (github.event.comment.author_association == 'OWNER' ||
@@ -29,6 +28,29 @@ jobs:
       github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
+      - name: Verify commenter has write access
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          # Security boundary: only collaborators with write/admin permission may
+          # reach the JULES_API_KEY step. Fail closed on a lower level or any API
+          # error. (Public repo: the default GITHUB_TOKEN can read this.)
+          script: |
+            let level = 'none';
+            try {
+              const res = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.payload.comment.user.login,
+              });
+              level = res.data.permission;
+            } catch (e) {
+              core.setFailed(`Cannot verify permission for ${context.payload.comment.user.login}: ${e.message}`);
+              return;
+            }
+            if (level !== 'admin' && level !== 'write') {
+              core.setFailed(`${context.payload.comment.user.login} lacks write access (permission: ${level}); refusing to invoke Jules.`);
+            }
+
       - name: Acknowledge with reaction
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
@@ -52,7 +74,17 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: context.payload.issue.number,
               });
-              ref = pr.data.head.ref;
+              const head = pr.data.head.ref;
+              // Defense-in-depth: jules-action templates starting_branch into a
+              // shell line (jq --arg starting_branch ...). A fork PR's head ref is
+              // attacker-controlled and git refs allow shell metacharacters
+              // ($ backtick ; | ( )), so reject anything outside a strict
+              // allowlist instead of passing it through.
+              if (!/^[A-Za-z0-9._\/-]+$/.test(head)) {
+                core.setFailed(`Refusing unsafe branch name: ${head}`);
+                return;
+              }
+              ref = head;
             }
             core.setOutput('ref', ref);
 

--- a/docs/superpowers/plans/2026-06-14-jules-trigger-workflow.md
+++ b/docs/superpowers/plans/2026-06-14-jules-trigger-workflow.md
@@ -1,0 +1,354 @@
+# Jules Trigger Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GitHub Actions workflow that invokes Google Jules when a trusted user mentions `@google-labs-jules` in an issue/PR comment.
+
+**Architecture:** One workflow file, one job. A job-level `if:` gate (mention + `author_association` OWNER/MEMBER/COLLABORATOR + not-a-bot) is the security boundary. Steps run sequentially: react 👀 → resolve start branch (PR head, else `main`) → invoke the SHA-pinned Jules action → comment on failure.
+
+**Tech Stack:** GitHub Actions; `actions/github-script` (v9.0.0) for the GitHub API calls; `google-labs-code/jules-action` (v1.0.0) for the invocation. Static validation via `actionlint`.
+
+**Design doc:** `docs/superpowers/specs/2026-06-14-jules-trigger-workflow-design.md`
+**Branch:** `feat/jules-trigger-workflow`
+
+---
+
+## File Structure
+
+- **Create:** `.github/workflows/jules-trigger.yml` — the entire feature. One job, four steps, gated by `author_association`.
+
+There is no application code to test in isolation: a GitHub workflow is verified by **static analysis** (`actionlint`, which checks YAML, `if:` expression syntax, and `uses:` refs) plus a **live trigger** the owner runs once. Each task below adds one valid, committable slice and validates it with `actionlint`.
+
+## Pinned references (already resolved — use verbatim)
+
+| Action | Pinned ref |
+|--------|-----------|
+| `actions/github-script` | `actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0` |
+| `google-labs-code/jules-action` | `google-labs-code/jules-action@bff7875eaa123cac6742b7cfc51005b95ba4d566  # v1.0.0` |
+
+Jules action inputs (from its `action.yml`): `prompt` (required), `jules_api_key` (required), `starting_branch` (optional, default `main`).
+
+## Prerequisite: install actionlint (one-time)
+
+- [ ] **Step 0: Install actionlint**
+
+Run: `brew install actionlint`
+Expected: actionlint installed (or "already installed"). Verify: `actionlint --version` prints a version.
+
+---
+
+## Task 1: Scaffold the workflow — triggers, permissions, gate, and the 👀 step
+
+**Files:**
+- Create: `.github/workflows/jules-trigger.yml`
+
+- [ ] **Step 1: Write the complete scaffold file**
+
+Create `.github/workflows/jules-trigger.yml` with exactly this content (a valid workflow that gates and reacts, nothing else yet):
+
+```yaml
+name: Jules Trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: jules-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  invoke:
+    # Security boundary (design §Security model): only a deliberate mention from
+    # a trusted, non-bot commenter ever reaches the JULES_API_KEY step. issue_comment
+    # runs with the base repo's secrets even for fork PRs, so author_association is
+    # what blocks outside contributors (CONTRIBUTOR/NONE).
+    if: >-
+      contains(github.event.comment.body, '@google-labs-jules') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR') &&
+      github.event.comment.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge with reaction
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+```
+
+- [ ] **Step 2: Validate with actionlint**
+
+Run: `actionlint .github/workflows/jules-trigger.yml`
+Expected: no output, exit code 0 (no errors). If actionlint reports expression or `uses:` errors, fix them before continuing.
+
+- [ ] **Step 3: Confirm the gate has all three conditions**
+
+Run: `grep -E "author_association|user.type|google-labs-jules" .github/workflows/jules-trigger.yml`
+Expected: lines showing the mention check, the three `author_association` comparisons, and the `user.type != 'Bot'` check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/jules-trigger.yml
+git commit -m "feat(jules-trigger): scaffold gated workflow with reaction step"
+```
+
+---
+
+## Task 2: Resolve the start branch (PR head, else main)
+
+**Files:**
+- Modify: `.github/workflows/jules-trigger.yml` (add a step after "Acknowledge with reaction")
+
+- [ ] **Step 1: Add the resolve-branch step**
+
+Insert this step immediately **after** the `Acknowledge with reaction` step (same `steps:` list, same indentation):
+
+```yaml
+      - name: Resolve start branch
+        id: branch
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            let ref = 'main';
+            if (context.payload.issue.pull_request) {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number,
+              });
+              ref = pr.data.head.ref;
+            }
+            core.setOutput('ref', ref);
+```
+
+- [ ] **Step 2: Validate with actionlint**
+
+Run: `actionlint .github/workflows/jules-trigger.yml`
+Expected: no output, exit code 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/jules-trigger.yml
+git commit -m "feat(jules-trigger): resolve PR head branch (else main)"
+```
+
+---
+
+## Task 3: Invoke Jules
+
+**Files:**
+- Modify: `.github/workflows/jules-trigger.yml` (add a step after "Resolve start branch")
+
+- [ ] **Step 1: Add the invoke step**
+
+Insert this step immediately **after** the `Resolve start branch` step:
+
+```yaml
+      - name: Invoke Jules
+        uses: google-labs-code/jules-action@bff7875eaa123cac6742b7cfc51005b95ba4d566  # v1.0.0
+        with:
+          prompt: ${{ github.event.comment.body }}
+          jules_api_key: ${{ secrets.JULES_API_KEY }}
+          starting_branch: ${{ steps.branch.outputs.ref }}
+```
+
+- [ ] **Step 2: Validate with actionlint**
+
+Run: `actionlint .github/workflows/jules-trigger.yml`
+Expected: no output, exit code 0. (actionlint will not flag the missing secret — that is a runtime/repo-settings concern, covered in Task 5.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/jules-trigger.yml
+git commit -m "feat(jules-trigger): invoke Jules with resolved branch"
+```
+
+---
+
+## Task 4: Comment on failure
+
+**Files:**
+- Modify: `.github/workflows/jules-trigger.yml` (add a step after "Invoke Jules")
+
+- [ ] **Step 1: Add the failure-report step**
+
+Insert this step immediately **after** the `Invoke Jules` step (it runs only if a prior step failed):
+
+```yaml
+      - name: Report failure
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `⚠️ Jules invocation failed — see the [workflow run](${runUrl}).`,
+            });
+```
+
+- [ ] **Step 2: Validate with actionlint**
+
+Run: `actionlint .github/workflows/jules-trigger.yml`
+Expected: no output, exit code 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/jules-trigger.yml
+git commit -m "feat(jules-trigger): post a comment when invocation fails"
+```
+
+---
+
+## Task 5: Final verification + owner prerequisites
+
+**Files:**
+- Reference only: `.github/workflows/jules-trigger.yml` (no further edits expected)
+
+The complete file should now read exactly:
+
+```yaml
+name: Jules Trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: jules-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  invoke:
+    if: >-
+      contains(github.event.comment.body, '@google-labs-jules') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR') &&
+      github.event.comment.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge with reaction
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Resolve start branch
+        id: branch
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            let ref = 'main';
+            if (context.payload.issue.pull_request) {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number,
+              });
+              ref = pr.data.head.ref;
+            }
+            core.setOutput('ref', ref);
+
+      - name: Invoke Jules
+        uses: google-labs-code/jules-action@bff7875eaa123cac6742b7cfc51005b95ba4d566  # v1.0.0
+        with:
+          prompt: ${{ github.event.comment.body }}
+          jules_api_key: ${{ secrets.JULES_API_KEY }}
+          starting_branch: ${{ steps.branch.outputs.ref }}
+
+      - name: Report failure
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `⚠️ Jules invocation failed — see the [workflow run](${runUrl}).`,
+            });
+```
+
+- [ ] **Step 1: Final actionlint pass**
+
+Run: `actionlint .github/workflows/jules-trigger.yml`
+Expected: no output, exit code 0.
+
+- [ ] **Step 2: Confirm all `uses:` are SHA-pinned (repo convention)**
+
+Run: `grep -E "uses:" .github/workflows/jules-trigger.yml`
+Expected: every `uses:` ends in a 40-char SHA with a `# vN` comment — no floating `@v1`/`@main` tags.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feat/jules-trigger-workflow
+```
+
+Expected: branch pushed. GitHub validates workflow syntax on push; check the repo's Actions tab shows no "invalid workflow file" error for `jules-trigger.yml`.
+
+- [ ] **Step 4: Owner prerequisite — add the `JULES_API_KEY` secret**
+
+This is a manual repo-settings action (cannot be scripted in the workflow):
+1. Get a Jules API key from https://jules.google (account settings / API).
+2. Repo → Settings → Secrets and variables → Actions → New repository secret.
+3. Name: `JULES_API_KEY`, value: the key. Save.
+
+Until this secret exists, the `Invoke Jules` step fails and the `Report failure` step posts the failure comment — which is the designed behavior.
+
+- [ ] **Step 5: Live trigger test (owner)**
+
+After the workflow is on the default branch (merge the PR, since `issue_comment` workflows run from the **default branch's** copy, not the PR branch):
+1. On any open PR, comment: `@google-labs-jules please review this PR`.
+2. Expect: a 👀 reaction appears on your comment within ~1 min, and a Jules session starts against that PR's head branch.
+3. Negative check: confirm a comment **without** the mention, or from a non-collaborator, does **not** start a run (Actions tab shows no triggered run).
+
+> **Important runtime note:** GitHub runs `issue_comment` workflows from the workflow file on the **repository default branch**, not from the PR's branch. So this workflow only takes effect once it is merged to `main`. Testing the trigger before merge will not run the new workflow.
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- Gate (mention + association + not-bot) → Task 1 `if:`. ✓
+- PR-aware start branch → Task 2. ✓
+- Invoke Jules (pinned, correct inputs) → Task 3. ✓
+- 👀 reaction → Task 1; failure comment → Task 4. ✓
+- Least-privilege permissions, concurrency, SHA-pinning → Task 1 scaffold + Task 5 Step 2. ✓
+- `JULES_API_KEY` prerequisite → Task 5 Step 4. ✓
+- Testing strategy (actionlint static + live trigger) → every task's validate step + Task 5 Step 5. ✓
+- Default-branch runtime caveat → Task 5 note (catches the "tested on PR branch, nothing happened" trap). ✓
+
+**Placeholder scan:** No TBD/TODO; all SHAs and inputs are concrete and verified. ✓
+
+**Type/name consistency:** Step output `steps.branch.outputs.ref` (set via `core.setOutput('ref', …)` in Task 2) is consumed as `${{ steps.branch.outputs.ref }}` in Task 3. Action SHAs identical across all tasks. ✓

--- a/docs/superpowers/specs/2026-06-14-jules-trigger-workflow-design.md
+++ b/docs/superpowers/specs/2026-06-14-jules-trigger-workflow-design.md
@@ -1,0 +1,140 @@
+# Design: Jules Bot Trigger Workflow
+
+**Date**: 2026-06-14
+**Status**: Approved (design) — pending implementation plan
+**Author**: Brainstormed via `/superpowers:brainstorming`
+
+## Problem
+
+Google Jules is a remote coding agent integrated with this repo (it opens PRs
+via personas — Forge, Bolt, Palette, Sentinel). But it is **not a GitHub-native
+reviewer**: requesting it as a PR reviewer or assignee is silently ignored, and a
+plain `@google-labs-jules` mention does nothing because no automation acts on it.
+The only reliable trigger today is launching a session from jules.google by hand.
+
+We want a mention on a PR (or issue) — e.g. "@google-labs-jules please review
+this PR" — to **actually invoke Jules**, scoped safely to trusted users.
+
+## Goal
+
+A GitHub Actions workflow that, when a **trusted** user posts a comment
+mentioning `@google-labs-jules`, invokes the Google Jules action against the
+right branch and gives visible feedback.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| **Trigger gate** | `author_association ∈ {OWNER, MEMBER, COLLABORATOR}` | GitHub-set, not spoofable, zero hardcoded usernames, auto-correct as the team changes. Fork/outside authors are `CONTRIBUTOR`/`NONE` → blocked. |
+| **Start branch** | PR-aware: PR head if the comment is on a PR, else `main` | Lets Jules iterate on the branch of the PR you mentioned it from. |
+| **Feedback** | 👀 reaction on receipt + comment on failure | Lightweight "received" signal; failures surface without digging the Actions tab. |
+| **Structure** | Single workflow, single job, sequential steps | Smallest thing that satisfies the above; matches the repo's single-file `ci.yml` style. |
+
+## Architecture
+
+One file: `.github/workflows/jules-trigger.yml`. One job, `invoke`.
+
+```
+issue_comment:[created]
+        │
+        ▼
+   job if: gate ──(fails)──▶ no run
+   (mention AND trusted AND not-a-bot)
+        │ (passes)
+        ▼
+   ① 👀 react to the comment
+        ▼
+   ② resolve start branch (PR head ‖ main)
+        ▼
+   ③ invoke Jules (pinned action)
+        ▼
+   ④ if failure() → comment linking the run
+```
+
+`issue_comment` fires for **both** issues and PRs (PRs are issues in GitHub's
+model); `types: [created]` means edits do not retrigger.
+
+## Security model
+
+The job-level `if:` is the security boundary. It requires **all** of:
+
+1. `contains(github.event.comment.body, '@google-labs-jules')` — a deliberate mention.
+2. `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR` — write-access trust.
+3. `github.event.comment.user.type != 'Bot'` — prevents a bot's own comment
+   (e.g. one that quotes the mention) from self-triggering a loop.
+
+**Why this matters:** `issue_comment` workflows run in the **base repo's**
+context with its secrets, even for comments on fork PRs. The `author_association`
+gate is what stops an outside contributor from ever reaching the `JULES_API_KEY`
+step. Without it, anyone who can comment could task an autonomous agent that has
+repository write access.
+
+**Least-privilege permissions:**
+
+```yaml
+permissions:
+  contents: read          # default
+  pull-requests: read     # resolve the PR head ref
+  issues: write           # 👀 reaction + failure comment (PR comments are issues)
+```
+
+## Components (steps)
+
+1. **Acknowledge** — `actions/github-script` (SHA-pinned):
+   `reactions.createForIssueComment(..., content: 'eyes')`.
+2. **Resolve start branch** — `actions/github-script` (SHA-pinned), `id: branch`:
+   if `context.payload.issue.pull_request` is set → `pulls.get(...).data.head.ref`;
+   else `main`. Exposed as `steps.branch.outputs.ref`.
+3. **Invoke Jules** — the Google Jules action (**exact path verified + SHA-pinned
+   at implementation time**; examples reference `google-labs-code/jules-invoke@v1`
+   while the source repo may be `…/jules-action`):
+   - `prompt: ${{ github.event.comment.body }}` (raw comment; mention-stripping is
+     deliberately out of scope)
+   - `jules_api_key: ${{ secrets.JULES_API_KEY }}`
+   - `starting_branch: ${{ steps.branch.outputs.ref }}`
+4. **Report failure** — `if: failure()`, `actions/github-script` (SHA-pinned):
+   `issues.createComment` linking `…/actions/runs/<runId>`.
+
+## Repo conventions to honor
+
+- **SHA-pin every action** with a `# vN` trailing comment (repo rule; see
+  `ci.yml`). Floating `@v1` tags are not used here.
+- **Explicit `permissions:`** block (every existing workflow has one).
+- **`concurrency`**: `group: jules-${{ github.event.issue.number }}`,
+  `cancel-in-progress: false` — never cancel an in-flight Jules invocation when a
+  second comment arrives.
+
+## Prerequisites (owner action, outside this workflow)
+
+- Add the **`JULES_API_KEY`** repository secret (Settings → Secrets and variables
+  → Actions). The workflow cannot run end-to-end without it; until then step ③
+  fails and step ④ posts the failure comment.
+
+## Error handling & edge cases
+
+- **Missing secret / action error** → step ③ fails → step ④ posts a failure
+  comment linking the run (Q3 behavior). Reaction from step ① already landed.
+- **Comment on a plain issue** (not a PR) → `starting_branch = main`.
+- **Untrusted / fork / bot commenter** → job `if:` is false → no run, no secret
+  exposure.
+- **Edited comment** → no retrigger (`types: [created]`).
+- **Mention inside a code block / quote by a trusted user** → would still trigger;
+  accepted risk, since the commenter is already trusted.
+
+## Testing strategy
+
+- **Static**: validate workflow YAML (`yamllint`, and `actionlint` if available)
+  — syntax, the `if:` expression, and pinned `uses:` refs.
+- **Gate reasoning**: a comment from a non-collaborator or a bot does not satisfy
+  the `if:`; documented as the security assertion (cannot be unit-tested without a
+  second account).
+- **Live**: the owner adds `JULES_API_KEY`, comments `@google-labs-jules …` on a
+  PR, and confirms 👀 + a Jules session on the PR's branch. Failure path confirmed
+  by triggering before the secret exists (expect the failure comment).
+
+## Out of scope (YAGNI)
+
+- Stripping the `@google-labs-jules` mention from the prompt.
+- Multi-job split (gate-and-resolve → invoke) or a reusable composite action.
+- Adding `actionlint` to the CI pipeline.
+- Explicit username allowlist (superseded by `author_association`).


### PR DESCRIPTION
## Summary

Adds `.github/workflows/jules-trigger.yml` — when a **trusted** user mentions `@google-labs-jules` in an issue/PR comment, it invokes the Google Jules coding agent. This makes the mention actually do something (Jules isn't a GitHub-native reviewer; reviewer/assignee requests for it are silently ignored).

- **Security gate** (job-level `if:`): comment mentions `@google-labs-jules` **AND** `author_association ∈ {OWNER, MEMBER, COLLABORATOR}` **AND** `user.type != 'Bot'`. Because `issue_comment` runs with the base repo's secrets even for fork PRs, `author_association` (server-side, not spoofable) is the boundary keeping outside contributors away from `JULES_API_KEY`.
- **PR-aware**: resolves the PR head branch when commented on a PR, else `main`.
- **Feedback**: 👀 reaction on receipt; a comment on failure linking the run.
- **Conventions**: SHA-pinned actions (`github-script` v9.0.0, `jules-action` v1.0.0), least-privilege `permissions`, `concurrency` that queues rather than cancels in-flight runs.

Brainstormed + planned under `docs/superpowers/specs/` and `docs/superpowers/plans/` (both included). Spec-compliant + quality-approved via subagent review; `actionlint` clean.

## Owner prerequisites (required before it works)

- [ ] Add the **`JULES_API_KEY`** repository secret (Settings → Secrets and variables → Actions).
- [ ] **Merge to `main`** — `issue_comment` workflows run from the default branch's copy, so the trigger has no effect until merged.

## Test Plan

- [x] `actionlint .github/workflows/jules-trigger.yml` — clean
- [x] YAML parses; all `uses:` SHA-pinned with `# vN`
- [ ] After merge + secret: comment `@google-labs-jules please review this PR` on an open PR → expect a 👀 reaction and a Jules session on that PR's branch
- [ ] Negative: a comment without the mention, or from a non-collaborator, triggers no run

🤖 Generated with [Claude Code](https://claude.com/claude-code)