### PR TITLE
feat: repo-hygiene sweep skill (PR + branch cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ records/
 
 # spec-review runtime (feedback, content-hash, lock, error log)
 .spec-review/
+
+# skill-creator eval workspaces (iteration outputs, benchmarks, rework runs)
+*-workspace/

--- a/.skillshare/skills/repo-hygiene/SKILL.md
+++ b/.skillshare/skills/repo-hygiene/SKILL.md
@@ -1,15 +1,21 @@
 ---
 name: repo-hygiene
-description: >-
-  Run a full repository hygiene sweep over open PRs/MRs and git branches in one
-  pass. Produces a sectioned report (ready-to-merge, needs-work,
-  stale/closeable, keep) with a recommended next step per item, then — after you
-  confirm — closes stale PRs and prunes stale branches. Composes the pr-review
-  and branch-clean skills and works across GitHub, GitLab, and local. Use this
-  whenever the user wants to "review open PRs", "clean up branches", "close
-  stale PRs/branches", "PR/branch hygiene", "tidy up the repo", "what's the
-  state of my PRs", or asks for any overview-plus-cleanup of the PR queue or
-  branch list — even if they don't say the word "hygiene".
+description: |
+  Use when one request covers BOTH pull/merge requests AND git branches — or
+  asks to actually close/delete the dead ones, not just list them. This is the
+  combined cleanup pass: it reviews every open PR/MR and every stale/merged/gone
+  branch together, sorts them, and after you confirm, closes the stale PRs and
+  prunes the branches in a single sweep across GitHub, GitLab, and local.
+
+  Reach for this on any "tidy up my repo" intent that spans the merge queue and
+  the branch list at once — e.g. cluttered after a batch of merges, a pile of old
+  MRs plus dozens of stale branches, "which PRs to merge vs close then prune the
+  branches behind them", "go through my PRs and close the dead ones and clean up
+  merged/gone branches locally and on github".
+
+  Pick this over pr-review (PRs only, no closing) or branch-clean (branches
+  only) whenever the ask touches both, or wants items closed/deleted rather than
+  only reported.
 ---
 
 # Repository Hygiene Sweep

--- a/.skillshare/skills/repo-hygiene/SKILL.md
+++ b/.skillshare/skills/repo-hygiene/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: repo-hygiene
+description: >-
+  Run a full repository hygiene sweep over open PRs/MRs and git branches in one
+  pass. Produces a sectioned report (ready-to-merge, needs-work,
+  stale/closeable, keep) with a recommended next step per item, then — after you
+  confirm — closes stale PRs and prunes stale branches. Composes the pr-review
+  and branch-clean skills and works across GitHub, GitLab, and local. Use this
+  whenever the user wants to "review open PRs", "clean up branches", "close
+  stale PRs/branches", "PR/branch hygiene", "tidy up the repo", "what's the
+  state of my PRs", or asks for any overview-plus-cleanup of the PR queue or
+  branch list — even if they don't say the word "hygiene".
+---
+
+# Repository Hygiene Sweep
+
+Give the user a single, organized picture of everything outstanding — every open
+PR/MR and every prunable branch — with a concrete next step for each, then act
+on the stale items once they confirm.
+
+This skill is an **orchestrator**. It does not reimplement PR or branch logic;
+it composes two existing, hardened skills:
+
+- `pr-review` → `~/.claude/scripts/pr_review.sh` (platform detection, CI rollup,
+  mergeability, per-PR disposition). Analysis-only.
+- `branch-clean` → `~/.claude/scripts/branch_clean.sh` (merged / `[gone]` /
+  stale grouping, protected-glob and current-branch guards). Dry-run by default.
+
+Reusing them means this skill inherits their safety rails and stays correct when
+they improve — don't duplicate their internals here.
+
+## When to use
+
+- The user wants an overview of the PR queue *and* a cleanup pass in one go.
+- "Review my open PRs and close the stale ones."
+- "Clean up old branches locally and on GitHub/GitLab."
+- Periodic repo tidy-up after a batch of merges.
+
+## Operating principle: report first, act on confirmation
+
+The default flow is **gather → report → confirm → act**. Nothing is closed or
+deleted until the user has seen the candidates and said go (or passed `--apply`).
+This mirrors the repo convention that destructive, outward-facing actions are
+reversible-friendly and explicitly authorized. Closing a PR and deleting a
+branch are hard to take back, so the friction is deliberate.
+
+## Workflow
+
+### 1. Gather (read-only)
+
+Run three read-only sources and capture their output. None mutates anything.
+
+```bash
+# (a) Per-PR disposition: mergeability, checks, staleness, superseded
+~/.claude/scripts/pr_review.sh --json            # add --stale-days N to tune
+
+# (b) Conservative branch candidates (merged-by-fast-forward / [gone] / stale-by-date)
+~/.claude/scripts/branch_clean.sh                # dry-run; add --stale-days N
+
+# (c) Squash-merge-aware enrichment the other two can't provide:
+#     open-PR diff sizes (empty-PR detection) + branch<->PR-state correlation
+python3 "<this-skill-dir>/scripts/hygiene_gather.py"   # --platform / --stale-days N / --protect glob
+```
+
+**Why (c) is not optional.** Two real gaps make the first two sources lie on a
+normal repo:
+
+- `pr_review.sh` has no changes-count, and a zero-diff PR produces no checks, so
+  its disposition defaults to `merge`. An **empty no-op PR therefore looks
+  mergeable.** `hygiene_gather.py` reports `empty_prs` (PRs with 0 changed
+  files) — treat any of those as **closeable**, overriding the `merge`
+  disposition.
+- `branch_clean.sh` finds merged branches via `git branch --merged`, which only
+  sees fast-forward ancestry. On a **squash-merge repo the merged branch's tip
+  is never an ancestor of the default branch**, so it reports almost nothing and
+  the real clutter (often dozens of branches) stays hidden. `hygiene_gather.py`
+  correlates each local/remote branch to its PR/MR merge-state and classifies it
+  (see step 2), which is what surfaces the actual cleanup.
+
+Use a consistent staleness window across all three (default to the repo's
+configured value; if the user names a number, pass the same `--stale-days N` to
+each). Detect the platform with `~/.claude/scripts/git_platform.sh` if you need
+to name it (github / gitlab / git).
+
+Handle the distinct failure modes: an **empty queue / no candidates** is a clean
+result; an **unauthenticated or missing CLI** is *not* — `hygiene_gather.py`
+reports those in its `errors` array. Surface them as "couldn't look", never as
+"all clean", because a silent auth failure would otherwise read as a tidy repo.
+GitLab note: `hygiene_gather.py` correlates MR state but cannot size MRs for
+empty-detection (glab's list has no changes count) — it flags this, and you can
+spot-check a suspected no-op with `glab mr diff <iid>`.
+
+### 2. Report — break everything into sections
+
+Synthesize both outputs into one report. The grouping and the per-item next step
+are the value the user is asking for, so do this thoughtfully rather than dumping
+raw script output. Use this structure:
+
+```markdown
+# Repo Hygiene — <repo> (<platform>)
+_<date> · stale threshold: <N>d_
+
+## Open PRs/MRs (<total>)
+
+### ✅ Ready to merge (<n>)
+- **#<num>** <title> — `<branch>` · checks ✓ · <age>
+  → Next: merge — `~/.claude/scripts/git_ops.sh pr-merge <num>`
+
+### 🔧 Needs work (<n>)
+- **#<num>** <title> — <conflict / failing checks / draft-with-activity>
+  → Next: <rebase | fix CI | finish draft>
+
+### 🗑️ Stale / closeable (<n>)
+- **#<num>** <title> — <reason: EMPTY no-op (0 files / +0/-0) | branch already merged | superseded by #X | >Nd no activity>
+  → Next: close
+
+### 🟢 Keep (<n>)
+- **#<num>** <title> — <active draft / pending checks / ongoing>
+
+## Branches
+
+Classified by PR/MR merge-state (from `hygiene_gather.py`), not just ancestry —
+so squash-merged branches show up as safe. Split into **safe** (auto-deletable on
+confirm) vs **confirm-individually** (may hold unmerged work).
+
+### ✅ Safe to delete (<n>)  — local
+- `<branch>` — merged via #<num> (squash) | merged (fast-forward) | `[gone]` (remote deleted)
+
+### ⚠️ Confirm individually (<n>)
+- `<branch>` — closed-unmerged (PR #<num> closed without merging) | no PR + stale >Nd
+  → may contain real work; never auto-delete — confirm each.
+
+### 🌐 Remote (origin) (<n>)
+- safe: `<branch>` (merged via #<num>) · confirm: `<branch>` (closed-unmerged / no-PR)
+  → remote deletion is opt-in (`--include-remote` / explicit request) even when safe.
+
+### 🟢 Keep
+- local with an open PR or recent unmerged work; remote backing an open PR.
+
+### 🔒 Protected / current — never deleted: <list>
+
+## Recommended actions
+1. **Close stale PRs:** #<a>, #<b>
+2. **Prune branches:** `<x>`, `<y>` (local; add remote on request)
+3. **Merge when ready:** #<c>
+
+_Reply **apply** to close the stale PRs and prune the stale branches, or tell me
+which specific items to act on._
+```
+
+Keep rationales to one line each — the user is scanning. If a section is empty,
+keep its heading with `(0)` so the report reads as complete coverage, not a
+silent omission.
+
+### 3. Act — only after confirmation
+
+When the user confirms (or invoked with `--apply` / "apply"), act on exactly the
+items you put in the **Stale / closeable** and **Safe to delete** lists — never
+on `keep`, `needs-work`, or `confirm-individually` items without a separate OK.
+
+**Close stale PRs** (including the empty no-ops) via the detected platform's CLI
+— there is no `pr-close` verb in `git_ops.sh`, so use the CLI directly. Leave a
+short comment so the trail explains *why*:
+
+```bash
+# GitHub
+gh pr close <num> --comment "Closing as stale: <reason>. Reopen if still needed."
+# GitLab
+glab mr close <num>
+```
+
+**Delete branches**, by class. The split matters because force-delete is only
+safe when something else proves the work is preserved:
+
+```bash
+# merged-ff + [gone]: hand to branch_clean.sh — its guarded -d path is enough
+~/.claude/scripts/branch_clean.sh --apply              # local, prompts (--yes to skip)
+
+# merged-pr (squash-merged): branch_clean refuses these (-d sees them as unmerged),
+# but the merged PR proves the work landed, so -D is safe HERE and only here.
+git branch -D <branch>                                 # only for verified merged-pr branches
+
+# remote, opt-in only (explicit "clean remotes too" / --include-remote):
+git push origin --delete <branch>                      # only for merged-pr remotes
+```
+
+The link that keeps `-D` safe: delete with `-D` **only** for branches
+`hygiene_gather.py` classified `merged-pr` (its PR/MR state is *merged*). For
+`closed-unmerged`, `stale`, or `no-pr` branches, the work may be unsaved — never
+`-D` them on the strength of the sweep; require an explicit per-branch go-ahead,
+and if a guarded delete fails, surface it rather than escalating to `-D`.
+
+Pass `--include-remote` / run `git push origin --delete` only when the user
+explicitly asked to clean remotes — local-only is the default.
+
+Report the outcome per item (`closed` / `deleted` / `FAILED` + reason).
+
+## Safety guarantees (inherited + enforced here)
+
+- **Report-first:** no PR closed, no branch deleted without a confirmed action.
+- **Scope:** act only on items shown in the stale/prunable sections of the report
+  the user just saw — never expand scope between report and action.
+- **Force-delete is evidence-gated:** `git branch -D` is used *only* on branches
+  whose PR/MR state is verified `merged`. Unmerged / closed-unmerged / no-PR
+  branches are never force-deleted on the strength of the sweep.
+- **Protected/current are untouchable:** the default branch, protected globs, and
+  the current branch are never deleted (both `branch_clean.sh` and
+  `hygiene_gather.py` mark them).
+- **Remote deletion is opt-in** (`--include-remote` / explicit request only).
+- **Auth/CLI failures are surfaced** (`errors` array), never reported as "clean".
+
+## Notes
+
+- Bot-PR floods (many near-identical Jules/Copilot/Palette PRs) are better
+  handled by `bot-pr-triage` — if the queue is dominated by bot duplicates, point
+  the user there for blob-level dedup before this general sweep.
+- Issue backlog hygiene is a separate concern — see `issue-prioritize` /
+  `issue-triage`.

--- a/.skillshare/skills/repo-hygiene/SKILL.md
+++ b/.skillshare/skills/repo-hygiene/SKILL.md
@@ -1,21 +1,10 @@
 ---
 name: repo-hygiene
-description: |
-  Use when one request covers BOTH pull/merge requests AND git branches — or
-  asks to actually close/delete the dead ones, not just list them. This is the
-  combined cleanup pass: it reviews every open PR/MR and every stale/merged/gone
-  branch together, sorts them, and after you confirm, closes the stale PRs and
-  prunes the branches in a single sweep across GitHub, GitLab, and local.
-
-  Reach for this on any "tidy up my repo" intent that spans the merge queue and
-  the branch list at once — e.g. cluttered after a batch of merges, a pile of old
-  MRs plus dozens of stale branches, "which PRs to merge vs close then prune the
-  branches behind them", "go through my PRs and close the dead ones and clean up
-  merged/gone branches locally and on github".
-
-  Pick this over pr-review (PRs only, no closing) or branch-clean (branches
-  only) whenever the ask touches both, or wants items closed/deleted rather than
-  only reported.
+description: >-
+  PR/MR + branch cleanup sweep: review every open PR and stale/merged/gone
+  branch, then after you confirm close the dead PRs and prune branches
+  (GitHub/GitLab/local). For any "tidy up my repo" ask spanning both; pick over
+  pr-review or branch-clean.
 ---
 
 # Repository Hygiene Sweep

--- a/.skillshare/skills/repo-hygiene/evals/evals.json
+++ b/.skillshare/skills/repo-hygiene/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "repo-hygiene",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "can you go through all my open PRs and tell me which ones are ready to merge, which are stuck, and which I should just close? then close the dead ones",
+      "expected_output": "A sectioned report grouping open PRs into ready/needs-work/stale/keep with a per-PR next step, ending with a confirmation prompt before closing anything (does not auto-close).",
+      "files": []
+    },
+    {
+      "id": 1,
+      "prompt": "my local branch list is a total mess after the last few merges. clean up the stale and already-merged branches locally and on github too",
+      "expected_output": "Runs branch_clean dry-run first, groups candidates by reason (merged/gone/stale), presents them, and only deletes (including remote, since explicitly requested) after confirmation. Never touches current/protected/default branch.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "do a full hygiene pass on this repo — review every open PR and every leftover branch, break it into sections with recommendations for what to do next",
+      "expected_output": "A single combined report covering both open PRs and prunable branches, organized into clearly labeled sections, each item with a one-line rationale and a recommended next step, plus a Recommended actions summary. Report-only unless told to apply.",
+      "files": []
+    }
+  ]
+}

--- a/.skillshare/skills/repo-hygiene/scripts/hygiene_gather.py
+++ b/.skillshare/skills/repo-hygiene/scripts/hygiene_gather.py
@@ -134,16 +134,20 @@ def is_ancestor(ref: str, default: str) -> bool:
 
 
 def classify_local(b: dict, default: str, current: str, protected_globs: list[str],
-                   merged: dict, closed: dict, stale_days: int, now: int) -> dict:
+                   merged: dict, closed: dict, open_refs: dict,
+                   stale_days: int, now: int) -> dict:
     name = b["name"]
     age_days = (now - b["committed"]) // 86400 if b["committed"] else None
     base = {"name": name, "age_days": age_days,
-            "pr": merged.get(name) or closed.get(name)}
+            "pr": open_refs.get(name) or merged.get(name) or closed.get(name)}
     if is_protected(name, default, current, protected_globs):
         base["classification"] = "protected" if name != current else "current"
         base["safe_delete"] = False
         return base
-    if name in merged:
+    if name in open_refs:
+        base["classification"] = "open-pr"          # keep: backs an open PR
+        base["safe_delete"] = False
+    elif name in merged:
         base["classification"] = "merged-pr"      # squash-merge safe; needs -D
         base["safe_delete"] = True
     elif is_ancestor(name, default):
@@ -227,7 +231,7 @@ def main() -> int:
                       "rely on branch_clean.sh (merged-ff / gone / stale only).")
 
     locals_ = [classify_local(b, default, current, protected_globs,
-                              merged, closed, args.stale_days, now)
+                              merged, closed, open_refs, args.stale_days, now)
                for b in local_branches()]
     remotes = [classify_remote(n, merged, closed, open_refs)
                for n in remote_branches(default)]
@@ -239,11 +243,16 @@ def main() -> int:
         "stale_days": args.stale_days,
         "open_pr_sizes": sizes,                 # github only; {} otherwise
         "empty_prs": [n for n, s in sizes.items() if s["empty"]],
+        "open_pr_refs": open_refs,              # head ref -> open PR number
         "merged_pr_refs": merged,
         "closed_pr_refs": closed,
         "branches": {"local": locals_, "remote": remotes},
         "errors": errors,
     }
+    # Surface gathered errors to stderr too, so a degraded run is visible in logs
+    # and not only in the JSON a caller might not inspect.
+    for e in errors:
+        err(e)
     print(json.dumps(result, indent=2))
     # Exit non-zero only if we could gather *nothing* useful, so callers can tell
     # "clean repo" from "couldn't look".

--- a/.skillshare/skills/repo-hygiene/scripts/hygiene_gather.py
+++ b/.skillshare/skills/repo-hygiene/scripts/hygiene_gather.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Squash-merge-aware hygiene data gatherer for the repo-hygiene skill.
+
+Supplies the two pieces the existing backends (pr_review.sh / branch_clean.sh)
+can't, in one platform-aware pass:
+
+  1. Open-PR diff sizes  -> detect empty zero-diff "no-op" PRs that pr_review.sh
+     would otherwise call mergeable (it has no changes-count field, and a PR with
+     no files produces no checks, so its disposition defaults to "merge").
+
+  2. Branch <-> PR-state correlation -> classify every local and remote branch by
+     the merge-state of its PR/MR. This is what `git branch --merged` cannot see:
+     on a squash-merge repo the merged branch's tip is never an ancestor of the
+     default branch, so the conservative branch_clean.sh pass reports it as "not
+     merged" and the real clutter stays hidden.
+
+Read-only. Classifies and prints JSON; never closes a PR or deletes a branch.
+Supports GitHub (gh) and GitLab (glab); degrades gracefully when a CLI is
+missing or unauthenticated (the gap is reported in `errors`, never swallowed).
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import shutil
+import subprocess
+import sys
+import time
+
+DEFAULT_PROTECTED = ["main", "master", "release/*", "hotfix/*"]
+
+
+def err(msg: str) -> None:
+    print(f"hygiene_gather: {msg}", file=sys.stderr)
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def git(*args: str) -> str:
+    return run(["git", *args]).stdout.strip()
+
+
+def detect_platform() -> str:
+    url = git("remote", "get-url", "origin").lower()
+    if "gitlab" in url:
+        return "gitlab"
+    if "github" in url:
+        return "github"
+    return "git"
+
+
+def is_protected(name: str, default: str, current: str, globs: list[str]) -> bool:
+    if name in (default, current):
+        return True
+    return any(fnmatch.fnmatch(name, g) for g in globs)
+
+
+# --- platform PR/MR queries -------------------------------------------------
+
+def gh_refs(state: str, errors: list[str]) -> dict[str, int]:
+    """headRefName -> PR number for the given state (open|merged|closed)."""
+    r = run(["gh", "pr", "list", "--state", state, "--limit", "500",
+             "--json", "number,headRefName"])
+    if r.returncode != 0:
+        errors.append(f"gh pr list --state {state}: {r.stderr.strip() or 'failed'}")
+        return {}
+    return {pr["headRefName"]: pr["number"] for pr in json.loads(r.stdout or "[]")}
+
+
+def gh_open_sizes(errors: list[str]) -> dict[int, dict]:
+    """PR number -> diff size + empty flag for OPEN PRs."""
+    r = run(["gh", "pr", "list", "--state", "open", "--limit", "500",
+             "--json", "number,headRefName,changedFiles,additions,deletions"])
+    if r.returncode != 0:
+        errors.append(f"gh pr list sizes: {r.stderr.strip() or 'failed'}")
+        return {}
+    out = {}
+    for pr in json.loads(r.stdout or "[]"):
+        cf = pr.get("changedFiles", 0)
+        out[pr["number"]] = {
+            "head": pr["headRefName"],
+            "changedFiles": cf,
+            "additions": pr.get("additions", 0),
+            "deletions": pr.get("deletions", 0),
+            "empty": cf == 0,
+        }
+    return out
+
+
+def glab_refs(flag: str, errors: list[str]) -> dict[str, int]:
+    r = run(["glab", "mr", "list", flag, "-P", "200", "-F", "json"])
+    if r.returncode != 0:
+        errors.append(f"glab mr list {flag}: {r.stderr.strip() or 'failed'}")
+        return {}
+    refs = {}
+    for mr in json.loads(r.stdout or "[]"):
+        src = mr.get("source_branch")
+        if src:
+            refs[src] = mr.get("iid")
+    return refs
+
+
+# --- branch enumeration -----------------------------------------------------
+
+def local_branches() -> list[dict]:
+    fmt = "%(refname:short)\t%(upstream:track)\t%(committerdate:unix)"
+    out = git("for-each-ref", "--format", fmt, "refs/heads")
+    rows = []
+    for line in filter(None, out.splitlines()):
+        parts = line.split("\t")
+        name = parts[0]
+        track = parts[1] if len(parts) > 1 else ""
+        cdate = int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 0
+        rows.append({"name": name, "gone": "[gone]" in track, "committed": cdate})
+    return rows
+
+
+def remote_branches(default: str) -> list[str]:
+    out = git("for-each-ref", "--format", "%(refname:short)", "refs/remotes/origin")
+    names = []
+    for line in filter(None, out.splitlines()):
+        short = line[len("origin/"):] if line.startswith("origin/") else line
+        if short in ("HEAD", default) or "HEAD ->" in line:
+            continue
+        names.append(short)
+    return names
+
+
+def is_ancestor(ref: str, default: str) -> bool:
+    return run(["git", "merge-base", "--is-ancestor", ref, default]).returncode == 0
+
+
+def classify_local(b: dict, default: str, current: str, protected_globs: list[str],
+                   merged: dict, closed: dict, stale_days: int, now: int) -> dict:
+    name = b["name"]
+    age_days = (now - b["committed"]) // 86400 if b["committed"] else None
+    base = {"name": name, "age_days": age_days,
+            "pr": merged.get(name) or closed.get(name)}
+    if is_protected(name, default, current, protected_globs):
+        base["classification"] = "protected" if name != current else "current"
+        base["safe_delete"] = False
+        return base
+    if name in merged:
+        base["classification"] = "merged-pr"      # squash-merge safe; needs -D
+        base["safe_delete"] = True
+    elif is_ancestor(name, default):
+        base["classification"] = "merged-ff"        # branch_clean handles via -d
+        base["safe_delete"] = True
+    elif b["gone"]:
+        base["classification"] = "gone"             # remote deleted
+        base["safe_delete"] = True
+    elif name in closed:
+        base["classification"] = "closed-unmerged"  # confirm: abandoned work
+        base["safe_delete"] = False
+    elif age_days is not None and age_days >= stale_days:
+        base["classification"] = "stale"            # confirm: no PR, old
+        base["safe_delete"] = False
+    else:
+        base["classification"] = "no-pr-active"     # keep
+        base["safe_delete"] = False
+    return base
+
+
+def classify_remote(name: str, merged: dict, closed: dict, open_refs: dict) -> dict:
+    base = {"name": name, "pr": merged.get(name) or closed.get(name) or open_refs.get(name)}
+    if name in open_refs:
+        base["classification"] = "open-pr"          # keep: backs an open PR
+        base["safe_delete"] = False
+    elif name in merged:
+        base["classification"] = "merged-pr"        # safe (opt-in remote delete)
+        base["safe_delete"] = True
+    elif name in closed:
+        base["classification"] = "closed-unmerged"  # confirm
+        base["safe_delete"] = False
+    else:
+        base["classification"] = "no-pr"            # confirm: unknown provenance
+        base["safe_delete"] = False
+    return base
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Squash-merge-aware PR/branch hygiene gatherer (read-only).")
+    ap.add_argument("--platform", choices=["github", "gitlab", "git"],
+                    help="Override platform autodetection.")
+    ap.add_argument("--stale-days", type=int, default=90,
+                    help="Days without a commit before a no-PR branch is stale (default 90).")
+    ap.add_argument("--protect", action="append", default=[],
+                    help="Extra protected glob (repeatable). Added to defaults.")
+    args = ap.parse_args()
+
+    errors: list[str] = []
+    platform = args.platform or detect_platform()
+    default = git("symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+    default = default.split("/")[-1] if default else "main"
+    current = git("rev-parse", "--abbrev-ref", "HEAD")
+    protected_globs = DEFAULT_PROTECTED + args.protect
+    now = int(time.time())
+
+    open_refs: dict = {}
+    merged: dict = {}
+    closed: dict = {}
+    sizes: dict = {}
+
+    if platform == "github":
+        if not shutil.which("gh"):
+            errors.append("gh not installed — cannot correlate PR state or detect empty PRs.")
+        else:
+            open_refs = gh_refs("open", errors)
+            merged = gh_refs("merged", errors)
+            closed = gh_refs("closed", errors)
+            sizes = gh_open_sizes(errors)
+    elif platform == "gitlab":
+        if not shutil.which("glab"):
+            errors.append("glab not installed — cannot correlate MR state.")
+        else:
+            open_refs = glab_refs("--opened", errors)
+            merged = glab_refs("--merged", errors)
+            closed = glab_refs("--closed", errors)
+            errors.append("gitlab: empty-MR diff sizes not gathered (glab list lacks a changes count); "
+                          "check `glab mr diff <iid>` for suspected no-ops.")
+    else:
+        errors.append("no GitHub/GitLab remote detected — branch correlation skipped; "
+                      "rely on branch_clean.sh (merged-ff / gone / stale only).")
+
+    locals_ = [classify_local(b, default, current, protected_globs,
+                              merged, closed, args.stale_days, now)
+               for b in local_branches()]
+    remotes = [classify_remote(n, merged, closed, open_refs)
+               for n in remote_branches(default)]
+
+    result = {
+        "platform": platform,
+        "default_branch": default,
+        "current_branch": current,
+        "stale_days": args.stale_days,
+        "open_pr_sizes": sizes,                 # github only; {} otherwise
+        "empty_prs": [n for n, s in sizes.items() if s["empty"]],
+        "merged_pr_refs": merged,
+        "closed_pr_refs": closed,
+        "branches": {"local": locals_, "remote": remotes},
+        "errors": errors,
+    }
+    print(json.dumps(result, indent=2))
+    # Exit non-zero only if we could gather *nothing* useful, so callers can tell
+    # "clean repo" from "couldn't look".
+    return 1 if errors and not (merged or closed or open_refs or locals_) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/configs/claude/config/command_config.yml
+++ b/configs/claude/config/command_config.yml
@@ -363,6 +363,18 @@ tool_policies:
     parallel_agents: conditional   # Tier 1 on the destructive --apply path
     validation_tier: 1
 
+  repo-hygiene:
+    allowed:
+      - Read
+      - Glob
+      - Grep
+      - Bash   # composes pr_review.sh / branch_clean.sh / hygiene_gather.py; close+delete only after confirm
+    forbidden:
+      - Write
+      - Edit   # report-first; never edits repo files
+    parallel_agents: conditional   # Tier 1 on the destructive close/prune path
+    validation_tier: 1
+
   token-benchmark:
     allowed:
       - Read

--- a/configs/cursor/rules/repo-hygiene.mdc
+++ b/configs/cursor/rules/repo-hygiene.mdc
@@ -1,0 +1,15 @@
+---
+description: "PR/MR + branch cleanup sweep: review every open PR and stale/merged/gone branch, then after you confirm close the dead PRs and prune branches (GitHub/GitLab/local). For any "tidy up my repo" ask spanning both; pick over pr-review or branch-clean."
+globs: ".claude/skills/repo-hygiene/**"
+alwaysApply: false
+---
+
+# repo-hygiene
+
+PR/MR + branch cleanup sweep: review every open PR and stale/merged/gone branch, then after you confirm close the dead PRs and prune branches (GitHub/GitLab/local). For any "tidy up my repo" ask spanning both; pick over pr-review or branch-clean.
+
+<!-- Auto-generated from .claude/skills/repo-hygiene/SKILL.md -->
+<!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
+
+Refer to `.cursor/skills/repo-hygiene/SKILL.md` for the full skill definition.
+


### PR DESCRIPTION
## Summary

Adds **`repo-hygiene`**, a report-first orchestrator skill that reviews open PRs/MRs **and** git branches in one pass, sorts them into sections with a recommended next step each, then — after confirmation — closes stale PRs and prunes branches across GitHub, GitLab, and local.

It **composes** the existing `pr-review` and `branch-clean` skills (inheriting their platform detection and safety guards) and adds one bundled, squash-merge-aware gatherer that supplies the two things those backends can't:

- **Empty-PR detection** — open-PR diff sizes; a zero-diff "no-op" PR is flagged closeable instead of mergeable (`pr_review.sh` has no changes-count, and an empty PR runs no checks, so it otherwise looks `merge`-able).
- **Squash-merge branch correlation** — classifies each local/remote branch by its PR/MR merge-state, surfacing squash-merged branches that `git branch --merged` cannot see (the merged tip is never an ancestor of the default branch on a squash-merge repo).

## Safety

- **Report-first**: nothing closed/deleted without a confirmed action.
- **Evidence-gated force-delete**: `git branch -D` is used only on branches whose PR state is verified `merged`; closed-unmerged / no-PR / stale branches require explicit per-branch confirmation.
- Remote deletion is opt-in; auth/CLI failures are surfaced, never reported as "clean".

## Validation (skill-creator evals, Opus 4.8)

- v2 **100%** vs prior **83.3%** pass (delta **+0.17**) — prior version missed empty PRs in the full-sweep and ~30 squash-merged branches (found 2 of 32).
- Measured rework cost ≈ **70k tokens** → net token-positive above a ~27% rework rate vs the prior version.
- Triggering-optimization run: no eval-backed delta (trigger rate is bound by base-model self-service + sibling competition, not wording); shipped the disambiguating description on design judgment, **0 false-fires** confirmed.

## Files

- `.skillshare/skills/repo-hygiene/` — `SKILL.md`, `scripts/hygiene_gather.py`, `evals/`
- `configs/claude/config/command_config.yml` — tool-policy entry (tier-1, conditional parallel agents)
- `.gitignore` — excludes skill-creator eval workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)