### PR TITLE
fix(agents): set stdin=DEVNULL for CLI agent subprocesses

### DIFF
--- a/configs/claude/scripts/agents/runners.py
+++ b/configs/claude/scripts/agents/runners.py
@@ -560,8 +560,12 @@ class CLIAgent(BaseAgent):
 
         try:
             cmd = self._build_command(prompt, output_file)
+            # stdin=DEVNULL so headless CLIs (e.g. `claude -p`, which reads piped
+            # stdin) get immediate EOF instead of inheriting and blocking on the
+            # parent's stdin until the timeout fires.
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/tests/python/agents/test_runners.py
+++ b/tests/python/agents/test_runners.py
@@ -301,6 +301,31 @@ class TestCLIAgentExecution:
         assert result["status"] == "complete"
         assert result["output"] == "prefix --model fake-model-1 hello world"
 
+    def test_subprocess_stdin_is_devnull(self, tmp_path):
+        """Headless CLIs must get EOF on stdin, not inherit the parent's.
+
+        `claude -p` reads piped stdin; inheriting an open parent stdin makes it
+        block until the timeout fires (observed: 300s hang). Pin stdin=DEVNULL.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        config = _make_config(tmp_path)
+        config.config["cli_agents"]["fake"] = {
+            "binary": "echo",
+            "base_args": [],
+            "output": "stdout",
+        }
+        agent = CLIAgent("fake", model="auto",
+                         rate_limiter=_make_limiter(), config=config)
+
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"ok", b""))
+        proc.returncode = 0
+        with patch("asyncio.create_subprocess_exec",
+                   return_value=proc) as spawn:
+            asyncio.run(agent._execute_impl("hi", "prompt"))
+        assert spawn.call_args.kwargs["stdin"] is asyncio.subprocess.DEVNULL
+
     def test_timeout_kills_subprocess(self, tmp_path):
         """Issue #306: timeout cancellation must kill the child, not leak it."""
         import os


### PR DESCRIPTION
## Problem

A live smoke test of `parallel_agent.py` (`--json --claude-model haiku "Reply ... PONG"`) hung the **claude** backend for the full 300s timeout while **gemini** and **antigravity** returned in seconds.

**Root cause:** `CLIAgent._execute_impl` (`agents/runners.py`) spawned children with `stdout`/`stderr` piped but left `stdin` unset, so the child inherited the parent's live stdin. `claude -p` reads piped stdin (to support `cat file | claude -p`), so it blocked reading the never-EOF inherited stdin until the timeout. `gemini -p` / `agy --print` don't read stdin in print mode, which is why only the claude backend hung.

**Proof:** `claude -p … </dev/null` returns instantly; `sleep 600 | claude -p …` blocks indefinitely — the orchestrator path matched the blocking case.

## Fix

Pass `stdin=asyncio.subprocess.DEVNULL` to `create_subprocess_exec` so the child gets immediate EOF.

## Test

- `test_subprocess_stdin_is_devnull` — mocks the spawn and asserts the `stdin` kwarg (fails before fix, passes after).
- Full suite: **310 passed**.

## Verification

Re-ran the live smoke test after the fix — all three agents return `PONG`:

| Agent | Before | After |
|-------|--------|-------|
| claude | timeout 300s | ✅ 3.6s |
| gemini | ✅ | ✅ |
| antigravity | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)