### PR TITLE
fix(check_status): bound auth probes so readiness check can't crawl/hang

### DIFF
--- a/configs/claude/scripts/check_status.sh
+++ b/configs/claude/scripts/check_status.sh
@@ -40,20 +40,50 @@ fi
 
 # Detect timeout command (timeout on Linux, gtimeout on macOS via coreutils);
 # a bare `timeout` made auth checks always fail on stock macOS (issue #315).
+# CHECK_STATUS_NO_TIMEOUT_CMD=1 forces the pure-bash fallback below (tests use
+# this to exercise the no-coreutils path deterministically on any platform).
 TIMEOUT_CMD=""
-if command -v timeout &> /dev/null; then
-    TIMEOUT_CMD="timeout"
-elif command -v gtimeout &> /dev/null; then
-    TIMEOUT_CMD="gtimeout"
+if [[ "${CHECK_STATUS_NO_TIMEOUT_CMD:-}" != "1" ]]; then
+    if command -v timeout &> /dev/null; then
+        TIMEOUT_CMD="timeout"
+    elif command -v gtimeout &> /dev/null; then
+        TIMEOUT_CMD="gtimeout"
+    fi
 fi
 
-# Run a command bounded by 3s when a timeout binary exists, unbounded otherwise
+# Recursively SIGKILL a process and all its descendants. A bare `kill $pid`
+# leaves grandchildren orphaned (e.g. the CLI's `node` workers), and an orphan
+# that still holds the script's stdout pipe blocks any caller capturing our
+# output — re-introducing the very stall we are bounding. Kill children first
+# so we don't reparent them to init before we can find them.
+kill_tree() {
+    local pid="$1" child
+    for child in $(pgrep -P "$pid" 2> /dev/null); do
+        kill_tree "$child"
+    done
+    kill -9 "$pid" 2> /dev/null
+}
+
+# Run a command bounded by 3s. Prefer timeout(1)/gtimeout(1); otherwise fall
+# back to a pure-bash watchdog so a slow CLI (e.g. `gemini auth status`, ~60s)
+# can't stall the readiness check on machines without GNU coreutils — without
+# this the whole check took ~196s on stock macOS.
 run_with_timeout() {
+    local secs=3
     if [[ -n "$TIMEOUT_CMD" ]]; then
-        "$TIMEOUT_CMD" 3 "$@"
-    else
-        "$@"
+        "$TIMEOUT_CMD" "$secs" "$@"
+        return $?
     fi
+    "$@" &
+    local cmd_pid=$!
+    { sleep "$secs"; kill_tree "$cmd_pid"; } &
+    local watcher_pid=$!
+    wait "$cmd_pid" 2> /dev/null
+    local rc=$?
+    # command finished first: cancel the watchdog so it doesn't linger
+    kill_tree "$watcher_pid" 2> /dev/null
+    wait "$watcher_pid" 2> /dev/null
+    return "$rc"
 }
 
 antigravity_enabled=""
@@ -223,8 +253,13 @@ if [[ "$claude_installed" == true ]]; then
 fi
 
 if [[ "$gemini_installed" == true ]]; then
-    # Add timeout to avoid hanging
-    if run_with_timeout gemini auth status &> /dev/null; then
+    # Prefer a fast credential check: `gemini auth status` has no real auth
+    # subcommand and runs as a ~60s model call, so probe it only as a last
+    # resort. An API key or the OAuth creds file is an immediate signal (same
+    # file-presence heuristic as the Codex check above).
+    if [[ -n "$GEMINI_API_KEY" || -n "$GOOGLE_API_KEY" || -f "$HOME/.gemini/oauth_creds.json" ]]; then
+        echo -e "  ${GREEN}✓${NC} Gemini authenticated"
+    elif run_with_timeout gemini auth status &> /dev/null; then
         echo -e "  ${GREEN}✓${NC} Gemini authenticated"
     else
         echo -e "  ${YELLOW}?${NC} Gemini authentication unknown (check timeout)"

--- a/tests/bats/check_status.bats
+++ b/tests/bats/check_status.bats
@@ -225,6 +225,49 @@ EOF
     assert_output --partial "Codex authentication unknown"
 }
 
+# --- Auth probe timeout fallback (no GNU coreutils on PATH) ---
+
+@test "auth probe is bounded by the pure-bash fallback when no timeout binary exists" {
+    # Regression: run_with_timeout was a no-op without timeout(1)/gtimeout(1),
+    # so a slow `gemini auth status` (~60s) ran unbounded and made the whole
+    # readiness check take ~196s on stock macOS. The fallback must cap it at ~3s.
+    write_services_yml true true false false
+    make_mock_cli claude 0
+    # gemini whose `auth` hangs well past the 3s bound
+    cat > "$MOCK_BIN/gemini" << 'EOF'
+#!/bin/bash
+case "$1" in
+    auth) sleep 30 ;;
+    --version) echo "gemini 1.0.0-mock"; exit 0 ;;
+    *) exit 0 ;;
+esac
+EOF
+    chmod +x "$MOCK_BIN/gemini"
+
+    local start=$SECONDS
+    run env CHECK_STATUS_NO_TIMEOUT_CMD=1 bash "$SCRIPT_UNDER_TEST"
+    local elapsed=$(( SECONDS - start ))
+
+    assert_success
+    # slow probe is killed -> reported as unknown, not hung
+    assert_output --partial "Gemini authentication unknown"
+    [ "$elapsed" -lt 15 ]
+}
+
+@test "gemini auth uses the fast credential check, not the slow CLI probe" {
+    # oauth_creds.json present must short-circuit to authenticated WITHOUT
+    # calling `gemini auth status` (which would exit 1 here -> "unknown").
+    write_services_yml true true false false
+    make_mock_cli claude 0
+    make_mock_cli gemini 1
+    mkdir -p "$HOME/.gemini"
+    echo '{}' > "$HOME/.gemini/oauth_creds.json"
+    run bash "$SCRIPT_UNDER_TEST"
+    assert_success
+    assert_output --partial "Gemini authenticated"
+    refute_output --partial "Gemini authentication unknown"
+}
+
 # --- State directory resolution (MANIFEST_STATE_ROOT seam) ---
 
 @test "MANIFEST_STATE_ROOT is honored and state dirs are created" {


### PR DESCRIPTION
## Problem

`check_status.sh` (also `parallel_agent.py --status`) took **~196s** on stock macOS. Observed mid-run it looked *truncated* — output stalled right after \"Claude authenticated\" — but it was never truncated; it was just slow, and reads were catching it mid-probe.

## Root causes

1. **`run_with_timeout` was a silent no-op** without `timeout(1)`/`gtimeout(1)` (not present on stock macOS), so the slow `gemini auth status` probe (**measured 61s**, network-variable) ran **unbounded**. The original code comment even chose \"unbounded otherwise\" (issue #315) — that's the latent defect.
2. **`gemini auth status` has no real auth subcommand** — it runs as a ~60s model call, so even bounded it can't answer in time.

## Fix

- **Pure-bash watchdog fallback** in `run_with_timeout` that enforces the intended 3s bound when no `timeout` binary exists, with a `kill_tree()` helper so a killed CLI's child processes can't keep the output pipe open and re-stall any caller capturing output (caught via wall-time, not just the internal assertion).
- **Fast gemini credential check** (`GEMINI_API_KEY`/`GOOGLE_API_KEY` or `~/.gemini/oauth_creds.json`), mirroring the existing Codex `auth.json` pattern; the slow CLI probe is now a last resort only.
- `CHECK_STATUS_NO_TIMEOUT_CMD=1` test seam forces the fallback path deterministically on any platform (CI Linux has real `timeout`).

## Result (affected machine)

| | Before | After |
|---|--------|-------|
| Runtime | ~196s | **2s** |
| Output | complete but appeared to hang | complete |
| Claude auth | ✓ (after 196s) | ✓ |
| Gemini auth | ✓ (after 196s) | ✓ (fast, via creds) |

## Tests

`tests/bats/check_status.bats`:
- auth probe bounded by the pure-bash fallback when no timeout binary exists (would run 30s unbounded before; ~3s after)
- gemini auth uses the fast credential check, not the slow CLI probe

Full suite: **412 bats passed**; `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)