### PR TITLE
docs: refresh README, diagrams, and docs set for issue-automation features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Parallel LLM agent orchestration framework for Claude Code, Cursor IDE, Gemini CLI, Codex CLI, and Antigravity IDE
 
-**Last Updated**: 2026-06-12
+**Last Updated**: 2026-06-15
 
 Manifest is a configuration repository that deploys a sophisticated parallel agent
 orchestration system to `~/.claude/`, `~/.cursor/`, `~/.gemini/`, `~/.codex/`, and `~/.antigravity/`, enabling Claude Code,
@@ -56,6 +56,12 @@ cd Manifest
   needed when the `claude`/`gemini` CLIs are logged in (SDK + API key still preferred when present)
 - **Cross-Platform**: Native support for macOS (Intel/Apple Silicon) and 5 major Linux distributions
 - **Unified Label Management**: Canonical label registry with sync across GitHub, GitLab, and Linear
+- **Autonomous Issue Development** (`/auto-issue-dev`): Picks the next `auto-dev`-labeled issue,
+  implements it test-first, and opens a PR for review (never merges); run unattended via `/loop /auto-issue-dev`
+- **Repo Hygiene Sweep** (`/repo-hygiene`): Review-then-confirm cleanup of open PRs and stale/merged/gone
+  branches across GitHub, GitLab, and local
+- **Issue-Linking Git Hooks** (`/pr-issue-sync`, `/commit-issue-sync`): Fail-open PostToolUse hooks that keep
+  the linked issue's status label and back-links in sync as commits land and PRs open (installable via `install_issue_hooks.sh`)
 - **Production Templates**: Pre-configured permission templates for Django, Express, Go microservices, Python monorepos
 - **SkillClaw Integration** (opt-in): Passively ingests Claude Code's own `~/.claude/projects/**/*.jsonl`
   transcripts, runs a `claude -p` map-reduce evolve pass (Max subscription, no API key), and proposes
@@ -100,6 +106,8 @@ Mermaid flowcharts showing bootstrap, execution, validation, and consensus flows
 | `/docs-readme` | Improve README structure and content following best practices | NEVER | Tier 2 |
 | `/issue-prioritize` | Fetch and rank open issues by impact, urgency, readiness, risk (GitHub/GitLab/Linear) | CONDITIONAL (top candidates) | Tier 2 |
 | `/issue-triage` | Linear issue audit: duplicates, staleness, priority validation | CONDITIONAL (scenario-based) | Tier 2 |
+| `/auto-issue-dev` | Autonomously develop one `auto-dev`-labeled issue test-first and open a PR (never merges); run via `/loop /auto-issue-dev` | CONDITIONAL | Tier 1 + Tier 2 |
+| `/repo-hygiene` | Review-then-confirm cleanup sweep of open PRs and stale/merged/gone branches | CONDITIONAL | Tier 2 |
 | `/plan-manage` | Plan lifecycle: create, review, execute, archive, abandon | CONDITIONAL | Tier 2 |
 | `/browser-test` | AI-powered E2E browser testing via browser-use YAML test prompts | CONDITIONAL | Tier 2 |
 | `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default) | NEVER | Tier 2 |
@@ -143,9 +151,10 @@ Mermaid flowcharts showing bootstrap, execution, validation, and consensus flows
 |----------|---------|----------|--------------|
 | [Getting Started](docs/GETTING_STARTED.md) | First-time setup walkthrough with verification steps | New users | 10 min |
 | [Configuration](docs/CONFIGURATION.md) | All configuration options, YAML reference, environment variables | Operators | 15 min |
-| [Architecture Diagrams](docs/ARCHITECTURE_DIAGRAMS.md) | Visual system documentation with 15 Mermaid diagrams | Developers | 20 min |
+| [Architecture Diagrams](docs/ARCHITECTURE_DIAGRAMS.md) | Visual system documentation with 19 Mermaid diagrams | Developers | 20 min |
 | [SkillClaw](docs/SKILLCLAW.md) | PR-gated skill evolution via passive transcript ingestion | Operators | 8 min |
 | [Spec Systems](docs/SPEC-SYSTEMS.md) | Map of the four spec/plan systems and when to use each | Contributors | 3 min |
+| [Token Benchmark](docs/TOKEN_BENCHMARK.md) | Manifest context token overhead and quality delta across providers (`/token-benchmark`) | Operators | 5 min |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Common problems, error messages, solutions | All users | 10 min |
 | [AGENTS.md](AGENTS.md) | AI agent instructions (Cursor, Claude, Gemini, Codex) | AI assistants | 8 min |
 | [CLAUDE.md](CLAUDE.md) | Claude Code-specific project context | AI assistants | 8 min |
@@ -199,6 +208,10 @@ Manifest/
 │   │   │   ├── git_platform.sh      # Git platform detection
 │   │   │   ├── git_ops.sh           # Platform-agnostic Git operations
 │   │   │   ├── linear_ops.sh        # Linear API wrapper (GraphQL)
+│   │   │   ├── issue_support.sh     # Issue-linking engine for pr-/commit-issue-sync hooks
+│   │   │   ├── issue_support_hook.sh # PostToolUse dispatcher routing PRs/commits to the engine
+│   │   │   ├── install_issue_hooks.sh # Enable/remove issue-linking hooks (PostToolUse or native)
+│   │   │   ├── auto_issue_dev.sh    # Selection/dependency engine for /auto-issue-dev
 │   │   │   ├── sync-skills.sh       # Skill deployment to home targets
 │   │   │   ├── label_sync.sh        # Label provisioning across platforms
 │   │   │   ├── skillclaw_scrub.py   # Redact API keys/auth headers from captured sessions
@@ -229,7 +242,7 @@ Manifest/
 │       ├── python/                  # Python project starter
 │       └── terraform/               # Terraform project starter
 ├── .skillshare/                     # Skill source of truth (managed by skillshare)
-│   └── skills/                      # 69 skills deployed to ~/.claude/skills/ by bootstrap
+│   └── skills/                      # 74 skills deployed to ~/.claude/skills/ by bootstrap
 ├── tests/                           # Test suites
 │   ├── python/                      # pytest tests for parallel_agent and agents/
 │   └── bats/                        # Bats shell tests for bootstrap and scripts
@@ -237,7 +250,7 @@ Manifest/
     ├── README.md                    # Documentation hub
     ├── GETTING_STARTED.md           # First-time setup walkthrough
     ├── CONFIGURATION.md             # Complete config reference
-    ├── ARCHITECTURE_DIAGRAMS.md     # Mermaid system diagrams (15 diagrams)
+    ├── ARCHITECTURE_DIAGRAMS.md     # Mermaid system diagrams (19 diagrams)
     ├── SKILLCLAW.md                 # SkillClaw integration guide
     ├── TROUBLESHOOTING.md           # Common issues and solutions
     └── COMMANDS.md                  # Command reference
@@ -349,10 +362,10 @@ export CODEX_HOME="$HOME/.manifest/custom-codex-state"
 ## Testing
 
 ```bash
-# Python tests (128 tests covering agents/ package and parallel_agent.py)
+# Python tests (310 tests covering agents/ package and parallel_agent.py)
 pytest tests/python/ -q
 
-# Shell tests (117 Bats tests covering bootstrap and scripts)
+# Shell tests (410 Bats tests covering bootstrap and scripts)
 npx bats tests/bats/
 
 # Lint shell scripts

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Mermaid flowcharts showing bootstrap, execution, validation, and consensus flows
 | `/docs-readme` | Improve README structure and content following best practices | NEVER | Tier 2 |
 | `/issue-prioritize` | Fetch and rank open issues by impact, urgency, readiness, risk (GitHub/GitLab/Linear) | CONDITIONAL (top candidates) | Tier 2 |
 | `/issue-triage` | Linear issue audit: duplicates, staleness, priority validation | CONDITIONAL (scenario-based) | Tier 2 |
-| `/auto-issue-dev` | Autonomously develop one `auto-dev`-labeled issue test-first and open a PR (never merges); run via `/loop /auto-issue-dev` | CONDITIONAL | Tier 1 + Tier 2 |
-| `/repo-hygiene` | Review-then-confirm cleanup sweep of open PRs and stale/merged/gone branches | CONDITIONAL | Tier 2 |
+| `/auto-issue-dev` | Autonomously develop one `auto-dev`-labeled issue test-first and open a PR (never merges); run via `/loop /auto-issue-dev` | NEVER | Tier 1 + Tier 2 |
+| `/repo-hygiene` | Review-then-confirm cleanup sweep of open PRs and stale/merged/gone branches | CONDITIONAL | Tier 1 + Tier 2 |
 | `/plan-manage` | Plan lifecycle: create, review, execute, archive, abandon | CONDITIONAL | Tier 2 |
 | `/browser-test` | AI-powered E2E browser testing via browser-use YAML test prompts | CONDITIONAL | Tier 2 |
 | `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default) | NEVER | Tier 2 |

--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -1515,9 +1515,9 @@ flowchart TB
 | `done` | `#0E8A16` (Green) | GitHub, GitLab, Linear | /plan-manage execute |
 | `follow-up` | `#D4C5F9` (Lavender) | GitHub, GitLab, Linear | /issue-triage |
 | `future` | `#C2E0C6` (Green) | GitHub, GitLab, Linear | /issue-prioritize |
-| `auto-dev` | (opt-in) | GitHub, GitLab, Linear | /auto-issue-dev (selection) |
-| `needs-human` | (flag) | GitHub, GitLab, Linear | /auto-issue-dev (mark-blocked) |
-| `blocked-dependency` | (flag) | GitHub, GitLab, Linear | /auto-issue-dev (mark-dependency) |
+| `auto-dev` | `#5319E7` (Purple) | GitHub, GitLab, Linear | /auto-issue-dev (selection) |
+| `needs-human` | `#B60205` (Red) | GitHub, GitLab, Linear | /auto-issue-dev (mark-blocked) |
+| `blocked-dependency` | `#6A737D` (Gray) | GitHub, GitLab, Linear | /auto-issue-dev (mark-dependency) |
 
 **Deprecated**: `processed` (replaced by `done`)
 

--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -2,7 +2,7 @@
 
 > Visual documentation of the Manifest parallel LLM agent orchestration framework
 
-**Last Updated**: 2026-06-12
+**Last Updated**: 2026-06-15
 **Project**: Manifest - AI Agent Orchestration Framework
 
 ---
@@ -24,8 +24,10 @@
 13. [Cross-Verification Consensus](#cross-verification-consensus)
 14. [Service State Management](#service-state-management)
 15. [Issue Management Architecture](#issue-management-architecture)
-16. [Label Management Architecture](#label-management-architecture)
-17. [SkillClaw Passive Ingest & Evolve Pipeline](#skillclaw-passive-ingest--evolve-pipeline)
+16. [Issue-Linking Hooks (commit-issue-sync / pr-issue-sync)](#issue-linking-hooks-commit-issue-sync--pr-issue-sync)
+17. [Autonomous Issue Developer (/auto-issue-dev)](#autonomous-issue-developer-auto-issue-dev)
+18. [Label Management Architecture](#label-management-architecture)
+19. [SkillClaw Passive Ingest & Evolve Pipeline](#skillclaw-passive-ingest--evolve-pipeline)
 
 ---
 
@@ -1282,6 +1284,176 @@ flowchart TB
 
 ---
 
+## Issue-Linking Hooks (commit-issue-sync / pr-issue-sync)
+
+How the issue-linking hooks keep the GitHub/GitLab issue tracker in sync as commits
+land and PRs/MRs open. A single PostToolUse dispatcher (`issue_support_hook.sh`)
+classifies the Bash command that just ran and, only on success, routes to the shared
+engine (`issue_support.sh`). The engine is **fail-open**: `sync-pr`/`sync-commit`
+always exit 0 (bounded by a per-hook `run_with_timeout`), so a git action is never
+blocked. An optional native `git post-commit` hook covers commits made outside an
+AI tool.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart TB
+    classDef input fill:#f0f9ff,stroke:#0284c7,color:#0c4a6e
+    classDef process fill:#f0fdf4,stroke:#16a34a,color:#14532d
+    classDef decision fill:#fef3c7,stroke:#d97706,color:#78350f
+    classDef config fill:#f3e8ff,stroke:#9333ea,color:#581c87
+    classDef platform fill:#3b82f6,stroke:#1d4ed8,color:#fff
+    classDef skip fill:#e5e7eb,stroke:#6b7280,color:#374151
+
+    INSTALL["install_issue_hooks.sh --enable [--native]<br/>flips tool_policies gate +<br/>writes PostToolUse entry"]:::config
+
+    subgraph "Triggers"
+        TOOLUSE["PostToolUse payload (stdin JSON)<br/>after a Bash command"]:::input
+        NATIVE["git post-commit hook<br/>(--native, non-AI commits)"]:::input
+    end
+
+    HOOK["issue_support_hook.sh<br/>classify command + success"]:::process
+    CLASS{"Command class?<br/>(gh/glab/git_ops pr-create<br/>· git commit · none)"}:::decision
+    OK{"Tool succeeded?<br/>(is_error / error)"}:::decision
+
+    ENGINE["issue_support.sh<br/>sync-pr N / sync-commit HEAD<br/>(run_with_timeout, fail-open exit 0)"]:::process
+    GATE{"tool_policies gate<br/>enabled?"}:::decision
+
+    RESOLVE["resolve_candidates()<br/>branch-prefix · PR/MR body<br/>· commit-message #N refs"]:::process
+    OFFER["offer_create()<br/>(no ref → dedup search,<br/>interactive create 'planned')"]:::process
+
+    subgraph "process_issue (per linked #N)"
+        TRANSITION["transition_issue<br/>forward-only label advance<br/>planned→in-progress→needs-review"]:::process
+        BACKLINK["comment_backlink<br/>(idempotent marker)"]:::process
+        CLOSEKW["ensure_closing_keyword<br/>Closes #N (PR only)"]:::process
+    end
+
+    GIT_OPS["git_ops.sh → gh / glab"]:::platform
+    NOOP["exit 0 (no-op)"]:::skip
+
+    INSTALL -.->|registers| TOOLUSE
+    INSTALL -.->|installs| NATIVE
+    TOOLUSE --> HOOK
+    NATIVE --> ENGINE
+    HOOK --> OK
+    OK -->|No| NOOP
+    OK -->|Yes| CLASS
+    CLASS -->|pr| ENGINE
+    CLASS -->|commit| ENGINE
+    CLASS -->|none| NOOP
+    ENGINE --> GATE
+    GATE -->|No| NOOP
+    GATE -->|Yes| RESOLVE
+    RESOLVE -->|refs found| TRANSITION
+    RESOLVE -->|none| OFFER
+    OFFER --> TRANSITION
+    TRANSITION --> BACKLINK --> CLOSEKW
+    TRANSITION --> GIT_OPS
+    BACKLINK --> GIT_OPS
+    CLOSEKW --> GIT_OPS
+```
+
+**Trigger → target mapping**:
+
+| Trigger | Hook class | Engine call | Status target | Extra action |
+|---------|-----------|-------------|---------------|--------------|
+| PR/MR created (`gh`/`glab`/`git_ops.sh pr-create`) | `pr` | `sync-pr N` | `needs-review` | back-link comment + ensure `Closes #N` |
+| `git commit` / `git_ops.sh commit` | `commit` | `sync-commit HEAD` | `in-progress` | back-link comment (only advances issues already `planned`) |
+| any other Bash command | `none` | — | — | no-op (exit 0) |
+
+**Key properties**:
+
+- **Opt-in & reversible**: `install_issue_hooks.sh --enable/--remove` flips the
+  `tool_policies.{pr-issue-sync,commit-issue-sync}.enabled` gate and idempotently
+  adds/removes the PostToolUse entry in `~/.claude/settings.json`. `--native` adds a
+  guarded `git post-commit` hook (refuses to clobber a pre-existing one).
+- **Fail-open**: `sync-pr`/`sync-commit` always exit 0; an internal `__inner`
+  re-exec is bounded by `hook_timeout_seconds` (default 5s) so a slow tracker
+  degrades to a warning — a re-run heals it (FR-017).
+- **Idempotent**: comment back-links carry a `<!-- issue-support:sync v1 ... -->`
+  marker; `Closes #N` and label transitions are skipped when already satisfied.
+- **Forward-only lifecycle**: `planned → in-progress → needs-review → done` — a
+  transition never moves an issue backward (rank check in `transition_issue`).
+- **Issue resolution**: a linked issue is found from the branch numeric prefix
+  (`017-foo` → `#17`), `#N` refs in the PR/MR body, and commit-message references.
+
+---
+
+## Autonomous Issue Developer (/auto-issue-dev)
+
+How `/auto-issue-dev` (engine: `auto_issue_dev.sh`) develops **exactly one** opted-in
+issue per invocation and opens a PR for review — never merging. `/loop` re-runs the
+skill with fresh context for the next issue. Selection is opt-in (the `auto-dev`
+label) and dependency-aware: issues with unmet `depends on #N` / `blocked by #N`
+references are tagged `blocked-dependency` and skipped. Status sync and `Closes #N`
+are delegated to the issue-linking hooks (above).
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart TD
+    classDef input fill:#f0f9ff,stroke:#0284c7,color:#0c4a6e
+    classDef process fill:#f0fdf4,stroke:#16a34a,color:#14532d
+    classDef decision fill:#fef3c7,stroke:#d97706,color:#78350f
+    classDef success fill:#22c55e,stroke:#166534,color:#fff
+    classDef warning fill:#eab308,stroke:#a16207,color:#fff
+    classDef stop fill:#e5e7eb,stroke:#6b7280,color:#374151
+
+    LOOP["/loop /auto-issue-dev<br/>(fresh context per run)"]:::input
+    PREFLIGHT["Preflight:<br/>install_issue_hooks.sh --enable<br/>+ gh/glab auth check"]:::process
+
+    NEXT["auto_issue_dev.sh next-issue --json<br/>list 'auto-dev' open issues,<br/>drop 'blocked-dependency',<br/>oldest-first"]:::process
+    DEPCHECK{"check-deps:<br/>unmet #N refs?"}:::decision
+    MARK_DEP["mark-dependency<br/>add 'blocked-dependency' label<br/>+ deduped comment, skip"]:::warning
+
+    READY{"Ready issue<br/>found?"}:::decision
+    STOP_EMPTY["Exit 3 → announce<br/>'queue empty', STOP"]:::stop
+
+    BRANCH["git switch -c N-slug<br/>(numeric prefix links #N)"]:::process
+    TDD["test-driven-development:<br/>failing test → implement → green"]:::process
+    VERIFY{"/verify<br/>tests + security pass?"}:::decision
+
+    PR["git_ops.sh pr-create<br/>→ PR hook injects Closes #N,<br/>moves #N to needs-review"]:::success
+    DRAFT["pr-create --draft [WIP]<br/>+ mark-blocked (needs-human label)"]:::warning
+    SUMMARY["Print one-line summary;<br/>STOP (one issue per run)"]:::stop
+
+    LOOP --> PREFLIGHT --> NEXT
+    NEXT --> READY
+    READY -->|No| STOP_EMPTY
+    READY -->|candidate| DEPCHECK
+    DEPCHECK -->|unmet| MARK_DEP
+    MARK_DEP --> NEXT
+    DEPCHECK -->|all met| BRANCH
+    BRANCH --> TDD --> VERIFY
+    VERIFY -->|Yes| PR
+    VERIFY -->|No / stuck| DRAFT
+    PR --> SUMMARY
+    DRAFT --> SUMMARY
+```
+
+**Engine subcommands** (`auto_issue_dev.sh`, wraps `git_ops.sh`):
+
+| Subcommand | Behavior | Exit |
+|------------|----------|------|
+| `next-issue [--json]` | First READY `auto-dev` issue (oldest-first, deps met) | `0` ready / `3` none |
+| `check-deps <N> [--json]` | Parse `depends on / blocked by / requires / needs #N`; verify each ref is closed/merged | `0` ready / `2` unmet / `1` missing |
+| `mark-blocked <N> <reason>` | Add `needs-human` label + deduped comment (fail-open) | `0` |
+| `mark-dependency <N> <refs>` | Add `blocked-dependency` label + deduped comment (fail-open) | `0` |
+
+**Invariants**:
+
+- **Never merges** — stops at PR-open; a human reviews and merges.
+- **One issue per invocation** — the loop lives in `/loop`, not inside the skill.
+- **Opt-in only** — issues without the `auto-dev` label are never touched.
+- **On failure** — push WIP, open a **draft** PR (no `Closes`), and `mark-blocked`
+  so a human inspects partial work; if there are no commits, skip the draft.
+- **Status hand-off** — `planned → in-progress → needs-review` and `Closes #N` are
+  applied by the issue-linking hooks, not by this engine (see previous section).
+
+**Labels** (`labels.yml`): `auto-dev` (opt-in selection), `blocked-dependency`
+(unmet dependency, excluded until the blocker merges), `needs-human` (auto-dev
+could not complete; needs a human).
+
+---
+
 ## Label Management Architecture
 
 How the canonical label registry drives consistent label provisioning across GitHub, GitLab, and Linear.
@@ -1333,16 +1505,19 @@ flowchart TB
     LABELS --> HEALTH
 ```
 
-**Canonical Labels** (5 labels, 3 platforms):
+**Canonical Labels** (3 platforms):
 
 | Label | Color | Platforms | Used By |
 |-------|-------|-----------|---------|
 | `planned` | `#1D76DB` (Blue) | GitHub, GitLab, Linear | /plan-manage create |
-| `in-progress` | `#FBCA04` (Yellow) | GitHub, GitLab, Linear | /plan-manage execute |
-| `needs-review` | `#E3A21A` (Orange) | GitHub, GitLab, Linear | /issue-triage |
+| `in-progress` | `#FBCA04` (Yellow) | GitHub, GitLab, Linear | /plan-manage execute, commit-issue-sync |
+| `needs-review` | `#E3A21A` (Orange) | GitHub, GitLab, Linear | /issue-triage, pr-issue-sync |
 | `done` | `#0E8A16` (Green) | GitHub, GitLab, Linear | /plan-manage execute |
 | `follow-up` | `#D4C5F9` (Lavender) | GitHub, GitLab, Linear | /issue-triage |
 | `future` | `#C2E0C6` (Green) | GitHub, GitLab, Linear | /issue-prioritize |
+| `auto-dev` | (opt-in) | GitHub, GitLab, Linear | /auto-issue-dev (selection) |
+| `needs-human` | (flag) | GitHub, GitLab, Linear | /auto-issue-dev (mark-blocked) |
+| `blocked-dependency` | (flag) | GitHub, GitLab, Linear | /auto-issue-dev (mark-dependency) |
 
 **Deprecated**: `processed` (replaced by `done`)
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -2,7 +2,7 @@
 
 > Building custom commands for Claude Code with Manifest
 
-**Last Updated**: 2026-06-10
+**Last Updated**: 2026-06-15
 **Audience**: Command developers, advanced users
 **Prerequisites**: Manifest installed, basic understanding of Markdown and Bash
 
@@ -54,6 +54,7 @@ frontmatter is the authoritative name and description.
 | `/version-pin` | Enforce specific, hashed version pins in dependency files (auto-fix on demand; warn-only save hook) | ALWAYS (Tier 1) |
 | `/pr-review` | Review all open PRs and recommend a disposition per PR (analysis-only) | NO |
 | `/branch-clean` | Prune merged/gone/stale branches safely (dry-run by default, local-only) | CONDITIONAL (--apply) |
+| `/repo-hygiene` | Review-then-confirm cleanup sweep of open PRs and stale/merged/gone branches (GitHub/GitLab/local) | CONDITIONAL (close/prune path) |
 | `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default); requires SkillClaw enabled | NO |
 | `/pass-cli` | Retrieve credentials from Proton Pass vaults via `pass-cli` agent CLI | NO |
 | `/spec-review` | Independent Antigravity (agy) cross-reference of spec/plan/tasks for internal consistency; on-demand or via fail-open PostToolUse save hook (content-hash debounced, detached); analysis-only; works with speckit and superpowers layouts; silent-mode findings land in `.spec-review/feedback.md` | NO |
@@ -67,6 +68,7 @@ frontmatter is the authoritative name and description.
 | `/scaffold` | Initialize new projects with quality gates and Manifest integration | NO |
 | `/ux-review` | UX audit: accessibility, responsive design, performance budgets | NO |
 | `/verify` | Run linters, tests, and security scans in parallel | CONDITIONAL |
+| `/token-benchmark` | Measure Manifest context token overhead and quality delta across providers; regenerates `docs/TOKEN_BENCHMARK.md` | NO |
 
 **CLI tool** (installed to `~/.local/bin/`):
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 > Complete documentation index for the Manifest parallel agent orchestration framework
 
-**Last Updated**: 2026-06-12
+**Last Updated**: 2026-06-15
 
 ---
 
@@ -55,7 +55,7 @@
 
 | File | Description | Last Updated | Status |
 |------|-------------|--------------|--------|
-| [README.md](../README.md) | Project overview and quick start | 2026-06-12 | ✅ |
+| [README.md](../README.md) | Project overview and quick start | 2026-06-15 | ✅ |
 | [CLAUDE.md](../CLAUDE.md) | AI assistant context for the repository | 2026-02-11 | ✅ |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | How to contribute to the project | 2026-05-31 | ✅ |
 | [CHANGELOG.md](../CHANGELOG.md) | Version history and release notes | 2026-05-31 | ✅ |
@@ -67,15 +67,16 @@
 | [GETTING_STARTED.md](GETTING_STARTED.md) | First-time user guide | 2026-06-12 | ✅ |
 | [CONFIGURATION.md](CONFIGURATION.md) | Configuration reference | 2026-06-12 | ✅ |
 | [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Common issues and solutions | 2026-06-12 | ✅ |
-| [COMMANDS.md](COMMANDS.md) | Built-in commands and how to build custom ones | 2026-06-10 | ✅ |
+| [COMMANDS.md](COMMANDS.md) | Built-in commands and how to build custom ones | 2026-06-15 | ✅ |
 
 ### Technical Documentation
 
 | File | Description | Last Updated | Status |
 |------|-------------|--------------|--------|
-| [ARCHITECTURE_DIAGRAMS.md](ARCHITECTURE_DIAGRAMS.md) | Visual system documentation | 2026-06-12 | ✅ |
+| [ARCHITECTURE_DIAGRAMS.md](ARCHITECTURE_DIAGRAMS.md) | Visual system documentation (19 Mermaid diagrams) | 2026-06-15 | ✅ |
 | [SKILLCLAW.md](SKILLCLAW.md) | SkillClaw session-capture and skill-evolution guide | 2026-06-08 | ✅ |
 | [SPEC-SYSTEMS.md](SPEC-SYSTEMS.md) | Map of the four spec/plan systems and when to use each | 2026-06-10 | ✅ |
+| [TOKEN_BENCHMARK.md](TOKEN_BENCHMARK.md) | Manifest context token overhead and quality delta across providers (`/token-benchmark`) | 2026-06-13 | ✅ |
 | [METRICS.md](METRICS.md) | Agent performance dashboard template (`/dashboard`) | 2026-02-11 | ✅ |
 | [KNOWLEDGE_BASE.md](KNOWLEDGE_BASE.md) | Auto-generated captured learnings (`learning_capture.sh sync-docs`) | 2026-02-13 | ✅ |
 | [PRE_COMMIT.md](PRE_COMMIT.md) | Pre-commit hook reference | 2026-02-05 | ✅ |
@@ -167,6 +168,11 @@ services:
 
 **Recent Additions**:
 
+- ✅ 2026-06-15: Documentation refresh for autonomous issue development and issue-linking
+  hooks — new `/auto-issue-dev`, `/repo-hygiene`, `/pr-issue-sync`, `/commit-issue-sync`
+  entries; two new architecture diagrams (issue-linking hooks; autonomous issue developer,
+  now 19 total); added `/token-benchmark` + TOKEN_BENCHMARK.md to the hub; corrected skill
+  and test counts in README
 - ✅ 2026-06-12: Documented the OAuth CLI fallback (SDK vs CLI backend selection for
   Claude/Gemini), `MODEL_CHECK_PROBE=1` live model-pin verification, and the honest
   `check_status.sh` pin summary — README, architecture diagrams,


### PR DESCRIPTION
## What

`/docs-all` refresh (docs-readme → docs-diagrams → docs-improve) bringing documentation in line with recently merged work: autonomous issue developer (`/auto-issue-dev`), repo-hygiene sweep, issue-linking git hooks, and the token cost benchmark.

## Changes

- **README.md** — document `/auto-issue-dev`, `/repo-hygiene`, and the issue-linking hooks (`pr-issue-sync` / `commit-issue-sync`); link the token benchmark doc; list the new issue-hook scripts in the tree; correct stale counts (74 skills, 310 Python / 410 Bats tests) and the Last Updated date.
- **docs/ARCHITECTURE_DIAGRAMS.md** — two new Mermaid diagrams (issue-linking hooks flow; autonomous issue developer), plus TOC, label-table (`auto-dev` / `needs-human` / `blocked-dependency`), and date refresh (19 diagrams total).
- **docs/COMMANDS.md** — add `/repo-hygiene` and `/token-benchmark` rows (verified against `command_config.yml` tool policies).
- **docs/README.md** — add `TOKEN_BENCHMARK.md` to the hub, correct diagram count and hub dates.

## Verification

- Counts re-measured live: 74 skills (dirs with `SKILL.md`), 310 Python tests (`pytest --co`), 410 Bats tests.
- `markdownlint-cli2` with CI globs (`README.md`, `docs/*.md`): **0 errors** (fixed one MD013 line-length wrap).
- Mermaid diagrams validated (`valid: true`).
- All internal doc links resolve.

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)