### PR TITLE
feat(audit-log): append-only JSONL audit trail with secret redaction

### DIFF
--- a/.skillshare/skills/auto-issue-dev/SKILL.md
+++ b/.skillshare/skills/auto-issue-dev/SKILL.md
@@ -43,7 +43,13 @@ this skill with fresh context for the next issue.
    - **Failure/stuck** → push WIP and open a **draft**:
      `git_ops.sh pr-create --draft --title "[WIP] <...>" --body "Partial; needs human."`
      then `auto_issue_dev.sh mark-blocked <N> "<one-line reason>"`.
-7. **Summary.** Print one line: issue, outcome (PR # or draft), and skip count.
+7. **Audit.** After determining the outcome, append one record to the audit log:
+   ```bash
+   configs/claude/scripts/audit_log.sh append \
+     "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"issue\":N,\"action\":\"<pr-opened|draft-pr|blocked>\",\"outcome\":\"<PR #NNN or draft or blocked: reason>\",\"reason\":\"<selection reason>\",\"skipped_dependency\":K}"
+   ```
+   The script redacts secrets before writing and fails open — a write failure never blocks the run.
+8. **Summary.** Print one line: issue, outcome (PR # or draft), and skip count.
 
 ## Notes
 

--- a/configs/claude/scripts/audit_log.sh
+++ b/configs/claude/scripts/audit_log.sh
@@ -19,7 +19,7 @@ text = sys.argv[1] if len(sys.argv) > 1 else ""
 PATTERNS = [
     (r"(ghp|gho|github_pat)_[A-Za-z0-9_]{20,}", "<REDACTED:github-token>"),
     (r"sk-ant-[A-Za-z0-9_-]{20,}",              "<REDACTED:anthropic-key>"),
-    (r"sk-[A-Za-z0-9]{20,}",                     "<REDACTED:api-key>"),
+    (r"sk-[A-Za-z0-9_-]{20,}",                   "<REDACTED:api-key>"),
     (r"(?i)(password|passwd|secret|token|api[_-]?key)\s*[:=]\s*\S+", r"\1=<REDACTED>"),
     (r"(?i)Bearer\s+[A-Za-z0-9\-._~+/]+=*",     "Bearer <REDACTED>"),
 ]
@@ -47,7 +47,10 @@ cmd_append() {
     local record="${1:-}"
     [[ -n "${record}" ]] || { err "append: record required"; return 0; }
     local redacted
-    redacted="$(cmd_redact "${record}" 2>/dev/null || printf '%s' "${record}")"
+    if ! redacted="$(cmd_redact "${record}" 2>/dev/null)"; then
+        err "WARNING: redaction failed; skipping audit append to prevent secret leak"
+        return 0
+    fi
     local dir
     dir="$(dirname "${AUDIT_FILE}")"
     mkdir -p "${dir}" 2>/dev/null || true

--- a/configs/claude/scripts/audit_log.sh
+++ b/configs/claude/scripts/audit_log.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# audit_log.sh — append-only JSONL audit writer for /auto-issue-dev
+#
+# Subcommands:
+#   append <json>   Redact known secret patterns and append record; exit 0 (fail-open)
+#   redact <text>   Emit redacted version of text on stdout; exit 0
+#
+# Env: AUTO_ISSUE_DEV_AUDIT_FILE (default: ~/.claude/auto_issue_dev_audit.jsonl)
+
+set -euo pipefail
+
+err() { echo "audit-log: $*" >&2; }
+
+AUDIT_FILE="${AUTO_ISSUE_DEV_AUDIT_FILE:-${HOME}/.claude/auto_issue_dev_audit.jsonl}"
+
+REDACT_PY='
+import sys, re
+text = sys.argv[1] if len(sys.argv) > 1 else ""
+PATTERNS = [
+    (r"(ghp|gho|github_pat)_[A-Za-z0-9_]{20,}", "<REDACTED:github-token>"),
+    (r"sk-ant-[A-Za-z0-9_-]{20,}",              "<REDACTED:anthropic-key>"),
+    (r"sk-[A-Za-z0-9]{20,}",                     "<REDACTED:api-key>"),
+    (r"(?i)(password|passwd|secret|token|api[_-]?key)\s*[:=]\s*\S+", r"\1=<REDACTED>"),
+    (r"(?i)Bearer\s+[A-Za-z0-9\-._~+/]+=*",     "Bearer <REDACTED>"),
+]
+for pat, repl in PATTERNS:
+    text = re.sub(pat, repl, text)
+sys.stdout.write(text)
+'
+
+usage() {
+    cat <<'USAGE'
+Usage: audit_log.sh <subcommand> [args]
+
+  append <json>   Redact and append one record to the audit log; exit 0 (fail-open)
+  redact <text>   Emit redacted version of text on stdout; exit 0
+
+Env: AUTO_ISSUE_DEV_AUDIT_FILE (default: ~/.claude/auto_issue_dev_audit.jsonl)
+USAGE
+}
+
+cmd_redact() {
+    python3 -c "${REDACT_PY}" "${1:-}"
+}
+
+cmd_append() {
+    local record="${1:-}"
+    [[ -n "${record}" ]] || { err "append: record required"; return 0; }
+    local redacted
+    redacted="$(cmd_redact "${record}" 2>/dev/null || printf '%s' "${record}")"
+    local dir
+    dir="$(dirname "${AUDIT_FILE}")"
+    mkdir -p "${dir}" 2>/dev/null || true
+    printf '%s\n' "${redacted}" >> "${AUDIT_FILE}" 2>/dev/null \
+        || err "WARNING: could not append to ${AUDIT_FILE} (audit record lost)"
+    return 0
+}
+
+main() {
+    local sub="${1:-}"; shift || true
+    case "${sub}" in
+        --help|-h|help) usage; exit 0 ;;
+        append)         cmd_append "$@"; exit 0 ;;
+        redact)         cmd_redact "$@"; exit 0 ;;
+        *) err "unknown subcommand: ${sub:-<none>}"; usage >&2; exit 64 ;;
+    esac
+}
+
+main "$@"

--- a/tests/bats/audit_log.bats
+++ b/tests/bats/audit_log.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# Tests for configs/claude/scripts/audit_log.sh
+
+SCRIPT="$BATS_TEST_DIRNAME/../../configs/claude/scripts/audit_log.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
+    TMP=$(mktemp -d "$BATS_TMPDIR/audit_log.XXXXXX")
+    export AUTO_ISSUE_DEV_AUDIT_FILE="$TMP/audit.jsonl"
+}
+teardown() { [[ -n "$TMP" && -d "$TMP" ]] && rm -rf "$TMP"; }
+
+# --- CLI surface ---
+
+@test "--help exits 0 and prints usage" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"append"* ]]
+    [[ "$output" == *"redact"* ]]
+}
+
+@test "unknown subcommand exits non-zero" {
+    run "$SCRIPT" bogus
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"audit-log:"* ]]
+}
+
+# --- redact subcommand ---
+
+@test "redact: masks GitHub PAT (ghp_...)" {
+    run "$SCRIPT" redact '{"token":"ghp_abcdefghijklmnopqrstuvwxyz123456"}'
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"ghp_"* ]]
+    [[ "$output" == *"REDACTED"* ]]
+}
+
+@test "redact: masks GitHub OAuth token (gho_...)" {
+    run "$SCRIPT" redact '{"auth":"gho_abcdefghijklmnopqrstuvwxyz123456"}'
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"gho_"* ]]
+    [[ "$output" == *"REDACTED"* ]]
+}
+
+@test "redact: masks Anthropic API key (sk-ant-...)" {
+    run "$SCRIPT" redact 'key=sk-ant-api03-aaaabbbbccccddddeeeeffffgggghhhh'
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"sk-ant-"* ]]
+    [[ "$output" == *"REDACTED"* ]]
+}
+
+@test "redact: masks OpenAI-style API key (sk-...)" {
+    run "$SCRIPT" redact 'key=sk-aaaaaabbbbbbccccccddddddeeeeeeffffffffgggggghh'
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"sk-aaaaa"* ]]
+    [[ "$output" == *"REDACTED"* ]]
+}
+
+@test "redact: masks generic token=value pattern" {
+    run "$SCRIPT" redact 'token=supersecret123'
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"supersecret123"* ]]
+    [[ "$output" == *"REDACTED"* ]]
+}
+
+@test "redact: masks Bearer authorization header" {
+    run "$SCRIPT" redact 'Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig'
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"eyJhbGci"* ]]
+    [[ "$output" == *"REDACTED"* ]]
+}
+
+@test "redact: passes clean text unchanged" {
+    run "$SCRIPT" redact '{"issue":42,"action":"pr-opened","outcome":"PR #99"}'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"issue":42'* ]]
+    [[ "$output" == *'"action":"pr-opened"'* ]]
+    [[ "$output" != *"REDACTED"* ]]
+}
+
+# --- append subcommand ---
+
+@test "append: creates audit file and writes one JSON line" {
+    run "$SCRIPT" append '{"issue":1,"action":"pr-opened"}'
+    [ "$status" -eq 0 ]
+    [ -f "$AUTO_ISSUE_DEV_AUDIT_FILE" ]
+    [ "$(wc -l < "$AUTO_ISSUE_DEV_AUDIT_FILE")" -eq 1 ]
+    python3 -c "import json; json.loads(open('$AUTO_ISSUE_DEV_AUDIT_FILE').read())"
+}
+
+@test "append: second call appends without mutating first line" {
+    "$SCRIPT" append '{"issue":1,"action":"pr-opened"}'
+    first="$(head -1 "$AUTO_ISSUE_DEV_AUDIT_FILE")"
+    run "$SCRIPT" append '{"issue":2,"action":"draft-pr"}'
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$AUTO_ISSUE_DEV_AUDIT_FILE")" -eq 2 ]
+    [ "$(head -1 "$AUTO_ISSUE_DEV_AUDIT_FILE")" = "$first" ]
+}
+
+@test "append: redacts secrets present in the record before writing" {
+    run "$SCRIPT" append '{"issue":3,"token":"ghp_abcdefghijklmnopqrstuvwxyz123456"}'
+    [ "$status" -eq 0 ]
+    [ -f "$AUTO_ISSUE_DEV_AUDIT_FILE" ]
+    ! grep -q "ghp_" "$AUTO_ISSUE_DEV_AUDIT_FILE"
+    grep -q "REDACTED" "$AUTO_ISSUE_DEV_AUDIT_FILE"
+}
+
+@test "append: fails open when file path is not writable (exit 0, no crash)" {
+    export AUTO_ISSUE_DEV_AUDIT_FILE="/dev/full"
+    run "$SCRIPT" append '{"issue":4,"action":"pr-opened"}'
+    [ "$status" -eq 0 ]
+}
+
+@test "append: fails open when parent directory cannot be created (exit 0)" {
+    export AUTO_ISSUE_DEV_AUDIT_FILE="/nonexistent-root/deeply/nested/audit.jsonl"
+    run "$SCRIPT" append '{"issue":5,"action":"pr-opened"}'
+    [ "$status" -eq 0 ]
+}

--- a/tests/bats/audit_log.bats
+++ b/tests/bats/audit_log.bats
@@ -55,6 +55,13 @@ teardown() { [[ -n "$TMP" && -d "$TMP" ]] && rm -rf "$TMP"; }
     [[ "$output" == *"REDACTED"* ]]
 }
 
+@test "redact: masks OpenAI sk-proj- key containing hyphens" {
+    run "$SCRIPT" redact 'key=sk-proj-abcdef1234567890abcdef1234567890'
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"sk-proj-"* ]]
+    [[ "$output" == *"REDACTED"* ]]
+}
+
 @test "redact: masks generic token=value pattern" {
     run "$SCRIPT" redact 'token=supersecret123'
     [ "$status" -eq 0 ]
@@ -114,4 +121,15 @@ teardown() { [[ -n "$TMP" && -d "$TMP" ]] && rm -rf "$TMP"; }
     export AUTO_ISSUE_DEV_AUDIT_FILE="/nonexistent-root/deeply/nested/audit.jsonl"
     run "$SCRIPT" append '{"issue":5,"action":"pr-opened"}'
     [ "$status" -eq 0 ]
+}
+
+@test "append: skips write and exits 0 when redaction fails (no unredacted secret written)" {
+    # Stub python3 to simulate redaction failure without breaking the shell itself
+    local fake_bin="$TMP/bin"
+    mkdir -p "$fake_bin"
+    printf '#!/bin/sh\nexit 1\n' > "$fake_bin/python3"
+    chmod +x "$fake_bin/python3"
+    PATH="$fake_bin:$PATH" run "$SCRIPT" append '{"issue":6,"secret":"sk-proj-abcdef1234567890abcdef"}'
+    [ "$status" -eq 0 ]
+    [ ! -f "$AUTO_ISSUE_DEV_AUDIT_FILE" ]
 }


### PR DESCRIPTION
## Summary

- New `configs/claude/scripts/audit_log.sh` with two subcommands:
  - `append <json>`: redacts known secret patterns before writing one JSONL record; always exits 0 (fail-open on locked/missing path)
  - `redact <text>`: standalone text redaction (GitHub tokens, Anthropic/OpenAI keys, Bearer headers, generic `token=value` pairs)
- Audit file defaults to `~/.claude/auto_issue_dev_audit.jsonl`; overridable via `AUTO_ISSUE_DEV_AUDIT_FILE`
- Updates `auto-issue-dev` skill to add a mandatory audit step (step 7) after every outcome — PR opened, draft, or blocked
- Additive: no change to issue selection or PR creation logic

## Test plan

- [x] `bats tests/bats/audit_log.bats` — 14/14 pass covering all acceptance criteria:
  - Append creates file and writes valid JSON
  - Second append doesn't mutate first line (append-only)
  - Secrets are redacted in written records
  - Fails open on unwritable path (exit 0)
  - Fails open when parent directory cannot be created (exit 0)
  - Redaction covers GitHub PAT/OAuth, Anthropic key, OpenAI key, `token=value`, Bearer header
  - Clean text passes through unchanged
- [x] `shellcheck configs/claude/scripts/audit_log.sh` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #359