### PR TITLE
🛠️ Forge: Add pre-commit hook to prevent empty catch bindings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,6 +129,14 @@ repos:
         language: system
         pass_filenames: false
 
+      # Check for empty or bindingless catch blocks in JavaScript templates
+      - id: check-empty-catch
+        name: Check for empty catch blocks
+        entry: tests/lint/check_empty_catch.sh
+        language: system
+        types_or: [javascript, ts]
+        pass_filenames: true
+
       # Validate YAML config files
       - id: validate-yaml-configs
         name: Validate YAML config files

--- a/tests/lint/check_empty_catch.sh
+++ b/tests/lint/check_empty_catch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+found=0
+for f in "$@"; do
+    out=$(grep -nE "catch\s*\{" "$f" || true)
+    if [ -n "$out" ]; then
+        echo "Found empty/bindingless catch in $f:"
+        echo "$out"
+        echo "Please use 'catch (e) {' and explicitly handle the error."
+        found=1
+    fi
+done
+if [ "$found" -eq 1 ]; then
+  return 1 2>/dev/null || exit 1
+else
+  return 0 2>/dev/null || exit 0
+fi


### PR DESCRIPTION
This pull request adds a new pre-commit hook to automatically detect and flag empty or bindingless optional catch blocks (like `catch {`) in JavaScript and TypeScript templates.

### 💡 What:
- Created a new bash-based linter script `tests/lint/check_empty_catch.sh` that uses `grep` to identify `catch {` patterns.
- Registered the script in `.pre-commit-config.yaml` as a `system` language hook under the `repo: local` section targeting `javascript` and `ts` files.

### 🎯 Why:
As documented in the `Forge` architectural log (`.jules/forge.md`), using empty JavaScript optional catch bindings silently swallows exceptions during hook execution (like WebSocket initialization or HTTP event delivery). This obscures critical failures and violates explicit routing and graceful degradation constraints. The new automated check ensures that all catch statements explicitly capture the error object (`catch (e) { ... }`) to enforce proper logging and error handling.

### 🔬 Measurement:
- Verified the script correctly flags violations and exits with a non-zero code.
- Tested the hook integration via `pre-commit run check-empty-catch --all-files`.
- Ran the full `bats` and `pytest` suites to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [1293813147180181626](https://jules.google.com/task/1293813147180181626) started by @RB-chrismandich*