### PR TITLE
SkillClaw: evolve 8 skill(s)

### DIFF
--- a/.skillshare/skills/automation-rework-breakeven/SKILL.md
+++ b/.skillshare/skills/automation-rework-breakeven/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: automation-rework-breakeven
+description: Use when deciding whether a more-thorough-but-costlier automation or skill version is worth it — separate correctness from cost, model net tokens as rework-avoided minus extra spend, and measure the rework cost empirically instead of assuming it.
+---
+# Break-Even Analysis for a More-Correct, Costlier Automation
+
+When a v2 of a skill/automation is more correct but spends more tokens per run, "is it worth it?" is a measurable question, not a vibe. Distinct from `token-benchmark` (config-deployment overhead) and `skill-creator` benchmarking (raw pass/time/tokens): this models the *correctness-for-tokens trade* with an empirically measured rework cost.
+
+1. **Separate the two axes.** Correctness (pass rate) and cost (tokens/time) are independent — a version that "finds more" is not automatically cheaper. State both; never let a pass-rate win imply a token saving.
+2. **Compute extra spend.** Take per-run token means for each version (averaged across evals) and the delta. Project it over N runs — that is the known cost the costlier version must earn back.
+3. **Write the net model:** `net = runs × p × R − extra_spend`, where `p` = fraction of runs that would otherwise trigger a cleanup/follow-up, and `R` = tokens for one rework incident.
+4. **Measure R — do not assume it.** Run a recovery session: hand an agent the cheaper version's (incomplete/wrong) output and the original task, and have it discover and fix what was missed. Average 2-3 runs for `R ± spread`.
+5. **Apply the salvage-value insight.** A confidently-wrong output has near-zero salvage value, so rework often costs ≈ a fresh full run. That means the costlier version's small premium buys out a full-price redo — the math usually favors it once misses are real.
+6. **Report a verdict, not just deltas.** Compute the break-even rate `p* = extra_spend / R`, then compare it to the *observed* miss rate (e.g. from evals) to say plainly whether it nets positive and under what usage mix.
+7. **Persist the baseline to memory** (per-run costs, measured R, break-even rate, usage assumption) so future sessions don't re-derive it.
+

--- a/.skillshare/skills/cli-help-before-dependency-checks/SKILL.md
+++ b/.skillshare/skills/cli-help-before-dependency-checks/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: cli-help-before-dependency-checks
+description: Use when adding or auditing --help/--version/usage on a script or CLI — the help path must succeed before any config/state/dependency lookup, and be verified in a clean environment (empty HOME, fresh clone, CI), not just your already-configured machine.
+---
+# Make --help Work Before Any Dependency Check
+
+The classic invisible-locally / red-in-CI failure: help dies on a fresh clone because a required file or env var is resolved at the top of the script, before args are parsed.
+
+1. **Spot the failure mode.** A script resolves state at top level — locating a required config file, asserting an env var, connecting to a service — and exits nonzero *before* parsing args. `script --help` then fails for anyone lacking that state (fresh clone, CI, new contributor) while passing for you because your `~/.config`/HOME is set up.
+2. **Reorder the entry point.** Handle `-h|--help|--version` and the `help` subcommand FIRST — before, or as an explicit early branch within, the dependency/state resolution block.
+3. **Use correct streams and codes.** Help/usage on request → stdout, exit 0. Usage-on-bad-input and errors → stderr, nonzero. Keep added help concise.
+4. **Verify in a stripped environment, not your configured one.** `env HOME=/tmp/empty-$$ bash ./script --help; echo $?` and also from a different CWD. A pass with your real HOME is not evidence.
+5. **Pin it with a coverage test.** A test that runs every user-facing entry point's `--help` and asserts exit 0 + a `Usage` line on stdout — ideally under the same bare-env conditions CI uses. This is exactly the bug that only CI catches.
+6. **Document exemptions.** Internal helpers and non-user-invoked hook wrappers can be exempt — list them with rationale so the coverage test skips them deliberately, not silently.

--- a/.skillshare/skills/errexit-safe-shell-counters/SKILL.md
+++ b/.skillshare/skills/errexit-safe-shell-counters/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: errexit-safe-shell-counters
+description: Use when writing or debugging bash under `set -e` that increments counters with `((var++))`/`((n--))` — the arithmetic command returns exit 1 when its result is 0, silently aborting the script on the first increment from zero (and only on bash ≥4, so macOS bash 3.2 hides it until CI).
+---
+# Errexit-Safe Shell Counters
+
+Distinct from `shell-pipefail-subshell-audit` (pipefail + `$()` parsing empty input). This is the `((...))`-returns-1-on-zero trap that passes locally and dies in CI.
+
+1. **Know the trap.** In bash, `((expr))` and `let` return exit status 1 whenever the arithmetic result is `0`. `((count++))` is *post*-increment — it evaluates to the OLD value — so the very first `((count++))` when `count=0` evaluates to 0 and returns 1.
+2. **See why it aborts.** Under `set -e`/`set -euo pipefail`, that nonzero status kills the script — usually mid-loop, right after the action you just counted — giving a baffling silent exit with no error message.
+3. **Understand why it's CI-only.** bash 3.2 (default macOS `/bin/bash`) does NOT trip errexit on `((...))`; bash ≥4 (Linux, GitHub/GitLab runners) does. The suite is green on your Mac and red in CI.
+4. **Confirm empirically before touching code.** Run `bash -c 'set -e; v=0; ((v++)); echo survived; echo $?'` on `/bin/bash` AND a bash-5 (`/opt/homebrew/bin/bash`, or `brew install bash`). Divergent exit codes prove this bug.
+5. **Fix to an always-success form.** Replace `((var++))` with `var=$((var + 1))` (clearest, shellcheck-clean). Alternatives: `: $((var++))` or `((var++)) || true`.
+6. **Sweep, don't spot-fix.** `grep -rnE '\(\([a-zA-Z_]+(\+\+|--)\)\)' path/to/scripts/*.sh` — one zero-start counter anywhere is a latent abort. Fix every site.
+7. **Re-verify under bash ≥4 with errexit active**, run the affected tests, and consider a repo lint guard (sibling to any array-expansion guard) so the pattern can't return.

--- a/.skillshare/skills/false-green-check-audit/SKILL.md
+++ b/.skillshare/skills/false-green-check-audit/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: false-green-check-audit
+description: Use when writing or reviewing a health-check, status, validation, or CI gate that can SKIP verifying something (missing credential, unsupported provider, absent tool) — ensure a skipped/unverifiable check never renders as a green pass, and add a verification path through the credential or channel the user actually uses (e.g. an OAuth CLI, not an assumed API key).
+---
+# Audit Checks for False-Green (Skip ≠ Pass)
+
+When "it read as green but was actually broken," the failure was the checker that couldn't see the break, not just the broken thing. Close the blind spot, don't only fix the instance.
+
+1. **Find every degrade-instead-of-verify path.** Grep the checker for `SKIPPED`, `UNSUPPORTED`, "no credentials", `|| true`, early `return 0` on a missing precondition. Each is a candidate false-green: the thing was never checked, yet the summary may count it as fine.
+2. **Separate "verified OK" from "could not verify" in the summary.** The overall/green line is green only when checks actually passed; unverifiable checks render as a distinct warn/info state (e.g. "N unverified — run X to verify") with the remediation, never folded into the pass count. Count and surface every non-OK class (including always-UNSUPPORTED ones) — a reviewer or bot will correctly flag a summary that claims "all verified" while some checks were skipped.
+3. **Ask why it skipped.** Usually the check assumed one access path — an API key, a specific binary, a network listing endpoint — that the real environment lacks because the user authenticates differently (OAuth/subscription CLI login, SSO, a proxy). The blind spot is the gap between the assumed path and the real one.
+4. **Add verification through the channel the user actually uses.** If the API-key path is unavailable but an OAuth-authenticated CLI is on PATH, do a cheap live one-shot through that CLI (tiny call, `--version`, a model/identifier probe) and classify the result (reachable / not-found→stale / unclassifiable→still skip). Gate the live path behind an opt-in flag if it costs money or latency.
+5. **Harden the probe loop.** Redirect `</dev/null` so the probed CLI doesn't drain the iteration's stdin and check only the first item (see shell-sete-silent-abort-audit).
+6. **Regression-test the honesty property.** Assert that with the precondition absent, the summary does NOT print the green "all good" line, and that an unverifiable item is reported as unverified — not as pass.

--- a/.skillshare/skills/merge-stacked-pr-chain/SKILL.md
+++ b/.skillshare/skills/merge-stacked-pr-chain/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: merge-stacked-pr-chain
+description: Use when merging a chain of stacked PRs (each based on the previous branch, not main) via the gh/glab CLI — `gh pr merge --delete-branch` on a parent CLOSES the dependent child instead of retargeting it; merge keeping the branch, retarget the child, then delete.
+---
+# Merge a Stacked PR Chain Safely
+
+Distinct from `clean-pr-from-stale-base` (rebasing one branch onto a fresh base) and `reset-reapply-clean-pr` (untangling tangled history). This is the merge-time choreography for an already-open stack.
+
+1. **Map the stack first.** `for n in <PRs>; do gh pr view $n --json number,baseRefName,headRefName; done`. Confirm the chain: A(base `main`) ← B(base A) ← C(base B) …
+2. **Ensure CI runs on every PR before merging.** A workflow keyed `on: pull_request: branches: [main]` only triggers for PRs targeting `main`; stacked children targeting a non-main base show "no checks reported" and can't be gated. Drop the base filter (`on: pull_request:` with no `branches:`) so each story-PR is independently green.
+3. **Merge bottom-up, one at a time.** For each parent: wait for green + `MERGEABLE`, then `gh pr merge <parent> --merge` **without** `--delete-branch`.
+4. **Immediately retarget the child** onto the surviving base: `gh pr edit <child> --base main`; verify with `gh pr view <child> --json baseRefName`.
+5. **Only then delete the merged parent branch:** `git push origin --delete <parent-branch>`. Order is the whole point — deleting before retargeting triggers the cascade.
+6. **Recover a cascaded-closed child.** If you already deleted a base and GitHub auto-closed the child (a closed PR can't be retargeted or reopened while its base ref is gone): restore the ref with `git push origin <merged-sha>:refs/heads/<deleted-base>`, then `gh pr reopen <child>`, `gh pr edit <child> --base main`, then delete the temp ref.
+7. **Let each retarget re-run CI** against its new base; wait for green before merging it.
+8. **Finish clean.** Sync local `main` (`git checkout main && git pull`) and prune the merged local branches.

--- a/.skillshare/skills/pin-known-bug-test-survives-fix/SKILL.md
+++ b/.skillshare/skills/pin-known-bug-test-survives-fix/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: pin-known-bug-test-survives-fix
+description: Use when adding a test around behavior you are NOT fixing now (a known bug or intentional placeholder) — make the assertion tolerate the post-fix output too, so fixing the bug later doesn't break the suite, and anchor the real invariant separately.
+---
+# Pin Known-Buggy Behavior Without Breaking on the Fix
+
+A naive `assert "<buggy value>"` becomes a tripwire that fails the day someone fixes the bug — quietly discouraging the fix. Write the pin so the eventual fix passes.
+
+1. **Recognize the case.** You're adding coverage to document current behavior of code with a known defect (or deliberate placeholder) that is out of scope for this change.
+2. **Assert an alternation, not a single value.** Accept current-buggy OR expected-after-fix: e.g. `assert_output --regexp "0 created, (2 updated, 0 unchanged|1 updated, 1 unchanged)"` — buggy form first, fixed form second.
+3. **Comment the intent at the assertion.** Name the bug, the current value, and the value the fix should produce, so the alternation reads as deliberate, not sloppy.
+4. **Anchor the real invariant elsewhere so the test keeps teeth.** Pin a checksum of the actual output (`shasum`) or a property that holds regardless of the buggy counter. The tolerant assertion documents the defect; the checksum proves the bytes are correct.
+5. **Don't leak test-framework state.** If a helper uses bats `run` (which overwrites `$output`/`$status`), don't assert on `$output` *after* calling it — pass the expected value INTO the helper as a parameter instead.
+6. **Track the underlying bug separately** (issue or follow-up task) so "pinned" doesn't decay into "forgotten."
+7. **Tighten on fix.** When the bug is fixed, the alternation already passes — collapse it to the single expected value in that same PR.

--- a/.skillshare/skills/reproduce-gated-ci-failure-locally/SKILL.md
+++ b/.skillshare/skills/reproduce-gated-ci-failure-locally/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: reproduce-gated-ci-failure-locally
+description: Use when a CI job fails but the run's logs are gated ("still in progress") or hard to read — pinpoint the failing step via the jobs API and reproduce that step's commands locally from the workflow file.
+---
+# Reproduce a Gated CI Failure Locally
+
+`gh run view --log-failed` often refuses with "run still in progress" while other jobs finish, leaving you blind. You don't need the logs — per-step conclusions and the workflow definition are enough to find and reproduce the failure offline. Broader than `ci-lint-config-drift` (that's the config-override sub-case); this applies to any failing step.
+
+1. **Get per-step conclusions mid-run.** `gh api repos/<owner>/<repo>/actions/jobs/<job_id> --jq '.steps[] | "\(.number). \(.name): \(.status) \(.conclusion)"'` returns each step's status/conclusion even before the whole run completes — naming the exact failing step.
+2. **Pin the commit the run used.** `gh run view <run_id> --json headSha` — reproduce against that same tree, not your latest local edits.
+3. **Find the named step in the workflow.** Open `.github/workflows/*.yml`; the step name from step 1 maps directly to a `run:`/`uses:` block. Read it verbatim.
+4. **Run that step's commands locally, in order.** For a multi-command step, execute one line at a time to isolate which fails and why.
+5. **Check the generated-artifact-drift class first.** A very common gate is "regenerated file is in sync with its source" (cursor rules ↔ skills, lockfile ↔ manifest, codegen ↔ schema). Run the generator and `git status --porcelain <output-dir>`; a new untracked file or diff IS the failure — fix by committing the regenerated artifact.
+6. **Confirm the step's scope before chasing a fix.** Read the step's globs/config path; a file outside CI's globs is not the cause (avoid false positives). For lint that passes locally but fails in CI, see `ci-lint-config-drift`.
+7. **Fix at the source, commit, and verify the fresh run** with `gh run watch <run_id> --exit-status` — never assume the fix took.

--- a/.skillshare/skills/shell-sete-silent-abort-audit/SKILL.md
+++ b/.skillshare/skills/shell-sete-silent-abort-audit/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: shell-sete-silent-abort-audit
+description: Use when a bash script under `set -e` (or `set -euo pipefail`) aborts, exits non-zero, or misbehaves in production but passes tests and small inputs — audit helper functions and sourced libs for three non-`$()` triggers. Complements shell-pipefail-subshell-audit (which covers `$()` parsing empty input).
+---
+# Audit Shell Helpers for Production-Only Aborts Tests Miss
+
+Three control-flow hazards that pass small fixtures and abort in production. Same family as `shell-pipefail-subshell-audit`, but the trigger is control flow, not `$()` parsing.
+
+1. **Recognize the signature.** Script exits non-zero (1, or 141 for SIGPIPE) right after a benign step (a "Deployed files" listing, a cleanup), with no error output, skipping everything after it — or a loop processes only its first item. Tests pass because fixtures are small, the file exists, or there's no real subprocess. The failing statement is often three files deep in a sourced helper that "can't fail."
+2. **Trailing-conditional return.** Scan every function and sourced script for a LAST statement of the form `[[ cond ]] && action` or `cmd && action`. When the guard is false the `&&` list returns non-zero, becomes the function's exit status, and under `set -e` in the caller aborts the whole script. This was a launchd-cleanup `[[ -f "$plist" ]] && {...}` that killed every bootstrap run silently. Fix: end on explicit `return 0`/`true`, guard with `|| true`, or rewrite as `if ... then ... fi`.
+3. **Subprocess draining a while-read loop's stdin.** Scan for `… | while IFS=… read …; do … <cmd> …; done` where `<cmd>` is a subprocess that reads stdin (ssh, an LLM/agent CLI, ffmpeg). It consumes the loop's piped stdin, so only the first iteration runs. Fix: redirect the inner command — `cmd </dev/null` — or read on a separate FD. Reproduce with a fake binary that does `cat >/dev/null` and assert every item is processed.
+4. **SIGPIPE from head-truncated pipelines.** `producer | head -N | while …` — when `head` exits after N lines, `producer` dies of SIGPIPE (141). Harmless under bare `set -e`, fatal once `pipefail` is added. Buffer through a guarded command substitution, or, if pipefail isn't set, label it defensive — don't claim it's the active bug.
+5. **Audit the whole sourced chain.** A top-level `set -e` propagates into every sourced lib; check the last statement of each helper, not just the entrypoint.
+6. **Prove each fix red-first.** Write the failing test reproducing the production condition (absent file, large input, stdin-draining subprocess), then fix, then green. State the real mechanism in the test comment — never encode a disproven first hypothesis (e.g. "SIGPIPE under set -e" when it's actually only fatal under pipefail).


### PR DESCRIPTION
Auto-evolved by SkillClaw from Manifest Claude Code transcripts (4-day window), then adjudicated by a multi-agent workflow: **21 candidates → 8 keep** via independent per-candidate judging, adversarial refutation, and intra-batch dedup (9 refuted as redundant, 3 intra-batch dups, 1 folded into an existing skill).

Review each commit independently; drop a skill by reverting its commit.

**Skills (one commit each):**
- `errexit-safe-shell-counters` — `((v++))` returns 1 on zero under `set -e` (bash 3.2 vs 4+ macOS/CI divergence)
- `shell-sete-silent-abort-audit` — broader `set -e` silent-abort family (trailing `[[ ]] &&`, stdin-drained while-read, SIGPIPE 141)
- `false-green-check-audit` — a skipped/unverifiable check must never render green
- `cli-help-before-dependency-checks` — `--help` must resolve before config/env (survive a fresh clone / bare `HOME`)
- `pin-known-bug-test-survives-fix` — alternation assertion accepting buggy-OR-fixed output
- `reproduce-gated-ci-failure-locally` — `gh api .../actions/jobs/<id>` for per-step conclusions mid-run
- `merge-stacked-pr-chain` — stacked-PR merge choreography + cascaded-close recovery
- `automation-rework-breakeven` — `net = runs·p·R − extra_spend` with R measured empirically

🤖 Generated with [Claude Code](https://claude.com/claude-code)