### PR TITLE
🎨 Palette: Add rich color styling to status in CLI table output

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,0 @@
-## 2024-06-16 - Add rich styling to status in CLI table output
-
-**Learning:** The CLI tool outputs the agent status ("complete" / "failed") but doesn't utilize `rich` color tags
-for status text within the summary table in `orchestrator.py`, leading to poor visual contrast.
-**Action:** Enhance the `table.add_row` call to include color tags for the status string.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-06-16 - Add rich styling to status in CLI table output
+
+**Learning:** The CLI tool outputs the agent status ("complete" / "failed") but doesn't utilize `rich` color tags
+for status text within the summary table in `orchestrator.py`, leading to poor visual contrast.
+**Action:** Enhance the `table.add_row` call to include color tags for the status string.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,10 +1,13 @@
 # Palette's Journal
 
 ## 2026-02-06 - Initial Setup
+
 **Learning:** UX improvements in CLI tools are just as critical as web UIs.
-**Action:** When working on CLI scripts, prioritize readability (colors, spacing) and explicit user guidance (defaults, help text).
+**Action:** When working on CLI scripts, prioritize readability (colors, spacing)
+and explicit user guidance (defaults, help text).
 
 ## 2026-06-08 - Rich Terminal UI Persistence
+
 **Learning:** By default, rich `Progress` and `Live` instances leave their
 final output in the terminal scrollback, causing unnecessary clutter during
 repeated script executions.
@@ -13,5 +16,18 @@ automatically clear them upon completion, keeping the user's terminal history
 clean.
 
 ## 2026-06-10 - CLI Spinner Terminal UX
-**Learning:** In bash scripts, hiding the cursor for a cleaner spinner requires careful lifecycle management. Relying solely on an `EXIT` trap is insufficient, as `SIGINT` (Ctrl+C) bypasses it, leaving the user with a broken (invisible) cursor. Output buffering is also crucial to prevent standard output from clobbering the spinner line.
-**Action:** Always buffer output to a temp file, print it only on error, and trap `INT`, `TERM`, and `EXIT` to ensure `tput cnorm` restores the terminal cursor regardless of how the script terminates.
+
+**Learning:** In bash scripts, hiding the cursor for a cleaner spinner requires
+careful lifecycle management. Relying solely on an `EXIT` trap is insufficient,
+as `SIGINT` (Ctrl+C) bypasses it, leaving the user with a broken (invisible)
+cursor. Output buffering is also crucial to prevent standard output from
+clobbering the spinner line.
+**Action:** Always buffer output to a temp file, print it only on error, and
+trap `INT`, `TERM`, and `EXIT` to ensure `tput cnorm` restores the terminal
+cursor regardless of how the script terminates.
+
+## 2024-06-16 - Add rich styling to status in CLI table output
+
+**Learning:** The CLI tool outputs the agent status ("complete" / "failed") but doesn't utilize `rich` color tags
+for status text within the summary table in `orchestrator.py`, leading to poor visual contrast.
+**Action:** Enhance the `table.add_row` call to include color tags for the status string.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -463,7 +463,7 @@ class Orchestrator:
         """Print results as formatted table"""
         table = Table(title="Parallel Agent Results")
         table.add_column("Agent", style="cyan")
-        table.add_column("Status", style="green")
+        table.add_column("Status")
         table.add_column("Time", justify="right", style="yellow")
         table.add_column("Model", style="blue")
 
@@ -473,8 +473,12 @@ class Orchestrator:
             model = agent_result.get("model", "N/A")
 
             status_icon = "✔" if status == "complete" else "✗"
+            status_color = "green" if status == "complete" else "red"
             table.add_row(
-                agent_name.title(), f"{status_icon} {status}", duration, model
+                agent_name.title(),
+                f"[{status_color}]{status_icon} {status}[/{status_color}]",
+                duration,
+                model,
             )
 
         self.console.print(table)


### PR DESCRIPTION
💡 What:
Removed the hardcoded 'green' style from the Status column in the `orchestrator.py`
results table and wrapped the individual status strings with dynamic rich
color tags (green for complete, red for anything else). Also logged the UX
learning into the `.Jules/palette.md` journal.

🎯 Why:
Previously, even a 'failed' status would render with a green color due to the
column default, which provides misleading visual feedback to the user.

📸 Before/After:
Before: The word 'failed' was printed in green text.
After: The word 'failed' is printed in red text.

♿ Accessibility:
Improves visual affordance and cognitive accessibility by matching the color
semantics (red) to the negative system state (failure), rather than relying
solely on the textual word or a small icon that could be missed.

---
*PR created automatically by Jules for task [14783094329847443761](https://jules.google.com/task/14783094329847443761) started by @RB-chrismandich*