### PR TITLE
🛠️ Forge: Fix silently swallowed exceptions in hooks and hygiene gatherers

### DIFF
--- a/.skillshare/skills/ai-hooks-integration/scripts/runtime/cli_wrapper.py
+++ b/.skillshare/skills/ai-hooks-integration/scripts/runtime/cli_wrapper.py
@@ -114,8 +114,10 @@ def run_hook(hook_cmd: str, payload: dict) -> dict | None:
         )
         if result.stdout.strip():
             return json.loads(result.stdout)
-    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
-        pass
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError) as e:
+        print(f"Hook warning: {{e}}", file=sys.stderr)
+    except Exception as e:
+        print(f"Hook unexpected error: {{e}}", file=sys.stderr)
     return None
 
 

--- a/.skillshare/skills/ai-hooks-integration/scripts/runtime/detect_source.py
+++ b/.skillshare/skills/ai-hooks-integration/scripts/runtime/detect_source.py
@@ -42,6 +42,11 @@ TOOL_SIGNATURES = {
 MAX_DEPTH = 8
 
 
+def debug_log_err(msg: str) -> None:
+    """Log debug message if HOOK_DEBUG=1."""
+    if os.environ.get("HOOK_DEBUG") == "1":
+        print(f"[detect_source] {msg}", file=sys.stderr)
+
 def get_process_cmdline(pid: int) -> str:
     """Get the command line of a process by PID.
 
@@ -61,8 +66,10 @@ def get_process_cmdline(pid: int) -> str:
         try:
             # /proc/*/cmdline uses null bytes as separators
             return proc_cmdline.read_bytes().replace(b"\x00", b" ").decode("utf-8", errors="replace").strip()
-        except (PermissionError, OSError):
-            pass
+        except (PermissionError, OSError) as e:
+            debug_log_err(f"Failed to read cmdline for {pid}: {e}")
+        except Exception as e:
+            debug_log_err(f"Unexpected error reading cmdline for {pid}: {e}")
 
     # Fallback: use ps command (macOS/Linux)
     if sys.platform != "win32":
@@ -77,8 +84,10 @@ def get_process_cmdline(pid: int) -> str:
             )
             if result.returncode == 0:
                 return result.stdout.strip()
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-            pass
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+            debug_log_err(f"ps command failed for {pid}: {e}")
+        except Exception as e:
+            debug_log_err(f"Unexpected error running ps for {pid}: {e}")
 
     return ""
 
@@ -104,8 +113,10 @@ def get_parent_pid(pid: int) -> int | None:
                 parts = stat_content[last_paren + 1 :].split()
                 if len(parts) >= 2:
                     return int(parts[1])
-        except (PermissionError, OSError, ValueError):
-            pass
+        except (PermissionError, OSError, ValueError) as e:
+            debug_log_err(f"Failed to read stat for {pid}: {e}")
+        except Exception as e:
+            debug_log_err(f"Unexpected error reading stat for {pid}: {e}")
 
     # Fallback: use ps command
     if sys.platform != "win32":
@@ -122,8 +133,10 @@ def get_parent_pid(pid: int) -> int | None:
                 ppid = int(result.stdout.strip())
                 # Return None for init/launchd (pid 0 or 1)
                 return ppid if ppid > 1 else None
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError, ValueError):
-            pass
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError, ValueError) as e:
+            debug_log_err(f"ps command failed to get ppid for {pid}: {e}")
+        except Exception as e:
+            debug_log_err(f"Unexpected error getting ppid for {pid}: {e}")
 
     return None
 

--- a/.skillshare/skills/repo-hygiene/scripts/hygiene_gather.py
+++ b/.skillshare/skills/repo-hygiene/scripts/hygiene_gather.py
@@ -36,7 +36,11 @@ def err(msg: str) -> None:
 
 
 def run(cmd: list[str]) -> subprocess.CompletedProcess:
-    return subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True)
+    except Exception as e:
+        err(f"Command {' '.join(cmd)} failed: {e}")
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr=str(e))
 
 
 def git(*args: str) -> str:


### PR DESCRIPTION
🛠️ Forge: Fix silently swallowed exceptions in hooks and hygiene gatherers

Replaces brittle or silent `pass` exception blocks in `.skillshare/skills/ai-hooks-integration/scripts/runtime/cli_wrapper.py` and `.skillshare/skills/ai-hooks-integration/scripts/runtime/detect_source.py` with proper error routing and logging (to `sys.stderr`, or conditionally based on `HOOK_DEBUG=1`). Also adds a robust fallback mechanism for `subprocess.run` calls in `.skillshare/skills/repo-hygiene/scripts/hygiene_gather.py` to prevent script crash on `FileNotFoundError` (e.g. when missing system binaries).

---
*PR created automatically by Jules for task [15341016101611615655](https://jules.google.com/task/15341016101611615655) started by @RB-chrismandich*