### PR TITLE
fix(ai-hooks): include hookEventName in unified_hook responses

### DIFF
--- a/.skillshare/skills/ai-hooks-integration/scripts/runtime/unified_hook.py
+++ b/.skillshare/skills/ai-hooks-integration/scripts/runtime/unified_hook.py
@@ -154,15 +154,22 @@ def normalize_event(source: str, payload: dict, event_type: str = "PreToolUse") 
     }
 
 
-def allow_response() -> dict:
+def allow_response(event_type: str = "PreToolUse") -> dict:
     """Generate an allow response."""
-    return {"hookSpecificOutput": {"permissionDecision": "allow"}, "continue": True}
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event_type,
+            "permissionDecision": "allow",
+        },
+        "continue": True,
+    }
 
 
-def deny_response(reason: str) -> dict:
+def deny_response(reason: str, event_type: str = "PreToolUse") -> dict:
     """Generate a deny response."""
     return {
         "hookSpecificOutput": {
+            "hookEventName": event_type,
             "permissionDecision": "deny",
             "permissionDecisionReason": reason,
         },
@@ -178,6 +185,7 @@ def run_handler(handler_path: str, event: dict) -> dict:
     """
     import subprocess
 
+    event_type = event.get("event_type", "PreToolUse")
     try:
         result = subprocess.run(
             [sys.executable, handler_path],
@@ -189,22 +197,22 @@ def run_handler(handler_path: str, event: dict) -> dict:
 
         if result.returncode != 0:
             debug_log(f"Handler error: {result.stderr}")
-            return allow_response()
+            return allow_response(event_type)
 
         if result.stdout.strip():
             return json.loads(result.stdout)
 
-        return allow_response()
+        return allow_response(event_type)
 
     except subprocess.TimeoutExpired:
         debug_log("Handler timeout")
-        return allow_response()
+        return allow_response(event_type)
     except json.JSONDecodeError as e:
         debug_log(f"Handler invalid JSON: {e}")
-        return allow_response()
+        return allow_response(event_type)
     except Exception as e:
         debug_log(f"Handler exception: {e}")
-        return allow_response()
+        return allow_response(event_type)
 
 
 def main() -> None:
@@ -247,7 +255,7 @@ def main() -> None:
         payload = json.loads(raw_input) if raw_input.strip() else {}
     except json.JSONDecodeError as e:
         debug_log(f"Invalid input JSON: {e}")
-        print(json.dumps(allow_response()))
+        print(json.dumps(allow_response(args.event_type)))
         return
 
     debug_log(f"Received payload: {json.dumps(payload)[:200]}...")
@@ -267,7 +275,7 @@ def main() -> None:
         should_drop, reason = should_drop_event(source, payload)
         if should_drop:
             debug_log(f"Event dropped: {reason}")
-            print(json.dumps(allow_response()))
+            print(json.dumps(allow_response(args.event_type)))
             return
 
     # Normalize event
@@ -283,7 +291,7 @@ def main() -> None:
     if args.handler:
         response = run_handler(args.handler, event)
     else:
-        response = allow_response()
+        response = allow_response(args.event_type)
 
     print(json.dumps(response))
 

--- a/.skillshare/skills/ai-hooks-integration/tests/test_unified_hook.py
+++ b/.skillshare/skills/ai-hooks-integration/tests/test_unified_hook.py
@@ -189,6 +189,27 @@ class TestResponses(unittest.TestCase):
         )
         self.assertFalse(response["continue"])
 
+    def test_responses_include_hook_event_name(self):
+        """hookSpecificOutput must carry hookEventName (Claude Code requires it)."""
+        # Defaults to PreToolUse.
+        self.assertEqual(
+            allow_response()["hookSpecificOutput"]["hookEventName"], "PreToolUse"
+        )
+        self.assertEqual(
+            deny_response("x")["hookSpecificOutput"]["hookEventName"], "PreToolUse"
+        )
+
+    def test_event_type_threads_into_hook_event_name(self):
+        """An explicit event type must propagate to hookEventName."""
+        self.assertEqual(
+            allow_response("PostToolUse")["hookSpecificOutput"]["hookEventName"],
+            "PostToolUse",
+        )
+        self.assertEqual(
+            deny_response("x", "PostToolUse")["hookSpecificOutput"]["hookEventName"],
+            "PostToolUse",
+        )
+
 
 class TestResponseFormat(unittest.TestCase):
     """Test that responses are valid JSON."""


### PR DESCRIPTION
## What

`allow_response()` and `deny_response()` in `unified_hook.py` omitted `hookSpecificOutput.hookEventName`, which Claude Code **requires** on `PreToolUse`/`PostToolUse` hook responses. Every allow/deny the unified hook emitted was therefore malformed and silently ignored by the harness.

## Fix

- Thread the event type from `main()` / `run_handler()` through both response builders (defaulting to `PreToolUse`).
- Emit `hookEventName` in `hookSpecificOutput`.

## Tests

Adds two regression tests:
- responses include `hookEventName` by default (`PreToolUse`).
- an explicit event type propagates to `hookEventName` (e.g. `PostToolUse`).

`python3 -m pytest .skillshare/skills/ai-hooks-integration/tests/test_unified_hook.py` → **24 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)