### PR TITLE
🎨 Palette: Improve validation verdict colors in CLI summary

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,10 @@ cursor regardless of how the script terminates.
 **Learning:** The CLI tool outputs the agent status ("complete" / "failed") but doesn't utilize `rich` color tags
 for status text within the summary table in `orchestrator.py`, leading to poor visual contrast.
 **Action:** Enhance the `table.add_row` call to include color tags for the status string.
+
+## 2026-06-15 - Validation Status Colors
+
+**Learning:** When displaying status or verdicts in a CLI UI, a binary green/red color scheme often fails
+to capture intermediate or warning states, leading to poor UX and unnecessary alarm.
+**Action:** Use a three-color semantic system (e.g., green for APPROVED, yellow for NEEDS_REVIEW, red for BLOCKED)
+to provide nuanced, accurate visual feedback in CLI summary tables.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -493,7 +493,12 @@ class Orchestrator:
 
         if result.get("validation"):
             verdict = result["validation"]["verdict"]
-            color = "green" if verdict == "APPROVED" else "red"
+            if verdict == "APPROVED":
+                color = "green"
+            elif verdict == "NEEDS_REVIEW":
+                color = "yellow"
+            else:
+                color = "red"
             self.console.print(f"[bold]Validation:[/bold] [{color}]{verdict}[/{color}]")
 
 


### PR DESCRIPTION
💡 What: Updated `orchestrator.py` to use a three-color semantic system for validation verdicts (green for APPROVED, yellow for NEEDS_REVIEW, red for BLOCKED).
🎯 Why: A binary green/red color scheme often fails to capture intermediate or warning states, leading to poor UX and unnecessary alarm. The new styling provides more nuanced, accurate visual feedback in the CLI summary table.
📸 Before/After: Before, NEEDS_REVIEW was displayed in red. Now, it is appropriately displayed in yellow.
♿ Accessibility: Improved visual hierarchy and differentiation of system states in terminal outputs, making warnings distinct from outright failures.

---
*PR created automatically by Jules for task [627103170298151521](https://jules.google.com/task/627103170298151521) started by @RB-chrismandich*