### PR TITLE
🎨 Palette: Improve validation status visibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,11 @@ cursor regardless of how the script terminates.
 **Learning:** The CLI tool outputs the agent status ("complete" / "failed") but doesn't utilize `rich` color tags
 for status text within the summary table in `orchestrator.py`, leading to poor visual contrast.
 **Action:** Enhance the `table.add_row` call to include color tags for the status string.
+
+## 2024-06-20 - Three-Color Semantic System for CLI Status Outputs
+
+**Learning:** When designing CLI summary tables or status outputs, using a binary green/red scheme fails to adequately
+represent intermediate states (like warnings or "NEEDS_REVIEW").
+**Action:** Always use a three-color semantic system (e.g., green for success/APPROVED, yellow for warnings/
+NEEDS_REVIEW, red for errors/BLOCKED) rather than a binary green/red scheme to provide nuanced visual
+feedback and accurately reflect intermediate states.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -493,7 +493,12 @@ class Orchestrator:
 
         if result.get("validation"):
             verdict = result["validation"]["verdict"]
-            color = "green" if verdict == "APPROVED" else "red"
+            if verdict == "APPROVED":
+                color = "green"
+            elif verdict == "NEEDS_REVIEW":
+                color = "yellow"
+            else:
+                color = "red"
             self.console.print(f"[bold]Validation:[/bold] [{color}]{verdict}[/{color}]")
 
 


### PR DESCRIPTION
💡 What: Updated `_print_summary` in `configs/claude/scripts/agents/orchestrator.py` to use a three-color semantic system for the validation verdict (APPROVED=green, NEEDS_REVIEW=yellow, BLOCKED=red) instead of defaulting to red for all non-APPROVED states.
🎯 Why: A binary green/red scheme fails to adequately represent intermediate states like "NEEDS_REVIEW", potentially alarming users unnecessarily when manual review is expected rather than a hard failure. A three-color system provides nuanced visual feedback that accurately reflects intermediate states.
📸 Before/After: Not applicable (purely terminal output colors).
♿ Accessibility: Improves visual accessibility by semantically differentiating warning states from critical failure states in terminal outputs.

---
*PR created automatically by Jules for task [9551345012794314911](https://jules.google.com/task/9551345012794314911) started by @RB-chrismandich*