### PR TITLE
🎨 Palette: Add semantic yellow color for NEEDS_REVIEW validation state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,11 @@ cursor regardless of how the script terminates.
 **Learning:** The CLI tool outputs the agent status ("complete" / "failed") but doesn't utilize `rich` color tags
 for status text within the summary table in `orchestrator.py`, leading to poor visual contrast.
 **Action:** Enhance the `table.add_row` call to include color tags for the status string.
+
+## 2026-06-19 - Semantic Colors for CLI Validation States
+
+**Learning:** Binary green/red schemes in CLI outputs fail to communicate
+intermediate states like warnings or manual review requests, confusing users
+when a process didn't fully fail but isn't fully approved.
+**Action:** Use a three-color semantic system (green=success, yellow=warning/review,
+red=error/blocked) for validation verdicts to provide nuanced visual feedback.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -493,7 +493,7 @@ class Orchestrator:
 
         if result.get("validation"):
             verdict = result["validation"]["verdict"]
-            color = "green" if verdict == "APPROVED" else "red"
+            color = "green" if verdict == "APPROVED" else "yellow" if verdict == "NEEDS_REVIEW" else "red"
             self.console.print(f"[bold]Validation:[/bold] [{color}]{verdict}[/{color}]")
 
 


### PR DESCRIPTION
💡 What: Updated CLI validation output to use a three-color semantic system (green, yellow, red).
🎯 Why: `NEEDS_REVIEW` was previously being colored red (error), which causes unnecessary alarm for an advisory state.
📸 Before/After: Before: `NEEDS_REVIEW` was red. After: `NEEDS_REVIEW` is yellow.
♿ Accessibility: Improves cognitive accessibility by correctly mapping visual color semantics to state meaning.

---
*PR created automatically by Jules for task [18198349546157434704](https://jules.google.com/task/18198349546157434704) started by @RB-chrismandich*