### PR TITLE
🛠️ Forge: Audit and flag empty catch blocks in skills

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -33,3 +33,8 @@ violates our explicit routing and graceful degradation constraints.
 **Action:** Configure automated checks to flag empty or bindingless `catch` blocks in generated JavaScript templates.
 Ensure all catch statements explicitly capture the error object (e.g. `catch (e) { ... }`) and either log the error
 message or correctly fallback/propagate it.
+
+## 2026-06-21 - Forge Missing Init
+
+**Learning:** When adopting the Forge persona, any explicit instruction to read `.jules/forge.md` accompanied by the caveat `(create this file if it is missing)` implies a strict requirement to establish the file structure, even if no critical learnings are discovered during the subsequent execution that warrant a journal entry. Failing to create the empty/initial file violates the strictness of the architectural persona.
+**Action:** When acting as Forge, unconditionally create the `.jules/forge.md` file (e.g., using `touch`) before performing any analysis, ensuring the base structural requirement is met regardless of the audit's outcome.

--- a/.skillshare/skills/ai-hooks-integration/references/use-cases.md
+++ b/.skillshare/skills/ai-hooks-integration/references/use-cases.md
@@ -38,6 +38,7 @@ echo '{"continue":true,"decision":"allow"}'
 ```
 
 **Config (Claude)**:
+
 ```json
 {
   "hooks": {
@@ -69,6 +70,7 @@ echo '{"continue":true}'
 ```
 
 **Config (Claude)**:
+
 ```json
 {
   "hooks": {
@@ -107,6 +109,7 @@ echo '{"continue":true}'
 ```
 
 **Config (Claude)**:
+
 ```json
 {
   "hooks": {
@@ -209,6 +212,7 @@ echo '{"continue":true}'
 ```
 
 **Config (Cursor)**:
+
 ```json
 {
   "version": 1,
@@ -331,6 +335,7 @@ echo "{\"systemMessage\":$ESCAPED}"
 ```
 
 **Config (Gemini)**:
+
 ```json
 {
   "hooks": {
@@ -729,7 +734,7 @@ module.exports = async function AutoFormatPlugin(pluginInput) {
             break;
         }
       } catch (e) {
-        // Silent fail - don't block
+        console.error("Auto-format failed:", e.message);
       }
     },
   };

--- a/.skillshare/skills/code-quality/SKILL.md
+++ b/.skillshare/skills/code-quality/SKILL.md
@@ -87,6 +87,7 @@ When triggered, this skill:
 | Command injection | Critical | User input in `subprocess`, `os.system` |
 | Unsafe deserialization | Critical | `pickle.load`, `yaml.load` (not safe_load) |
 | Bare exceptions | High | `except:` without specific exception |
+| Empty catch blocks | High | `catch {}` or `catch (e) {}` with no handling |
 | Missing input validation | High | External data used without validation |
 
 ### Quality Checks

--- a/.skillshare/skills/refactor-node/SKILL.md
+++ b/.skillshare/skills/refactor-node/SKILL.md
@@ -101,7 +101,7 @@ proceed with the standard analysis.
 ### Step 5: Code Quality
 
 - Async/await consistency (no mixing callbacks and promises)
-- Proper error handling (no swallowed rejections)
+- Proper error handling (no swallowed rejections, no empty catch blocks)
 - Memory leak patterns (event listeners, intervals without cleanup)
 - Consistent file naming convention (kebab-case recommended)
 


### PR DESCRIPTION
This commit acts on the "Forge" persona instructions to harden the codebase and enforce architectural compliance.

- Audited the `ai-hooks-integration` scripts and templates for empty/bindingless `catch` blocks.
- Fixed a swallowed exception in the provided JavaScript snippet inside `references/use-cases.md`.
- Updated the `code-quality/SKILL.md` file to actively scan for and flag empty catch blocks (`catch {}` or `catch (e) {}`).
- Updated the `refactor-node/SKILL.md` file to explicitly instruct the agent to look out for empty catch blocks.
- Documented a structural learning in `.jules/forge.md` regarding the creation of the forge log file even when no critical learnings are found, adhering to the strict architectural guidelines.
- Executed `markdownlint-cli2` and fixed existing linting warnings in the modified markdown file.
- Executed `pytest` on the `ai-hooks-integration` test suite to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [15846167813089139328](https://jules.google.com/task/15846167813089139328) started by @RB-chrismandich*