### PR TITLE
🎨 Palette: Add semantic colors to agent status in CLI table

### DIFF
--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -472,8 +472,12 @@ class Orchestrator:
             duration = f"{agent_result.get('duration_seconds', 0):.2f}s"
             model = agent_result.get("model", "N/A")
 
-            status_icon = "✔" if status == "complete" else "✗"
-            status_color = "green" if status == "complete" else "red"
+            if status == "complete":
+                status_icon, status_color = "✔", "green"
+            elif status in ("failed", "error"):
+                status_icon, status_color = "✗", "red"
+            else:
+                status_icon, status_color = "⚠", "yellow"
             table.add_row(
                 agent_name.title(),
                 f"[{status_color}]{status_icon} {status}[/{status_color}]",


### PR DESCRIPTION
🎨 Palette: Add semantic colors to agent status in CLI table

💡 What: Updated `_print_table` in `orchestrator.py` to use a 3-color semantic system for the agent status strings (green for complete, red for failed/error, yellow for everything else).
🎯 Why: Binary green/red indicators fail to convey intermediate or nuanced states accurately, and using full rich color tagging makes the status immediately discernible at a glance.
📸 Before/After: N/A (CLI visual enhancement)
♿ Accessibility: Improved visual contrast and explicit color categorization based on status condition severity.

---
*PR created automatically by Jules for task [7254450160197307767](https://jules.google.com/task/7254450160197307767) started by @RB-chrismandich*