### PR TITLE
🎨 Palette: Color-code confidence level in orchestrator summary

### DIFF
--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -490,8 +490,12 @@ class Orchestrator:
     def _print_summary(self, result: Dict):
         """Print consensus summary"""
         consensus = result["cross_verification"]
+
+        confidence = consensus["confidence"].upper()
+        conf_color = "green" if confidence == "HIGH" else "yellow" if confidence == "MEDIUM" else "red"
+
         self.console.print(
-            f"\n[bold]Consensus:[/bold] {consensus['consensus_score']}% ({consensus['confidence'].upper()})"
+            f"\n[bold]Consensus:[/bold] {consensus['consensus_score']}% ([{conf_color}]{confidence}[/{conf_color}])"
         )
         self.console.print(f"[bold]Agents:[/bold] {consensus['agent_count']}")
 


### PR DESCRIPTION
💡 What: Added semantic coloring to confidence in CLI summary output
🎯 Why: Makes it easier to quickly visually distinguish low/medium/high confidence at a glance
📸 Before/After: None (CLI output change)
♿ Accessibility: Improves CLI readability by adding visual distinction for confidence levels

---
*PR created automatically by Jules for task [6299138935913638011](https://jules.google.com/task/6299138935913638011) started by @RB-chrismandich*