### PR TITLE
docs(bolt): correct misleading 2026-06-21 counting learning

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,11 +43,18 @@ of `.strip()` and the exception overhead for noise lines, yielding ~45% faster p
 **Action:** When parsing large, homogeneous JSONL files where the target lines consistently start with a specific
 character (like `{`), use direct prefix checks (`line[0]`) to filter lines before calling `json.loads`.
 
-## 2026-06-21 - Optimize Generator Comprehensions to List Comprehensions inside hot loops
+## 2026-06-21 - Generator vs list comprehension for counting (small, cold paths)
 
-**Learning:** `sum(1 for ...)` is slower than `len([1 for ...])` due to generator yielding overhead. And evaluating membership
-against a list comprehension instead of a set comprehension avoids set allocation overhead.
+**Learning:** `len([1 for ... if cond])` is measurably faster than `sum(1 for ... if cond)` on
+small/medium inputs: the list comprehension runs in a tight C loop and avoids the per-item
+generator `next()` overhead (benchmarked ~40% faster at n=50–500, collapsing to ~2% by n=5000
+as list-allocation cost catches up). The tradeoff is memory — `len([...])` materializes a
+throwaway list (O(k)) where `sum(genexpr)` is O(1) — so it only pays off on small, bounded
+inputs in cold paths, not in genuinely hot loops over large data.
 
 **Action:** Replaced `sum(1 for count in word_counts.values() if count > 1)` with
-`len([1 for count in word_counts.values() if count > 1])` in `configs/claude/scripts/agents/orchestrator.py` because
-`len([])` operates at C speed.
+`len([1 for count in word_counts.values() if count > 1])` in `configs/claude/scripts/agents/orchestrator.py`,
+which is the once-per-run consensus calc over a few hundred words — small input, cold path. For
+large or memory-sensitive loops keep `sum(1 for ...)` to avoid the list allocation. Unrelated to
+set-vs-list membership: prefer a `set` for membership tests (O(1) vs O(n)); do not swap a set
+comprehension for a list to "save allocation."


### PR DESCRIPTION
Follow-up to #390. The learning entry that PR added to `.jules/bolt.md` carried two inaccuracies that would mislead future bot runs:

1. **"hot loop" framing** — `_calculate_consensus` runs **once per orchestration** over a few hundred words; it's a cold path. The original PR comment was already corrected at merge; this fixes the matching learnings entry.
2. **set-vs-list non-sequitur** — the entry claimed evaluating "membership against a list comprehension instead of a set comprehension avoids set allocation overhead." No set→list change happened in #390, and the advice is backwards: sets exist for O(1) membership.

### What changed
Rewrites the 2026-06-21 entry to record what's actually true:
- `len([1 for ...])` is faster than `sum(1 for ...)` on **small** inputs (benchmarked ~40% at n=50–500, collapsing to ~2% by n=5000),
- at the cost of **O(k) memory** for a throwaway list (`sum(genexpr)` is O(1)),
- so it only pays off on small, bounded, cold paths — keep `sum(1 for ...)` for large/hot loops,
- plus a correction: prefer `set` for membership, don't swap set→list to "save allocation."

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)