### PR TITLE
feat: post-pr-review-monitor skill — babysit a freshly-opened PR

### DIFF
--- a/.skillshare/skills/post-pr-review-monitor/SKILL.md
+++ b/.skillshare/skills/post-pr-review-monitor/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: post-pr-review-monitor
+description: >-
+  Babysit a just-opened pull/merge request: watch CI to green, address GitHub
+  Copilot findings, and tag Google Jules (@google-labs-jules) then handle its
+  feedback. Use when a PR/MR was just opened, or for "monitor/babysit my PR",
+  "get the bots to review it", "tag jules", "address copilot comments".
+---
+
+# Post-PR Review Monitor
+
+Drive a freshly-opened PR/MR from "just created" to "CI green + every AI
+reviewer satisfied" with as little babysitting from the user as possible. The
+job is orchestration: you watch CI, get the review bots engaged, and route any
+findings to the skill that actually fixes them — you are the conductor, not a
+new copy of every instrument.
+
+This is a **self-paced loop**: CI and the review bots take minutes, sometimes
+much longer. You poll, act when something lands, sleep, and repeat — until the
+PR is clean or you hit a wall you should hand back to the user.
+
+## The four phases
+
+Run them roughly in order, but treat them as a loop, not a one-way pipeline: a
+CI fix you push restarts CI, and a bot review can arrive while you are waiting
+on something else. Re-check earlier phases whenever you push a commit.
+
+### 0. Resolve the PR and platform
+
+Default to the PR for the **current branch**; accept an explicit PR/MR number or
+URL if the user gave one.
+
+- GitHub: `gh pr view --json number,headRefName,url,state,isDraft` (current
+  branch) or `gh pr view <N> --json ...`.
+- GitLab: `glab mr view` / `glab mr view <N>`.
+- Detect the platform with the repo's helper if unsure:
+  `configs/claude/scripts/git_platform.sh`.
+
+If no PR exists for the branch, say so and ask whether to create one (or point
+the user at `/project-commit`) rather than guessing. If the PR is a **draft**,
+note it — Copilot/Jules often won't auto-review a draft; offer to mark it ready.
+
+See `references/platform-commands.md` for the full GitHub/GitLab command
+cookbook and bot-identity detection.
+
+### 1. Monitor CI until it is green
+
+Watch the checks rather than polling blindly:
+
+- GitHub: `gh pr checks <N> --watch --interval 30` blocks until every check
+  concludes, then exits non-zero if any failed.
+- GitLab: `glab ci status --live` / `glab mr view <N>` for the pipeline state.
+
+When a check **fails**, don't just report it — diagnose and fix:
+
+1. Pull the failing logs (`gh run view <run-id> --log-failed`, or the GitLab job
+   trace). Read the *actual* error, not the check name.
+2. Find the root cause in the diff. A lint/format failure that only shows up in
+   CI often means CI overrides the local linter config — the `ci-lint-config-drift`
+   skill is the right tool there.
+3. Apply a **scoped** fix. Re-run the same checks locally first (lean on the
+   `verify` skill — it runs the lint/test/scan chain CI runs) so you are not
+   pushing on faith.
+4. Commit with a message naming the failure you fixed, push, and go back to
+   watching. Each push restarts CI, so loop here until green.
+
+**Know when to stop.** If the same check fails after ~2-3 honest fix attempts,
+or the failure is environmental / needs a decision (flaky infra, a secret, a
+product choice), stop and hand back a crisp diagnosis instead of thrashing. A
+human un-sticking you in 30 seconds beats ten more failed pushes.
+
+### 2. GitHub Copilot — address findings if it reviewed
+
+Copilot is **addressed-if-present**, not summoned: this phase only acts when
+Copilot is already on the PR. (Jules is the one you tag in phase 3.)
+
+- **Is Copilot on the PR?** Check both requested reviewers and submitted
+  reviews for the Copilot bot — its login is `copilot-pull-request-reviewer[bot]`
+  and it shows as "Copilot" in the reviewers list. See
+  `references/platform-commands.md` for the exact `gh api` queries.
+- **No Copilot →** skip this phase (Copilot review may not be enabled on the
+  repo; that's fine, don't try to force it).
+- **Copilot present with findings →** hand the work to the **`address-pr-comments`**
+  skill. It already does this correctly: fetch all three feedback channels,
+  verify each claim against the current code (bots are sometimes wrong — line
+  numbers drift, claims go stale), fix the real ones, decline wrong ones with
+  evidence, re-test, push, and reply to / resolve every thread. Don't
+  re-implement that here.
+
+### 3. Google Jules — tag it, then watch for and address its feedback
+
+Jules is **not** a GitHub-native reviewer: requesting it as a reviewer or
+assignee is silently ignored. The only programmatic trigger in this repo is a
+**comment mention** that the `jules-trigger.yml` workflow acts on.
+
+1. **Is Jules already tagged?** Scan the PR's comments (not reviews) for a
+   `@google-labs-jules` mention. Also note whether the trigger landed: the
+   workflow reacts with 👀 on the triggering comment.
+2. **Not tagged → tag it.** Post a comment mentioning it with a clear ask:
+   `gh pr comment <N> --body "@google-labs-jules please review this PR"`
+   (GitLab: `glab mr note <N> --message "..."`). Only a trusted commenter
+   (repo OWNER/MEMBER/COLLABORATOR) actually triggers Jules — if you're acting
+   as the PR author that's normally satisfied; if the mention gets no 👀 within
+   a few minutes, surface that the trigger may be gated and let the user post it.
+3. **Watch for Jules activity, then address it.** Jules does not leave inline
+   GitHub *review* comments the way Copilot does — its feedback shows up as one
+   or more of:
+   - **PR comments** from the Jules bot / its personas (Forge, Bolt, Palette,
+     Sentinel),
+   - **commits pushed to the PR branch**, or
+   - a **separate linked PR**.
+   Poll for these (see waiting strategy below). When findings land as comments,
+   route them through **`address-pr-comments`** just like Copilot's. If Jules
+   pushes commits or opens a sibling PR, review that diff on its merits before
+   accepting (the `bot-pr-triage` skill covers judging bot diffs) — Jules
+   over-produces and is sometimes wrong, so verify, don't rubber-stamp.
+
+### 4. Close the loop
+
+Once CI is green and both bots are satisfied (findings addressed or none
+present), post a short status so the user can verify at a glance: CI state, what
+Copilot/Jules found and how each item was handled, and anything still pending or
+handed back. If you pushed fixes, confirm the final CI run is green.
+
+## Waiting strategy (the "self-paced loop")
+
+You are waiting on slow, external state — don't burn a foreground `sleep`, and
+don't busy-spin every few seconds.
+
+- **CI:** prefer the blocking watch (`gh pr checks --watch`); it returns the
+  moment checks finish.
+- **Bot reviews (Copilot/Jules):** there's no blocking primitive — poll on an
+  interval with backoff. Bots typically respond within a few minutes but can
+  take much longer. In Claude Code, drive the wait with the `Monitor` tool
+  (re-check a condition on an interval) or `ScheduleWakeup` for longer gaps,
+  rather than a foreground sleep.
+- **Cap the wait.** Pick a sensible overall budget (e.g. ~15-20 min of polling
+  for a bot to first respond) and a max number of rounds. When you hit the cap
+  with no response, **don't loop forever** — report current state ("Jules tagged,
+  👀 seen, no findings yet after 20 min") and let the user decide whether to keep
+  waiting. Silent infinite polling is worse than an honest pause.
+
+## Scope and honesty
+
+- **Don't fabricate progress.** Only claim CI is green / a bot is satisfied
+  after you've seen it. "Pending" is a valid, useful status.
+- **Verify bot claims before acting on them** — this is delegated to
+  `address-pr-comments`, which is built around exactly that discipline.
+- This skill orchestrates; the heavy lifting lives in focused skills
+  (`address-pr-comments`, `verify`, `ci-lint-config-drift`, `bot-pr-triage`).
+  Reach for them instead of duplicating their logic.
+
+## Auto-trigger on PR creation
+
+This workflow is wired to fire automatically when you open a PR/MR from an AI
+coding tool (Claude Code, Cursor, Gemini CLI, Antigravity): a PostToolUse-style
+hook watches for `gh pr create` / `glab mr create` and invokes this skill on the
+new PR. See `references/auto-trigger-hook.md` for the hook definition and how it
+deploys across tools.

--- a/.skillshare/skills/post-pr-review-monitor/evals/evals.json
+++ b/.skillshare/skills/post-pr-review-monitor/evals/evals.json
@@ -1,0 +1,27 @@
+{
+  "skill_name": "post-pr-review-monitor",
+  "notes": "This workflow depends on live GitHub/CI/bot state. Evals run in a DRY-RUN posture: agents produce their exact action plan + commands instead of executing mutating gh/glab calls. This isolates the skill's decision logic and platform-specific knowledge (Jules @-mention trigger, Copilot bot login, gh pr checks --watch, delegation to address-pr-comments, polling caps).",
+  "evals": [
+    {
+      "id": 0,
+      "name": "full-babysit-explicit-pr",
+      "prompt": "I just opened PR #128 on this GitHub repo (chrismandich/Manifest). Babysit it for me end to end — make sure CI goes green and get the AI review bots to look at it. Lay out exactly what you'll do and every command you'd run, in order. This is a dry run: do NOT execute any mutating gh/glab commands (no comments, no pushes); just produce the plan and the commands.",
+      "expected_output": "An ordered plan that: (1) resolves PR #128, (2) watches CI with gh pr checks --watch and describes diagnose+fix+push on failure, (3) checks whether Copilot reviewed (addressed-if-present, by bot login) and routes findings to address-pr-comments, (4) checks if @google-labs-jules was already mentioned and if not posts the mention to tag it, then polls for Jules feedback and routes it to address-pr-comments, (5) caps the wait and hands back on stall.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "did-checks-pass-and-jules",
+      "prompt": "did the checks pass on my PR? and has jules actually looked at it yet — if not can you get it to review. (current branch). dry run please, don't run anything that comments or pushes, just tell me exactly what you'd check and the commands.",
+      "expected_output": "Auto-detects the PR for the current branch (gh pr view). Reports how it would check CI status. Knows Jules is NOT a native reviewer and is triggered by a @google-labs-jules comment mention (not a reviewer request), checks existing comments for the mention, and would post 'gh pr comment <N> --body \"@google-labs-jules please review this PR\"' if absent. Mentions watching for the 👀 trigger reaction and Jules feedback via comments/commits/sibling PR.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "copilot-findings-present",
+      "prompt": "Copilot left a bunch of review comments on PR #92 and CI is already green. What's the right way to deal with the copilot feedback and get this PR to a clean reviewed state? Describe the approach and commands — dry run, don't actually post replies or push.",
+      "expected_output": "Recognizes CI is green so phase 1 is done. Identifies Copilot is present-with-findings and routes to the address-pr-comments skill (verify each claim against current code, fix real ones, decline wrong ones with evidence, reply/resolve threads) rather than re-implementing. Also checks whether Jules has been tagged and would tag it if not. Does not blindly accept bot claims.",
+      "files": []
+    }
+  ]
+}

--- a/.skillshare/skills/post-pr-review-monitor/references/auto-trigger-hook.md
+++ b/.skillshare/skills/post-pr-review-monitor/references/auto-trigger-hook.md
@@ -1,0 +1,90 @@
+# Auto-trigger hook: run the monitor when a PR is created
+
+This skill can fire automatically the moment you open a PR/MR from an AI coding
+tool. The trigger is a **tool-lifecycle hook** (Claude Code PostToolUse and the
+equivalents in Cursor, Gemini CLI, and Antigravity) that watches shell commands
+for a successful `gh pr create` / `glab mr create` and then nudges the agent to
+run `post-pr-review-monitor` on the new PR.
+
+It is *not* a git hook: PR/MR creation is a remote event, and a git hook can't
+see it. It's also not server-side CI — it runs inside your AI session, where the
+"address the findings" half of this workflow actually lives.
+
+## How it works
+
+```
+you run: gh pr create / glab mr create
+            │ (tool succeeds)
+            ▼
+PostToolUse / AfterTool / afterShellExecution hook
+            │ stdin = tool payload (JSON)
+            ▼
+scripts/pr_create_trigger.py
+            │ matches `gh pr create` | `glab mr create` AND success?
+            ├── no  → prints nothing, exit 0   (fail-open: never blocks you)
+            └── yes → emits additionalContext telling the agent to run the skill
+```
+
+The handler is **fail-open**: malformed payloads, non-matching commands, and
+failed PR creations all produce no output and exit 0, so the hook can never
+wedge your normal workflow.
+
+## Install across all four tools (recommended)
+
+Use the `ai-hooks-integration` skill's unified installer — one handler, source
+detection, registered on the right event for each tool:
+
+```bash
+HANDLER="$HOME/.claude/skills/post-pr-review-monitor/scripts/pr_create_trigger.py"
+
+~/.claude/skills/ai-hooks-integration/scripts/install_all.py \
+  --unified \
+  --handler "$HANDLER" \
+  --name post-pr-review-monitor \
+  --dry-run        # drop --dry-run to apply
+```
+
+Unified mode registers the handler on each tool's tool-lifecycle event and
+normalizes the payload; the handler (`pr_create_trigger.py`) does its own
+filtering — it only acts on a successful `gh pr create` / `glab mr create` and
+no-ops on everything else, so there's no per-event/matcher flag to set.
+
+This registers the equivalent event per tool:
+
+| Tool        | Config                          | Event                   |
+|-------------|---------------------------------|-------------------------|
+| Claude Code | `~/.claude/settings.json`       | PostToolUse (Bash)      |
+| Gemini CLI  | `~/.gemini/settings.json`       | AfterTool               |
+| Cursor      | `~/.cursor/hooks.json`          | afterShellExecution     |
+| Antigravity | symlinks to `~/.claude/` config | (covered via Claude)    |
+
+In this repo, Antigravity's config is symlinked to Claude's (`configs/antigravity/`
+→ `../claude/`), so the Claude hook covers Antigravity. OpenCode, if used, takes
+a plugin instead — see `install_opencode_plugin.py` in ai-hooks-integration.
+
+## Single tool only
+
+```bash
+~/.claude/skills/ai-hooks-integration/scripts/merge_hooks.py \
+  --tool claude --path ~/.claude/settings.json \
+  --command "python3 $HOME/.claude/skills/post-pr-review-monitor/scripts/pr_create_trigger.py"
+```
+
+## Verify / debug / remove
+
+```bash
+# Debug: log decisions to stderr
+echo '{"tool_input":{"command":"gh pr create --fill"},"tool_response":{"success":true}}' \
+  | HOOK_DEBUG=1 python3 ~/.claude/skills/post-pr-review-monitor/scripts/pr_create_trigger.py
+
+# Remove from all tools
+~/.claude/skills/ai-hooks-integration/scripts/remove_all.py --name post-pr-review-monitor
+```
+
+## Why a hook, not a slash command
+
+The point is zero-friction: the review loop should start itself the instant a PR
+exists, without you remembering to invoke it. The hook only *suggests* the skill
+via injected context — the agent still decides and you stay in control. If you'd
+rather trigger it by hand, just say "monitor my PR" / "babysit this PR" and the
+skill's own description handles the rest.

--- a/.skillshare/skills/post-pr-review-monitor/references/platform-commands.md
+++ b/.skillshare/skills/post-pr-review-monitor/references/platform-commands.md
@@ -1,0 +1,125 @@
+# Platform command cookbook
+
+GitHub (`gh`) and GitLab (`glab`) commands for each phase, plus how to detect
+the AI review bots. Read this when you need the exact invocation.
+
+## Contents
+
+- [Resolve PR + platform](#resolve-pr--platform)
+- [CI / pipeline status](#ci--pipeline-status)
+- [Detect Copilot](#detect-copilot)
+- [Detect / tag Jules](#detect--tag-jules)
+- [Fetch review feedback](#fetch-review-feedback)
+
+## Resolve PR + platform
+
+```bash
+# Platform detection (repo helper): prints github | gitlab | git
+configs/claude/scripts/git_platform.sh
+
+# GitHub — PR for the current branch
+gh pr view --json number,headRefName,baseRefName,url,state,isDraft,reviewRequests
+
+# GitHub — explicit PR
+gh pr view <N> --json number,headRefName,url,state,isDraft,reviewRequests,reviews
+
+# GitLab — MR for the current branch / explicit
+glab mr view
+glab mr view <N>
+```
+
+If `gh pr view` errors with "no pull requests found", there is no PR for the
+branch yet — ask before creating one.
+
+## CI / pipeline status
+
+```bash
+# GitHub — block until all checks finish; exits non-zero if any failed
+gh pr checks <N> --watch --interval 30
+
+# GitHub — one-shot snapshot (table of check -> state)
+gh pr checks <N>
+
+# GitHub — logs for a failed run (find run-id from the checks output / Actions tab)
+gh run view <run-id> --log-failed
+gh run list --branch <branch> --limit 5   # locate the run-id
+
+# GitLab — live pipeline status / MR pipeline
+glab ci status --live
+glab mr view <N>                # shows pipeline state
+glab ci trace <job-id>          # job log
+```
+
+## Detect Copilot
+
+GitHub Copilot code review posts as a bot. Identify it by login, not display name.
+
+```bash
+# Is Copilot a requested reviewer?
+gh pr view <N> --json reviewRequests \
+  --jq '.reviewRequests[] | select(.login // .name | test("[Cc]opilot"))'
+
+# Has Copilot submitted a review? (bot login: copilot-pull-request-reviewer[bot])
+gh api repos/{owner}/{repo}/pulls/<N>/reviews \
+  --jq '.[] | select(.user.login | test("copilot")) | {state, id, body}'
+```
+
+- Login to match: `copilot-pull-request-reviewer[bot]` (case-insensitive
+  `copilot` substring is a safe filter).
+- If neither query returns anything, Copilot review is not on this PR — skip the
+  Copilot phase. Do not try to add it; whether it runs is a repo/org setting.
+
+GitLab: GitHub Copilot PR review is GitHub-specific; on GitLab this phase is a
+no-op unless an equivalent review bot is configured.
+
+## Detect / tag Jules
+
+Jules is triggered by a **comment mention**, acted on by `.github/workflows/jules-trigger.yml`.
+
+```bash
+# Already mentioned on the PR? (look at issue/PR comments, NOT reviews)
+gh pr view <N> --comments | grep -i 'google-labs-jules'
+# or structured:
+gh api repos/{owner}/{repo}/issues/<N>/comments \
+  --jq '.[] | select(.body | test("google-labs-jules")) | {user: .user.login, body}'
+
+# Tag Jules
+gh pr comment <N> --body "@google-labs-jules please review this PR"
+
+# Did the trigger land? The workflow adds a 👀 reaction to the triggering comment.
+gh api repos/{owner}/{repo}/issues/comments/<comment-id>/reactions \
+  --jq '.[] | .content'    # expect "eyes"
+
+# GitLab equivalent (mention/note)
+glab mr note <N> --message "@google-labs-jules please review this PR"
+```
+
+### Jules feedback shows up as (poll for all three)
+
+```bash
+# 1. Comments from Jules / its personas (Forge, Bolt, Palette, Sentinel)
+gh api repos/{owner}/{repo}/issues/<N>/comments \
+  --jq '.[] | select(.user.login | test("jules|forge|bolt|palette|sentinel"; "i"))'
+
+# 2. New commits pushed to the PR branch
+gh pr view <N> --json commits --jq '.commits[-3:]'
+
+# 3. A separate linked PR opened by Jules
+gh pr list --search "head:jules" --json number,title,headRefName
+```
+
+Trust gate: only a comment from an OWNER / MEMBER / COLLABORATOR triggers Jules
+(the workflow's `author_association` check). As the PR author you normally
+qualify. If no 👀 appears within a few minutes, the mention may not have passed
+the gate — surface this and let the user post it from a trusted account.
+
+## Fetch review feedback
+
+Routing findings to fixes is the job of the **`address-pr-comments`** skill —
+invoke it rather than re-implementing. For reference, its three channels are:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<N>/comments    # inline code comments
+gh api repos/{owner}/{repo}/pulls/<N>/reviews     # review bodies
+gh pr view <N> --comments                         # issue-level discussion
+```

--- a/.skillshare/skills/post-pr-review-monitor/scripts/pr_create_trigger.py
+++ b/.skillshare/skills/post-pr-review-monitor/scripts/pr_create_trigger.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Auto-trigger handler for post-pr-review-monitor.
+
+Reads a tool-lifecycle hook payload on stdin (Claude PostToolUse, Gemini
+AfterTool, Cursor afterShellExecution — normalized by ai-hooks-integration's
+unified handler) and, when it sees a SUCCESSFUL `gh pr create` / `glab mr create`
+shell command, emits hook output that nudges the agent to run the
+post-pr-review-monitor skill on the just-created PR.
+
+Fail-open by design: any parse error, a non-matching command, or a failed
+command prints nothing and exits 0, so the hook never blocks normal work.
+
+Debug: set HOOK_DEBUG=1 to log decisions to stderr.
+"""
+import json
+import os
+import re
+import sys
+
+# Matches `gh pr create ...` and `glab mr create ...` anywhere in the command
+# (covers `cd foo && gh pr create`, leading env vars, etc.).
+PR_CREATE_RE = re.compile(r"\b(gh\s+pr\s+create|glab\s+mr\s+create)\b")
+
+
+def debug(msg: str) -> None:
+    if os.environ.get("HOOK_DEBUG"):
+        print(f"[pr-create-trigger] {msg}", file=sys.stderr)
+
+
+def extract_command(payload: dict) -> str:
+    """Pull the shell command out of the various tool payload shapes."""
+    ti = payload.get("tool_input") or payload.get("toolInput") or {}
+    if isinstance(ti, dict):
+        cmd = ti.get("command") or ti.get("cmd")
+        if cmd:
+            return str(cmd)
+    # Cursor afterShellExecution / Gemini AfterTool fallbacks
+    for key in ("command", "cmd"):
+        if payload.get(key):
+            return str(payload[key])
+    return ""
+
+
+def succeeded(payload: dict) -> bool:
+    """Best-effort success check; default True when the tool gives no signal."""
+    resp = payload.get("tool_response") or payload.get("toolResponse") or {}
+    if isinstance(resp, dict):
+        if resp.get("success") is False:
+            return False
+        if isinstance(resp.get("exit_code"), int) and resp["exit_code"] != 0:
+            return False
+    if isinstance(payload.get("exit_code"), int) and payload["exit_code"] != 0:
+        return False
+    # PostToolUse only fires after success; PostToolUseFailure is a separate event.
+    return True
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        debug("payload not JSON; no-op")
+        return 0
+
+    command = extract_command(payload)
+    if not PR_CREATE_RE.search(command):
+        debug(f"no PR-create command in: {command!r}")
+        return 0
+    if not succeeded(payload):
+        debug("PR-create command did not succeed; no-op")
+        return 0
+
+    debug("PR-create detected — emitting trigger")
+    context = (
+        "A pull/merge request was just created. Run the "
+        "`post-pr-review-monitor` skill on this new PR: monitor CI to green "
+        "(diagnosing and fixing failures), address GitHub Copilot findings if "
+        "Copilot reviewed, and tag @google-labs-jules (if not already tagged) "
+        "then watch for and address its feedback. Auto-detect the PR for the "
+        "current branch."
+    )
+    out = {
+        "hookSpecificOutput": {
+            "hookEventName": payload.get("hook_event_name", "PostToolUse"),
+            "additionalContext": context,
+        }
+    }
+    print(json.dumps(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/configs/claude/config/command_config.yml
+++ b/configs/claude/config/command_config.yml
@@ -75,6 +75,16 @@ tool_policies:
     parallel_agents: gate-only
     validation_tier: 1
 
+  post-pr-review-monitor:
+    allowed:
+      - Bash
+      - Read
+      - Edit
+      - Write
+    forbidden: []
+    parallel_agents: never        # orchestrates other skills; no cross-verification fan-out
+    validation_tier: 1            # pushes commits + posts PR comments
+
   pr-issue-sync:
     allowed:
       - Bash

--- a/configs/cursor/rules/post-pr-review-monitor.mdc
+++ b/configs/cursor/rules/post-pr-review-monitor.mdc
@@ -1,0 +1,15 @@
+---
+description: "Babysit a just-opened pull/merge request: watch CI to green, address GitHub Copilot findings, and tag Google Jules (@google-labs-jules) then handle its feedback. Use when a PR/MR was just opened, or for \"monitor/babysit my PR\", \"get the bots to review it\", \"tag jules\", \"address copilot comments\"."
+globs: ".claude/skills/post-pr-review-monitor/**"
+alwaysApply: false
+---
+
+# post-pr-review-monitor
+
+Babysit a just-opened pull/merge request: watch CI to green, address GitHub Copilot findings, and tag Google Jules (@google-labs-jules) then handle its feedback. Use when a PR/MR was just opened, or for "monitor/babysit my PR", "get the bots to review it", "tag jules", "address copilot comments".
+
+<!-- Auto-generated from .claude/skills/post-pr-review-monitor/SKILL.md -->
+<!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
+
+Refer to `.cursor/skills/post-pr-review-monitor/SKILL.md` for the full skill definition.
+

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -54,6 +54,7 @@ frontmatter is the authoritative name and description.
 | `/sync-configs` | Detect cross-platform config drift and broken symlinks | NO |
 | `/version-pin` | Enforce specific, hashed version pins in dependency files (auto-fix on demand; warn-only save hook) | ALWAYS (Tier 1) |
 | `/pr-review` | Review all open PRs and recommend a disposition per PR (analysis-only) | NO |
+| `/post-pr-review-monitor` | Babysit a just-opened PR/MR: watch CI to green (fix failures), address Copilot findings, tag Jules and handle its feedback. Auto-triggers on `gh pr create`/`glab mr create` | NO |
 | `/branch-clean` | Prune merged/gone/stale branches safely (dry-run by default, local-only) | CONDITIONAL (--apply) |
 | `/repo-hygiene` | Review-then-confirm cleanup sweep of open PRs and stale/merged/gone branches (GitHub/GitLab/local) | CONDITIONAL (close/prune path) |
 | `/skill-evolve` | Promote SkillClaw-evolved skills into a review PR (dry-run by default); requires SkillClaw enabled | NO |


### PR DESCRIPTION
## Summary

Adds the **`post-pr-review-monitor`** skill — babysits a freshly-opened PR/MR from "just created" to "CI green + every AI reviewer satisfied" with minimal user babysitting. It is an **orchestrator/conductor**: it watches CI, engages GitHub Copilot and Google Jules (`@google-labs-jules`), and routes any findings to the skills that actually fix them (`ci-lint-config-drift`, `address-pr-comments`) rather than reimplementing them. Self-paced poll → act → sleep loop.

## What's included

- `.skillshare/skills/post-pr-review-monitor/` — SKILL.md, `evals/evals.json`, two reference docs (`auto-trigger-hook.md`, `platform-commands.md`), and `scripts/pr_create_trigger.py` (auto-trigger on `gh pr create` / `glab mr create`).
- `command_config.yml` — `tool_policies` entry (Tier 1: pushes commits + posts PR comments; `parallel_agents: never` since it orchestrates other skills).
- `docs/COMMANDS.md` — reference row.

## Not superseded

Distinct from the merged auto-dev **merge** loop (#361/#387), which merges PRs *after* review. This skill drives a *freshly-opened* PR to review-ready. No equivalent existed on `main`.

## Provenance

Preserved from a stale `worktree-skill-post-pr` worktree found during branch cleanup — the work had been eval-developed via skill-creator but never committed or PR'd. The skill-creator `-workspace` eval scratch is intentionally excluded; only the skill + config wiring are committed here.

## Verification

- `ruff` ✅ · `py_compile` ✅ · `context_budget.bats` ✅ 5/5 (frontmatter budget respected) · `yamllint` ✅ · `deploy_skills.bats` + `sync_skills.bats` ✅ 30/30
- `bandit` not installed locally → security gate skipped (CI covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
