### PR TITLE
fix: services.yml heredoc drift + cursor-rules unchanged-detection

### DIFF
--- a/bootstrap/lib/config.sh
+++ b/bootstrap/lib/config.sh
@@ -363,6 +363,7 @@ services:
       - haiku    # Fast, economical
       - sonnet   # Balanced (default)
       - opus     # Maximum capability
+      - fable    # Top tier (security-critical tasks)
 
   # Gemini CLI - Google's AI assistant
   # Install: npm install -g @google/gemini-cli
@@ -383,7 +384,7 @@ services:
     model_tiers:
       - mini     # Lightweight
       - flash    # Balanced (default)
-      - advanced # Maximum capability
+      - advanced  # Maximum capability
 
   # Codex CLI - OpenAI terminal coding agent
   # Install: npm install -g @openai/codex
@@ -394,17 +395,22 @@ services:
     model_tiers:
       - mini     # Lightweight
       - flash    # Balanced (default)
-      - advanced # Maximum capability
+      - advanced  # Maximum capability
       - auto     # Use Codex config default model
     auth:
       - OPENAI_API_KEY
       - ~/.codex/auth.json
 
-  # Antigravity IDE - VS Code fork with Claude Code extension
-  # Install: Download from https://antigravity.sh
+  # Antigravity CLI - Google's agentic IDE CLI (agy)
+  # Install: via the Antigravity IDE, then run: agy install
   antigravity:
     enabled: $ENABLE_ANTIGRAVITY
-    description: "VS Code-fork IDE; inherits ~/.claude/ config via Claude Code extension"
+    command: agy
+    description: "Antigravity CLI for cross-vendor verification (Gemini/Claude catalog)"
+    model_tiers:
+      - mini     # Lightweight
+      - flash    # Balanced (default)
+      - advanced  # Maximum capability
 
   # SkillClaw - evolves SKILL.md skills from Claude Code transcripts (proxy-free)
   # Managed by bootstrap/lib/skillclaw.sh; no install, no daemon, no proxy.

--- a/configs/claude/scripts/generate_cursor_rules.sh
+++ b/configs/claude/scripts/generate_cursor_rules.sh
@@ -46,7 +46,9 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     description=""
     if head -1 "$skill_file" | grep -q '^---'; then
         front_matter=$(sed -n '2,/^---$/p' "$skill_file" | sed '$d')
-        desc_line=$(echo "$front_matter" | grep '^description:' | head -1)
+        # `|| true`: under `set -euo pipefail` a no-match grep would abort the
+        # script; tolerate a SKILL.md with no description and fall back below.
+        desc_line=$(echo "$front_matter" | grep '^description:' | head -1 || true)
         desc_value=$(echo "$desc_line" | sed 's/^description:[[:space:]]*//')
 
         if [[ "$desc_value" =~ ^[\|\>][+-]?$ || -z "$desc_value" ]]; then
@@ -57,7 +59,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
                 grep '^  ' |
                 sed 's/^  //' |
                 tr '\n' ' ' |
-                sed 's/[[:space:]]*$//')
+                sed 's/[[:space:]]*$//' || true)
         else
             # Inline value
             description=$(echo "$desc_value" | sed 's/^"//' | sed 's/"$//')
@@ -90,8 +92,13 @@ Refer to \`.cursor/skills/$skill_name/SKILL.md\` for the full skill definition.
 "
 
     if [[ -f "$rule_file" ]]; then
-        existing=$(cat "$rule_file")
-        if [[ "$existing" == "$content" ]]; then
+        # Compare against the exact bytes a write would produce. $(...) strips
+        # trailing newlines, so capture with a sentinel to preserve them; the
+        # write below is `echo "$content"`, which appends one newline beyond
+        # $content's own. Comparing raw $content here would never match and the
+        # unchanged branch would be dead code (every rule re-written each run).
+        existing=$(cat "$rule_file"; printf x); existing="${existing%x}"
+        if [[ "$existing" == "$content"$'\n' ]]; then
             log "Skip $skill_name: unchanged"
             skipped=$((skipped + 1))
             continue

--- a/tests/bats/generate_cursor_rules.bats
+++ b/tests/bats/generate_cursor_rules.bats
@@ -163,14 +163,10 @@ EOF
 }
 
 @test "missing description falls back to '<name> skill'" {
-    # BUG: the intended fallback (description="${description:-$skill_name skill}",
-    # line 65) is unreachable. With `set -euo pipefail`, a SKILL.md whose
-    # frontmatter has no `description:` line makes
-    #   desc_line=$(echo "$front_matter" | grep '^description:' | head -1)
-    # (line 48) a failing pipeline (grep exits 1), which aborts the whole
-    # script with exit 1 and no output. Fix: append `|| true` to that pipeline.
-    skip "BUG: script exits 1 on a SKILL.md without a description (pipefail + grep, line 48)"
-
+    # Regression: under `set -euo pipefail`, a SKILL.md with no `description:`
+    # line made the grep pipelines exit 1 and aborted the script with no output,
+    # so the intended fallback (description="${description:-$skill_name skill}")
+    # was unreachable. The grep pipelines now tolerate no-match (`|| true`).
     mkdir -p "$SKILLS_DIR/nodesc"
     cat > "$SKILLS_DIR/nodesc/SKILL.md" <<'EOF'
 ---
@@ -188,14 +184,10 @@ EOF
 
 # ── Idempotence / change detection ───────────────────────────────────────────
 
-@test "second run is byte-idempotent on disk (counter miscounts: BUG)" {
-    # BUG: the "unchanged" branch (lines 84-90) never fires. $content ends in a
-    # newline and `echo "$content"` appends another, but
-    # existing=$(cat "$rule_file") strips ALL trailing newlines — so
-    # existing == content is always false and every rule is re-written and
-    # counted as "updated" on every run. The on-disk bytes ARE stable (the
-    # rewrite is identical), so this test pins true idempotence on content and
-    # documents the miscount. Expected-after-fix: "0 created, 0 updated, 2 unchanged".
+@test "second run is byte-idempotent on disk and counts rules as unchanged" {
+    # Idempotence: a second run over already-current rules writes nothing and
+    # counts both as unchanged. (The unchanged-detection compares the exact
+    # bytes that would be written, including the trailing newline echo appends.)
     make_skill alpha "Alpha"
     make_skill beta "Beta"
     "$GEN"
@@ -204,18 +196,17 @@ EOF
 
     run "$GEN"
     assert_success
-    # Accept the current (buggy) counter output OR the expected-after-fix one,
-    # so fixing the script's unchanged-detection doesn't break this test.
-    # Files themselves are unchanged either way (shasum below is the real pin).
-    assert_output --regexp "0 created, (2 updated, 0 unchanged|0 updated, 2 unchanged)"
+    # Both rules are byte-identical to the prior run, so unchanged-detection
+    # must count them as unchanged (not re-written). The shasum below is the
+    # real pin; the counter now reflects it.
+    assert_output --partial "0 created, 0 updated, 2 unchanged"
     assert_equal "$(shasum "$RULES_DIR/alpha.mdc")" "$before_alpha"
     assert_equal "$(shasum "$RULES_DIR/beta.mdc")" "$before_beta"
 }
 
 @test "changed skill description is reflected in the regenerated rule" {
-    # NOTE: because of the unchanged-detection BUG above, the counter reports
-    # both rules as "updated" and cannot distinguish the truly changed one.
-    # Assert on rule content instead, which is the behavior that matters.
+    # Only the rule whose SKILL.md changed is rewritten; the stable one is
+    # counted as unchanged.
     make_skill alpha "Alpha original"
     make_skill beta "Beta stable"
     "$GEN"
@@ -223,8 +214,7 @@ EOF
     make_skill alpha "Alpha revised"   # rewrite SKILL.md with new description
     run "$GEN"
     assert_success
-    # Current (buggy) form first; fixed form should report 1 updated, 1 unchanged.
-    assert_output --regexp "0 created, (2 updated, 0 unchanged|1 updated, 1 unchanged)"
+    assert_output --partial "0 created, 1 updated, 1 unchanged"
 
     run cat "$RULES_DIR/alpha.mdc"
     assert_output --partial "Alpha revised"
@@ -256,6 +246,20 @@ EOF
     assert_equal "$(cat "$RULES_DIR/alpha.mdc")" "$before"
 }
 
+@test "--dry-run on an unchanged rule reports unchanged, not would-update" {
+    # Regression: the unchanged-detection compared existing=$(cat file) (which
+    # strips trailing newlines) against $content (which keeps one), so the
+    # "unchanged" branch never fired and --dry-run falsely reported every
+    # already-current rule as "Would update". A no-op run must be silent.
+    make_skill alpha "Alpha stable"
+    "$GEN"   # create alpha.mdc; nothing changes afterwards
+
+    run "$GEN" --dry-run
+    assert_success
+    refute_output --partial "[DRY-RUN] Would update:"
+    assert_output --partial "0 created, 0 updated, 1 unchanged"
+}
+
 # ── Edge cases ───────────────────────────────────────────────────────────────
 
 @test "empty skills dir produces zero counts and exits 0" {
@@ -282,10 +286,9 @@ EOF
 
     run "$REPO_ROOT/configs/claude/scripts/generate_cursor_rules.sh"
     assert_success
-    # BUG (see unchanged-detection note above): everything is counted as
-    # "updated" even though the rewrites are byte-identical. After the fix this
-    # should read "0 created, 0 updated, N unchanged".
-    assert_output --regexp "Cursor rules: 0 created, [0-9]+ updated, [0-9]+ unchanged"
+    # Tree is already in sync, so every rule is counted as unchanged and
+    # nothing is rewritten.
+    assert_output --regexp "Cursor rules: 0 created, 0 updated, [0-9]+ unchanged"
 
     # The real invariant: the tree is still clean afterwards (no drift).
     git -C "$REPO_ROOT" diff --exit-code --quiet configs/cursor/rules/


### PR DESCRIPTION
## Summary

Two fixes surfaced while validating a local `bootstrap.sh` redeploy + comprehensive test run.

### 1. `services.yml` heredoc drift (`bootstrap/lib/config.sh`)
The deployed `~/.claude/config/services.yml` is written by the `write_services_config()` **heredoc** — the committed `configs/claude/config/services.yml` is vestigial (copied then overwritten) and had silently drifted *ahead* of the heredoc. `--reconfigure` couldn't fix it (same stale heredoc). Re-synced the heredoc:
- add `fable` tier to claude `model_tiers` (`claude-fable-5`, confirmed real in `parallel_agent.yml`)
- refresh antigravity: `command: agy`, accurate description, `model_tiers`
- align cursor/codex `advanced` comment spacing for full parity

### 2. `generate_cursor_rules.sh` — two latent `set -euo pipefail` bugs
- **Unchanged-detection was dead code.** `existing=$(cat file)` strips trailing newlines while `echo "$content"` writes one, so the equality check never matched → `--dry-run` reported false drift on all 84 rules and every run rewrote every file. Now compares against the exact bytes a write produces (sentinel-preserved trailing newline). **On-disk output unchanged — zero file churn.**
- **No-`description:` SKILL.md aborted the script** (no-match grep under pipefail). Grep pipelines now tolerate no-match (`|| true`), making the `<name> skill` fallback reachable.

## Testing
- `tests/bats/generate_cursor_rules.bats`: added a dry-run-unchanged regression, un-skipped the missing-description test, and tightened three tests that previously accepted the buggy counter output to assert the fixed contract.
- **bats 513/513**, **pytest 310/310**, shellcheck/yamllint clean on changed files.
- Verified deployed `services.yml` carries `fable` + `agy` with toggles preserved (cursor/codex stay disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)