### PR TITLE
feat: add pr-regression-smoke skill (post-PR full regression + smoke gate)

### DIFF
--- a/.skillshare/skills/pr-regression-smoke/SKILL.md
+++ b/.skillshare/skills/pr-regression-smoke/SKILL.md
@@ -62,6 +62,7 @@ the gating signal.
 - `tests/lint/check_array_expansion.sh`
 - `yamllint configs/claude/config/*.yml`
 - `markdownlint-cli2` over `AGENTS.md CLAUDE.md README.md docs/*.md`
+- generated-artifact drift: `generate_commands_doc.py --check` (docs/COMMANDS.md + GEMINI.md/AGENTS.md command index) and a `generate_cursor_rules.sh` regenerate-and-clean-tree check — adding a skill that forgets these is the classic way a green local run still red-CIs
 - `bats tests/bats/` (full suite)
 - `pytest tests/python/` (full suite)
 

--- a/.skillshare/skills/pr-regression-smoke/SKILL.md
+++ b/.skillshare/skills/pr-regression-smoke/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: pr-regression-smoke
+description: |
+  Full Manifest regression (CI mirror: shellcheck, yamllint, markdownlint, bats
+  + pytest) plus a deployed-env smoke pass (bootstrap re-deploy, env health,
+  orchestration round-trip), as a post-PR gate. Use right after a PR opens or
+  merges — "regression test the PR", "did the merge break anything", "verify main
+  is still green". Whole-repo verdict; prefer over verify (one lang) or health-check.
+---
+
+# PR Regression + Smoke
+
+Confirm a pull request introduced no regressions by running the **entire** repo
+test suite the way CI does, then exercising the **deployed** environment so you
+catch breakage that unit tests can't see (a broken `bootstrap.sh`, a dangling
+symlink, an orchestrator that no longer responds).
+
+This skill works on whatever is currently checked out, so it fits both moments a
+PR creates risk: right after the branch is pushed (a pre-merge gate) and right
+after it merges to `main` (a post-merge regression check). It does not inspect
+GitHub state or know about PR numbers — it validates the code in front of it.
+
+## When to reach for this vs. neighbors
+
+- **`verify`** runs a *single project's* lint/test/security for one language. Use
+  it for a quick quality pass on a subdirectory. This skill is the whole-repo,
+  CI-equivalent gate plus a smoke pass — heavier and PR-scoped.
+- **`health-check`** validates only the deployed environment (configs, symlinks,
+  auth). That is a *subset* of this skill's smoke phase.
+- Reach for **this** skill when someone wants one verdict answering "is it safe
+  to merge / did the merge break anything?"
+
+## How to run it
+
+The deterministic work lives in a bundled runner so the verdict is reproducible
+and the exit code can gate a merge or feed a hook. From the repo root:
+
+```bash
+.skillshare/skills/pr-regression-smoke/scripts/run_pr_regression.sh
+```
+
+Useful flags (the script self-documents via `--help`):
+
+| Flag | Use when |
+|------|----------|
+| `--quick` | Fast feedback loop: lint + bats only, skips pytest and smoke |
+| `--skip-deploy` | You don't want the smoke pass to re-run `bootstrap.sh` against `~/` |
+| `--skip-orchestration` | Offline / no API credits — avoids the live agent round-trip |
+| `--skip-smoke` | Regression suite only |
+| `--skip-regression` | Smoke pass only |
+
+The runner exits **0 (PASS)** when every gate is clean, **1 (WARN)** when only
+non-blocking smoke checks degraded (e.g. an unauthenticated agent), and
+**2 (FAIL)** when a real regression gate failed. Surface that exit code — it is
+the gating signal.
+
+## What it checks
+
+**Regression (mirrors `.github/workflows/ci.yml` — keep them in lockstep):**
+
+- `shellcheck -S warning` over `configs/claude/scripts/*.sh` and `bootstrap.sh` + `bootstrap/lib/*.sh`
+- `tests/lint/check_array_expansion.sh`
+- `yamllint configs/claude/config/*.yml`
+- `markdownlint-cli2` over `AGENTS.md CLAUDE.md README.md docs/*.md`
+- `bats tests/bats/` (full suite)
+- `pytest tests/python/` (full suite)
+
+**Smoke (deployed environment — what unit tests can't see):**
+
+- `bootstrap.sh --skip-install --skip-auth --force` — the deploy path still works *(hard gate: a broken deploy is a regression)*
+- `check_status.sh` — symlinks, config syntax, auth, orchestration readiness *(soft: disabled/unauth agents are normal)*
+- `parallel_agent.py --claude-only` round-trip — an agent actually responds end-to-end *(soft)*
+
+## Reporting back to the user
+
+After the run, relay the runner's markdown table and verdict verbatim, then add a
+one-line recommendation tied to the exit code:
+
+- **PASS** → "Safe to merge / merge confirmed clean."
+- **WARN** → name which smoke check degraded and whether it's environmental
+  (e.g. "orchestration warned — this machine isn't authenticated, not a code
+  issue") so the user can judge it.
+- **FAIL** → lead with the failing gate(s) and the captured tail output; do not
+  bury it under the passing rows.
+
+If a gate **fails**, don't stop at reporting — offer to drive `systematic-debugging`
+on the first failure, since a red regression suite is exactly what it's for.
+
+## Keeping the mirror honest
+
+The regression list above must track `ci.yml`. If a PR changes CI (adds a lint, a
+new test path, bumps a tool), update the runner's `run_regression()` to match in
+the same change — a gate that has silently drifted from CI gives false confidence.
+When CI and this skill disagree, CI is the source of truth.

--- a/.skillshare/skills/pr-regression-smoke/scripts/run_pr_regression.sh
+++ b/.skillshare/skills/pr-regression-smoke/scripts/run_pr_regression.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# run_pr_regression.sh — complete regression + smoke test for the Manifest repo.
+#
+# Mirrors the gates in .github/workflows/ci.yml (shellcheck, array-expansion,
+# yamllint, markdownlint, bats, pytest) and adds a deployed-environment smoke
+# pass (bootstrap re-deploy, env health, live orchestration probe).
+#
+# Why a script and not freehand commands: a PR gate needs a *reliable* verdict.
+# A script aggregates every phase's real exit code into one number, so the
+# pass/warn/fail decision is deterministic and reproducible rather than
+# something a reader has to eyeball from scrolled-past output.
+#
+# Exit codes (chosen so this can gate a merge or feed a hook):
+#   0 = PASS  every gate clean
+#   1 = WARN  no regressions, but a non-blocking smoke check degraded
+#   2 = FAIL  a regression gate failed (lint/test/deploy)
+set -u
+
+SCRIPT_NAME="run_pr_regression.sh"
+err() { echo "${SCRIPT_NAME}: $*" >&2; }
+
+usage() {
+  cat <<'EOF'
+Usage: run_pr_regression.sh [options]
+Complete regression (lint/bats/pytest) + smoke (deploy/env/orchestration) for Manifest.
+  --skip-regression     Skip the regression suite
+  --skip-smoke          Skip the smoke pass
+  --skip-deploy         Within smoke, skip the bootstrap re-deploy
+  --skip-orchestration  Within smoke, skip the live parallel_agent probe (costs an API call)
+  --quick               Regression lint+bats only; skip pytest and the whole smoke pass
+  -h, --help            Show this help and exit
+Exit: 0 = PASS, 1 = WARN (non-blocking), 2 = FAIL (regression).
+EOF
+}
+
+# --- Parse args BEFORE any repo/tool lookup so --help works in any environment.
+SKIP_REGRESSION=0 SKIP_SMOKE=0 SKIP_DEPLOY=0 SKIP_ORCH=0 QUICK=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skip-regression) SKIP_REGRESSION=1 ;;
+    --skip-smoke) SKIP_SMOKE=1 ;;
+    --skip-deploy) SKIP_DEPLOY=1 ;;
+    --skip-orchestration) SKIP_ORCH=1 ;;
+    --quick) QUICK=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) err "unknown option: $1"; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  err "not inside a git repository"; exit 2
+}
+cd "$REPO_ROOT" || { err "cannot cd to repo root"; exit 2; }
+
+# --- Result accumulation ----------------------------------------------------
+declare -a R_PHASE R_NAME R_STATUS R_SUMMARY
+FAILS=0 WARNS=0
+
+record() { # record <phase> <name> <status> <summary>
+  R_PHASE+=("$1"); R_NAME+=("$2"); R_STATUS+=("$3"); R_SUMMARY+=("$4")
+  case "$3" in fail) FAILS=$((FAILS + 1));; warn) WARNS=$((WARNS + 1));; esac
+}
+
+# run_step <phase> <name> <mode:hard|soft> <command-string>
+#   hard: a non-zero exit is a regression  -> fail
+#   soft: a non-zero exit is a degradation -> warn (e.g. unauthenticated env)
+run_step() {
+  local phase="$1" name="$2" mode="$3" cmd="$4" log rc
+  log="$(mktemp)"
+  echo "▶ ${phase}: ${name}"
+  if bash -c "$cmd" >"$log" 2>&1; then
+    record "$phase" "$name" pass "ok"
+  else
+    rc=$?
+    local tail_line
+    tail_line="$(grep -vE '^\s*$' "$log" | tail -1)"
+    if [ "$mode" = soft ]; then
+      record "$phase" "$name" warn "rc=${rc}: ${tail_line:0:80}"
+      err "WARN ${name} (rc=${rc}) — see below"
+    else
+      record "$phase" "$name" fail "rc=${rc}: ${tail_line:0:80}"
+      err "FAIL ${name} (rc=${rc}) — see below"
+    fi
+    tail -25 "$log" | sed 's/^/    /'
+  fi
+  rm -f "$log"
+}
+
+# Mark a step skipped because a required tool is absent (skip != fail).
+need() { # need <tool> <phase> <name>
+  command -v "$1" >/dev/null 2>&1 && return 0
+  record "$2" "$3" skip "tool '$1' not installed"
+  echo "▶ ${2}: ${3} — skip ('$1' not installed)"
+  return 1
+}
+
+# --- Regression suite (mirrors ci.yml) --------------------------------------
+run_regression() {
+  echo "═══ Regression ═══"
+  if need shellcheck Regression shellcheck-scripts; then
+    run_step Regression shellcheck-scripts hard 'shellcheck -S warning configs/claude/scripts/*.sh'
+    run_step Regression shellcheck-bootstrap hard 'shellcheck -S warning bootstrap.sh bootstrap/lib/*.sh'
+  fi
+  run_step Regression array-expansion-lint hard 'tests/lint/check_array_expansion.sh'
+  # Invoke yamllint as a module: the bare console-script shim can fail to exec
+  # under `bash -c` on some Python installs (the shebang falls through to sh),
+  # whereas `python3 -m yamllint` is portable.
+  if python3 -c 'import yamllint' 2>/dev/null; then
+    run_step Regression yamllint hard 'python3 -m yamllint configs/claude/config/*.yml'
+  else
+    record Regression yamllint skip "python 'yamllint' module not installed"
+    echo "▶ Regression: yamllint — skip (module not installed)"
+  fi
+  # markdownlint-cli2 auto-discovers .markdownlint.jsonc; run via npx (no global install).
+  run_step Regression markdownlint hard 'npx --no-install markdownlint-cli2 AGENTS.md CLAUDE.md README.md "docs/*.md" 2>/dev/null'
+
+  # bats: prefer the repo-pinned binary, fall back to a PATH install.
+  local bats_bin="bats"
+  [ -x ./node_modules/.bin/bats ] && bats_bin="./node_modules/.bin/bats"
+  if need "${bats_bin%% *}" Regression bats || [ -x ./node_modules/.bin/bats ]; then
+    run_step Regression bats hard "${bats_bin} tests/bats/"
+  fi
+
+  if [ "$QUICK" = 1 ]; then
+    record Regression pytest skip "--quick mode"
+    echo "▶ Regression: pytest — skip (--quick)"
+    return
+  fi
+  if need python3 Regression pytest; then
+    run_step Regression pytest hard 'python3 -m pytest tests/python/ -q'
+  fi
+}
+
+# --- Smoke pass (deployed environment) --------------------------------------
+run_smoke() {
+  echo "═══ Smoke ═══"
+  # Bootstrap re-deploy: a broken deploy path is a genuine regression a PR can
+  # introduce, so this gate is hard. --skip-install/--skip-auth keep it fast and
+  # non-interactive; --force avoids the overwrite prompt.
+  if [ "$SKIP_DEPLOY" = 1 ]; then
+    record Smoke bootstrap-deploy skip "--skip-deploy"
+    echo "▶ Smoke: bootstrap-deploy — skip"
+  else
+    run_step Smoke bootstrap-deploy hard './bootstrap.sh --skip-install --skip-auth --force'
+  fi
+
+  # Env health is soft: disabled agents or missing auth are normal local states,
+  # not regressions the PR caused.
+  run_step Smoke env-health soft "$HOME/.claude/scripts/check_status.sh"
+
+  if [ "$SKIP_ORCH" = 1 ]; then
+    record Smoke orchestration skip "--skip-orchestration"
+    echo "▶ Smoke: orchestration — skip"
+  else
+    # One real round-trip through the orchestrator proves agents respond
+    # end-to-end. claude-only keeps it to a single cheap call; soft because an
+    # unauthenticated machine should warn, not block a code PR.
+    run_step Smoke orchestration soft \
+      "$HOME/.claude/scripts/parallel_agent.py --json --claude-only --timeout 90 'Reply with the single word OK'"
+  fi
+}
+
+# --- Drive ------------------------------------------------------------------
+[ "$SKIP_REGRESSION" = 1 ] || run_regression
+if [ "$QUICK" = 1 ]; then
+  SKIP_SMOKE=1
+fi
+[ "$SKIP_SMOKE" = 1 ] || run_smoke
+
+# --- Report -----------------------------------------------------------------
+echo ""
+echo "## PR Regression + Smoke Report"
+echo ""
+echo "| Phase | Check | Status | Summary |"
+echo "|-------|-------|--------|---------|"
+i=0
+while [ "$i" -lt "${#R_NAME[@]}" ]; do
+  printf '| %s | %s | %s | %s |\n' \
+    "${R_PHASE[$i]}" "${R_NAME[$i]}" "${R_STATUS[$i]}" "${R_SUMMARY[$i]}"
+  i=$((i + 1))
+done
+echo ""
+
+if [ "$FAILS" -gt 0 ]; then
+  echo "**Verdict: FAIL** — ${FAILS} gate(s) failed, ${WARNS} warning(s)."
+  exit 2
+elif [ "$WARNS" -gt 0 ]; then
+  echo "**Verdict: WARN** — 0 failures, ${WARNS} non-blocking warning(s)."
+  exit 1
+fi
+echo "**Verdict: PASS** — all gates clean."
+exit 0

--- a/.skillshare/skills/pr-regression-smoke/scripts/run_pr_regression.sh
+++ b/.skillshare/skills/pr-regression-smoke/scripts/run_pr_regression.sh
@@ -115,6 +115,15 @@ run_regression() {
   # markdownlint-cli2 auto-discovers .markdownlint.jsonc; run via npx (no global install).
   run_step Regression markdownlint hard 'npx --no-install markdownlint-cli2 AGENTS.md CLAUDE.md README.md "docs/*.md" 2>/dev/null'
 
+  # Generated-artifact drift. Adding/renaming a skill must be reflected in
+  # docs/COMMANDS.md, the GEMINI.md/AGENTS.md command index, and the per-skill
+  # Cursor rules — CI fails the build otherwise. These mirror those CI gates so
+  # the drift is caught here, before the push, not after.
+  run_step Regression commands-doc-drift hard 'configs/claude/scripts/generate_commands_doc.py --check'
+  # No --check on the cursor generator: regenerate, then a dirty rules/ tree is drift.
+  run_step Regression cursor-rule-drift hard \
+    'bash configs/claude/scripts/generate_cursor_rules.sh >/dev/null 2>&1; [ -z "$(git status --porcelain configs/cursor/rules/)" ]'
+
   # bats: prefer the repo-pinned binary, fall back to a PATH install.
   local bats_bin="bats"
   [ -x ./node_modules/.bin/bats ] && bats_bin="./node_modules/.bin/bats"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,6 +368,7 @@ standing line instead (spec 362, FR-011 documented gap): **before a commit run
 - **CI/CD, Testing & Quality**: `/a11y-audit` · `/browser-test` · `/ci-lint-config-drift` · `/ci-setup` · `/live-data-validation` · `/performance-check` · `/pin-known-bug-test-survives-fix` · `/refactor-go` · `/refactor-node` · `/refactor-python` · `/refactor-shell` · `/refactor-terraform` · `/reproduce-gated-ci-failure-locally` · `/statistical-test-fixture-variance` · `/ux-review` · `/verify`
 - **Infrastructure & Config**: `/api-bulk-endpoint-optimization` · `/app-native-config-validation` · `/cli-help-before-dependency-checks` · `/containerized-internal-service-probe` · `/debug-layered-config-substitution` · `/deploy-drift-root-cause` · `/diagnose-stalled-background-process` · `/headless-llm-cli-seam` · `/ingestion-table-idempotency` · `/out-of-band-cache-warm` · `/pass-cli` · `/retire-component-cleanup` · `/scaffold` · `/shell-pipefail-subshell-audit` · `/shell-sete-silent-abort-audit` · `/sync-configs` · `/version-pin`
 - **Meta & Orchestration**: `/antipattern-detect` · `/checkpoint` · `/code-quality` · `/dashboard` · `/health-check` · `/help` · `/learning-loop` · `/memory-log-compress` · `/session-memory-compress` · `/token-benchmark` · `/token-economy`
+- **Uncategorized**: `/pr-regression-smoke`
 
 Run `/help <query>` for descriptions and when-to-use.
 

--- a/configs/claude/config/command_config.yml
+++ b/configs/claude/config/command_config.yml
@@ -85,6 +85,17 @@ tool_policies:
     parallel_agents: never        # orchestrates other skills; no cross-verification fan-out
     validation_tier: 1            # pushes commits + posts PR comments
 
+  pr-regression-smoke:
+    allowed:
+      - Bash       # run_pr_regression.sh: lint/bats/pytest, bootstrap, check_status, parallel_agent
+      - Read
+      - Skill      # may hand a failing gate to systematic-debugging
+    forbidden:
+      - Write      # read-only on repo source; only validates, never edits
+      - Edit
+    parallel_agents: never        # a CI-mirror gate runner, not a cross-verification fan-out
+    validation_tier: 2            # verification skill; no source mutation
+
   pr-issue-sync:
     allowed:
       - Bash

--- a/configs/cursor/rules/commands-index.mdc
+++ b/configs/cursor/rules/commands-index.mdc
@@ -13,6 +13,7 @@ alwaysApply: true
 - **CI/CD, Testing & Quality**: `/a11y-audit` · `/browser-test` · `/ci-lint-config-drift` · `/ci-setup` · `/live-data-validation` · `/performance-check` · `/pin-known-bug-test-survives-fix` · `/refactor-go` · `/refactor-node` · `/refactor-python` · `/refactor-shell` · `/refactor-terraform` · `/reproduce-gated-ci-failure-locally` · `/statistical-test-fixture-variance` · `/ux-review` · `/verify`
 - **Infrastructure & Config**: `/api-bulk-endpoint-optimization` · `/app-native-config-validation` · `/cli-help-before-dependency-checks` · `/containerized-internal-service-probe` · `/debug-layered-config-substitution` · `/deploy-drift-root-cause` · `/diagnose-stalled-background-process` · `/headless-llm-cli-seam` · `/ingestion-table-idempotency` · `/out-of-band-cache-warm` · `/pass-cli` · `/retire-component-cleanup` · `/scaffold` · `/shell-pipefail-subshell-audit` · `/shell-sete-silent-abort-audit` · `/sync-configs` · `/version-pin`
 - **Meta & Orchestration**: `/antipattern-detect` · `/checkpoint` · `/code-quality` · `/dashboard` · `/health-check` · `/help` · `/learning-loop` · `/memory-log-compress` · `/session-memory-compress` · `/token-benchmark` · `/token-economy`
+- **Uncategorized**: `/pr-regression-smoke`
 
 Run `/help <query>` for descriptions and when-to-use.
 

--- a/configs/cursor/rules/pr-regression-smoke.mdc
+++ b/configs/cursor/rules/pr-regression-smoke.mdc
@@ -1,0 +1,15 @@
+---
+description: "Run the complete Manifest regression suite plus a deployed-environment smoke test as a post-Pull-Request gate. Use this whenever a PR has just been opened or just merged and you need to confirm nothing regressed — covers the full CI mirror (shellcheck, array-expansion lint, yamllint, markdownlint, all bats and pytest suites) AND a live smoke pass (bootstrap re-deploy, env health, orchestration round-trip). Trigger on phrases like \"regression test the PR\", \"did the merge break anything\", \"run the full suite + smoke\", \"post-PR check\", \"verify main is still green\", or any request to validate the whole repo after a change lands. Prefer this over `verify` (single-language quality gate) or `health-check` (env only) when the goal is a whole-repo PR gate with a verdict."
+globs: ".claude/skills/pr-regression-smoke/**"
+alwaysApply: false
+---
+
+# pr-regression-smoke
+
+Run the complete Manifest regression suite plus a deployed-environment smoke test as a post-Pull-Request gate. Use this whenever a PR has just been opened or just merged and you need to confirm nothing regressed — covers the full CI mirror (shellcheck, array-expansion lint, yamllint, markdownlint, all bats and pytest suites) AND a live smoke pass (bootstrap re-deploy, env health, orchestration round-trip). Trigger on phrases like "regression test the PR", "did the merge break anything", "run the full suite + smoke", "post-PR check", "verify main is still green", or any request to validate the whole repo after a change lands. Prefer this over `verify` (single-language quality gate) or `health-check` (env only) when the goal is a whole-repo PR gate with a verdict.
+
+<!-- Auto-generated from .claude/skills/pr-regression-smoke/SKILL.md -->
+<!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->
+
+Refer to `.cursor/skills/pr-regression-smoke/SKILL.md` for the full skill definition.
+

--- a/configs/cursor/rules/pr-regression-smoke.mdc
+++ b/configs/cursor/rules/pr-regression-smoke.mdc
@@ -1,12 +1,12 @@
 ---
-description: "Run the complete Manifest regression suite plus a deployed-environment smoke test as a post-Pull-Request gate. Use this whenever a PR has just been opened or just merged and you need to confirm nothing regressed — covers the full CI mirror (shellcheck, array-expansion lint, yamllint, markdownlint, all bats and pytest suites) AND a live smoke pass (bootstrap re-deploy, env health, orchestration round-trip). Trigger on phrases like \"regression test the PR\", \"did the merge break anything\", \"run the full suite + smoke\", \"post-PR check\", \"verify main is still green\", or any request to validate the whole repo after a change lands. Prefer this over `verify` (single-language quality gate) or `health-check` (env only) when the goal is a whole-repo PR gate with a verdict."
+description: "Full Manifest regression (CI mirror: shellcheck, yamllint, markdownlint, bats + pytest) plus a deployed-env smoke pass (bootstrap re-deploy, env health, orchestration round-trip), as a post-PR gate. Use right after a PR opens or merges — \"regression test the PR\", \"did the merge break anything\", \"verify main is still green\". Whole-repo verdict; prefer over verify (one lang) or health-check."
 globs: ".claude/skills/pr-regression-smoke/**"
 alwaysApply: false
 ---
 
 # pr-regression-smoke
 
-Run the complete Manifest regression suite plus a deployed-environment smoke test as a post-Pull-Request gate. Use this whenever a PR has just been opened or just merged and you need to confirm nothing regressed — covers the full CI mirror (shellcheck, array-expansion lint, yamllint, markdownlint, all bats and pytest suites) AND a live smoke pass (bootstrap re-deploy, env health, orchestration round-trip). Trigger on phrases like "regression test the PR", "did the merge break anything", "run the full suite + smoke", "post-PR check", "verify main is still green", or any request to validate the whole repo after a change lands. Prefer this over `verify` (single-language quality gate) or `health-check` (env only) when the goal is a whole-repo PR gate with a verdict.
+Full Manifest regression (CI mirror: shellcheck, yamllint, markdownlint, bats + pytest) plus a deployed-env smoke pass (bootstrap re-deploy, env health, orchestration round-trip), as a post-PR gate. Use right after a PR opens or merges — "regression test the PR", "did the merge break anything", "verify main is still green". Whole-repo verdict; prefer over verify (one lang) or health-check.
 
 <!-- Auto-generated from .claude/skills/pr-regression-smoke/SKILL.md -->
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->

--- a/configs/gemini/GEMINI.md
+++ b/configs/gemini/GEMINI.md
@@ -546,6 +546,7 @@ plans untouched 7+ days should be updated, completed, or abandoned. Use
 - **CI/CD, Testing & Quality**: `/a11y-audit` · `/browser-test` · `/ci-lint-config-drift` · `/ci-setup` · `/live-data-validation` · `/performance-check` · `/pin-known-bug-test-survives-fix` · `/refactor-go` · `/refactor-node` · `/refactor-python` · `/refactor-shell` · `/refactor-terraform` · `/reproduce-gated-ci-failure-locally` · `/statistical-test-fixture-variance` · `/ux-review` · `/verify`
 - **Infrastructure & Config**: `/api-bulk-endpoint-optimization` · `/app-native-config-validation` · `/cli-help-before-dependency-checks` · `/containerized-internal-service-probe` · `/debug-layered-config-substitution` · `/deploy-drift-root-cause` · `/diagnose-stalled-background-process` · `/headless-llm-cli-seam` · `/ingestion-table-idempotency` · `/out-of-band-cache-warm` · `/pass-cli` · `/retire-component-cleanup` · `/scaffold` · `/shell-pipefail-subshell-audit` · `/shell-sete-silent-abort-audit` · `/sync-configs` · `/version-pin`
 - **Meta & Orchestration**: `/antipattern-detect` · `/checkpoint` · `/code-quality` · `/dashboard` · `/health-check` · `/help` · `/learning-loop` · `/memory-log-compress` · `/session-memory-compress` · `/token-benchmark` · `/token-economy`
+- **Uncategorized**: `/pr-regression-smoke`
 
 Run `/help <query>` for descriptions and when-to-use.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1006,7 +1006,7 @@ Expected output:
 <!-- BEGIN GENERATED COMMANDS (command_catalog.py) — do not edit by hand -->
 <!-- Regenerate: configs/claude/scripts/generate_commands_doc.py -->
 
-_85 commands, generated from `.skillshare/skills/*/SKILL.md`._
+_86 commands, generated from `.skillshare/skills/*/SKILL.md`._
 
 ### Git & PRs
 
@@ -1132,5 +1132,11 @@ _85 commands, generated from `.skillshare/skills/*/SKILL.md`._
 | `/session-memory-compress` | Compress or summarize session memory — distill a session/transcript into a dated one-line entry, or losslessly compress/rotate existing memory entries (daily summary, shorthand rewrite, one-sentence log line) with zero information loss. | Compress or summarize session memory — distill a session/transcript into a dated one-line entry, or losslessly compress/rotate existing memory entries (daily summary, shorthand rewrite, one-sentence log line) with zero information loss. | available |
 | `/token-benchmark` | Measure token overhead and quality delta from Manifest config across Claude, Gemini CLI, and Antigravity CLI using MMLU/HumanEval/HellaSwag/TruthfulQA prompts before/after manifest context injection; regenerates docs/TOKEN_BENCHMARK.md. | Measure token overhead and quality delta from Manifest config across Claude, Gemini CLI, and Antigravity CLI using MMLU/HumanEval/HellaSwag/TruthfulQA prompts before/after manifest context injection; regenerates docs/TOKEN_BENCHMARK. | available |
 | `/token-economy` | Switch the current session into terse, surgical, clarify-first mode to cut token usage. Invoke when responses are verbose, during long refactors, or to conserve budget. Opt-in session mutator — re-invoke if it wears off. | Switch the current session into terse, surgical, clarify-first mode to cut token usage. | available |
+
+### Uncategorized
+
+| Command | Description | When to use | Status |
+|---------|-------------|-------------|--------|
+| `/pr-regression-smoke` | Full Manifest regression (CI mirror: shellcheck, yamllint, markdownlint, bats + pytest) plus a deployed-env smoke pass (bootstrap re-deploy, env health, orchestration round-trip), as a post-PR gate. Use right after a PR opens or merges — "regression test the PR", "did the merge break anything", "verify main is still green". Whole-repo verdict; prefer over verify (one lang) or health-check. | Full Manifest regression (CI mirror: shellcheck, yamllint, markdownlint, bats + pytest) plus a deployed-env smoke pass (bootstrap re-deploy, env health, orchestration round-trip), as a post-PR gate. | available |
 
 <!-- END GENERATED COMMANDS -->


### PR DESCRIPTION
## Summary

New project skill **`/pr-regression-smoke`** — a post-Pull-Request gate that runs the **entire** repo test suite the way CI does, then smoke-tests the **deployed** environment, and emits one verdict with a gating exit code (`0=PASS / 1=WARN / 2=FAIL`).

It works on whatever is currently checked out, so it fits both moments a PR creates risk: right after the branch is pushed (pre-merge) and right after it merges to `main` (post-merge regression).

## What it checks

**Regression** (mirrors `.github/workflows/ci.yml`):
- `shellcheck -S warning` (scripts + bootstrap), `tests/lint/check_array_expansion.sh`
- `yamllint`, `markdownlint-cli2`
- full `bats tests/bats/` + `pytest tests/python/` suites

**Smoke** (what unit tests can't see):
- `bootstrap.sh --skip-install --skip-auth --force` re-deploy — *hard gate* (a broken deploy path is a regression)
- `check_status.sh` env health — *soft* (disabled/unauth agents are normal local state)
- `parallel_agent.py --claude-only` round-trip — *soft* (an agent actually responds)

The **hard vs. soft** split is the design crux: real regressions block; environmental states only warn, so the exit code is trustworthy as a merge gate.

## Files
- `.skillshare/skills/pr-regression-smoke/SKILL.md` + `scripts/run_pr_regression.sh` (shellcheck-clean; `--help` works before any dependency lookup)
- `configs/claude/config/command_config.yml` — `tool_policies` registration (`validation_tier: 2`, no parallel-agent fan-out)
- `configs/cursor/rules/{pr-regression-smoke,commands-index}.mdc` — auto-generated by bootstrap (cross-platform propagation)

## Verification
Ran the skill against its own change set — **exit 0 PASS, 10/10 gates green** (535 bats + 364 pytest), frontmatter within `context_budget`. During development the skill caught two real regressions it had introduced (a `bash -c`-incompatible yamllint shim and a context-budget overflow), both fixed here — a regression gate that demonstrably catches a fresh regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)