### PR TITLE
⚡ Bolt: Fast-path JSON prefix check in guidance_hint

### DIFF
--- a/configs/claude/scripts/guidance_hint.py
+++ b/configs/claude/scripts/guidance_hint.py
@@ -156,6 +156,11 @@ def _command_from_payload(raw: str) -> Optional[str]:
     `BeforeTool`-style `args.command`/top-level `command` shapes used by Gemini/
     Cursor via ai-hooks-integration). Unknown shapes return None (fail-open).
     """
+    if isinstance(raw, str):
+        # ⚡ Bolt: Fast-path bypass for string allocation overhead and slow
+        # ValueError/JSONDecodeError on json.loads for obvious non-JSON strings
+        if raw and raw[0] not in ' \t\n\r{[':
+            return None
     try:
         payload = json.loads(raw)
     except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
💡 What: Added a safe fast-path prefix check in `_command_from_payload` before calling `json.loads()`.
🎯 Why: To avoid the significant `JSONDecodeError` exception overhead when processing non-JSON raw strings, which happens frequently during hook evaluations. It checks `isinstance(raw, str)` to avoid `AttributeError` regressions for non-string inputs.
📊 Impact: Bypasses exception overhead on non-JSON string payloads, reducing lag in hook processing.
🔬 Measurement: Run the test suite and observe it passes, demonstrating exact functional preservation with zero exception throws on non-JSON inputs.

---
*PR created automatically by Jules for task [9976142671971763915](https://jules.google.com/task/9976142671971763915) started by @RB-chrismandich*