### PR TITLE
🎨 Palette: Add semantic red color to CLI error messages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,10 @@ intermediate states like warnings or manual review requests, confusing users
 when a process didn't fully fail but isn't fully approved.
 **Action:** Use a three-color semantic system (green=success, yellow=warning/review,
 red=error/blocked) for validation verdicts to provide nuanced visual feedback.
+
+## 2026-06-22 - Semantic Errors in CLI Logs
+
+**Learning:** When errors are printed to the terminal without distinct red color formatting, they easily blend
+in with standard text, reducing the user's ability to quickly spot failures in busy output streams.
+**Action:** Consistently apply semantic red styling (`\033[0;31m`) to standard error messages in bash
+scripts to ensure they stand out visually and draw immediate attention.

--- a/configs/claude/scripts/learning_capture.sh
+++ b/configs/claude/scripts/learning_capture.sh
@@ -23,9 +23,10 @@ set -euo pipefail
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
+RED='\033[0;31m'
 RESET='\033[0m'
 
-err() { echo "learning-capture: $*" >&2; }
+err() { echo -e "${RED}learning-capture: $*${RESET}" >&2; }
 
 # --- Knowledge base file location ------------------------------------
 if [[ -f "${HOME}/.claude/config/knowledge_base.yml" ]]; then


### PR DESCRIPTION
💡 What: Added semantic red color formatting to the `err()` function output in `learning_capture.sh`.
🎯 Why: Without visual distinction, error messages blend into standard output, making it difficult for users to quickly spot failures. Red formatting immediately draws attention to critical errors.
📸 Before/After: Before, errors were standard terminal text color. After, errors are displayed in semantic red.
♿ Accessibility: Improves visual hierarchy and contrast for error states, aiding quicker cognitive recognition of failures.

---
*PR created automatically by Jules for task [6968264456180459308](https://jules.google.com/task/6968264456180459308) started by @RB-chrismandich*