### PR TITLE
🎨 Palette: Add elapsed time to CLI progress spinner

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,11 @@ intermediate states like warnings or manual review requests, confusing users
 when a process didn't fully fail but isn't fully approved.
 **Action:** Use a three-color semantic system (green=success, yellow=warning/review,
 red=error/blocked) for validation verdicts to provide nuanced visual feedback.
+
+## 2026-06-23 - Elapsed Time Context in CLI Spinners
+
+**Learning:** When long-running CLI tasks (like orchestrating multiple LLM agents) fallback
+to a simple spinner, users lose context on how long the operation has been running,
+which can lead to premature aborts.
+**Action:** Include a `TimeElapsedColumn()` alongside the `SpinnerColumn` in
+`rich.progress.Progress` to provide continuous visual feedback on execution duration.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -19,7 +19,7 @@ try:
     from rich.console import Console
     from rich.live import Live
     from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
     from rich.table import Table
 except ImportError:
     print("Error: Missing dependencies. Install with: pip install -r requirements.txt")
@@ -142,6 +142,7 @@ class Orchestrator:
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
             console=self.console,
             transient=True,
         ) as progress:


### PR DESCRIPTION
💡 What: Added `TimeElapsedColumn` to the fallback progress spinner in the CLI orchestrator (`configs/claude/scripts/agents/orchestrator.py`).
🎯 Why: When streaming is unavailable, users previously only saw a spinner without any indication of how long the operation had been running. Adding elapsed time provides better context for long-running LLM queries and prevents premature aborts.
📸 Before/After: Before: `⠋ Running 3 agents...` After: `⠋ Running 3 agents... 0:04`
♿ Accessibility: Improves user feedback by providing concrete duration context alongside the infinite spinner animation.

---
*PR created automatically by Jules for task [4656256824111919358](https://jules.google.com/task/4656256824111919358) started by @RB-chrismandich*