### PR TITLE
🎨 Palette: Semantic colors for disabled services

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,6 @@ intermediate states like warnings or manual review requests, confusing users
 when a process didn't fully fail but isn't fully approved.
 **Action:** Use a three-color semantic system (green=success, yellow=warning/review,
 red=error/blocked) for validation verdicts to provide nuanced visual feedback.
+## 2026-06-21 - Semantic Colors for CLI States
+**Learning:** In CLI status tables (like `check_status.sh`), using a red cross (`✗`) for intentionally disabled services communicates a false error state, increasing cognitive overload. A three-color semantic system (green=success/enabled, yellow=warning/inactive/disabled, red=error/blocked) provides nuanced visual feedback and accurately reflects intermediate, non-error states.
+**Action:** When designing or refactoring CLI outputs, explicitly reserve red (`RED`) for critical failures or blocked states, and use yellow (`YELLOW`) with an appropriate icon (like `○` or `⚠`) for optional, inactive, or intentionally disabled components.

--- a/configs/claude/scripts/check_status.sh
+++ b/configs/claude/scripts/check_status.sh
@@ -126,31 +126,31 @@ if [[ -f ~/.claude/config/services.yml ]]; then
     if [[ "$claude_enabled" == "true" ]]; then
         echo -e "  ${GREEN}✓${NC} Claude"
     else
-        echo -e "  ${RED}✗${NC} Claude (disabled)"
+        echo -e "  ${YELLOW}○${NC} Claude (disabled)"
     fi
 
     if [[ "$gemini_enabled" == "true" ]]; then
         echo -e "  ${GREEN}✓${NC} Gemini"
     else
-        echo -e "  ${RED}✗${NC} Gemini (disabled)"
+        echo -e "  ${YELLOW}○${NC} Gemini (disabled)"
     fi
 
     if [[ "$cursor_enabled" == "true" ]]; then
         echo -e "  ${GREEN}✓${NC} Cursor"
     else
-        echo -e "  ${RED}✗${NC} Cursor (disabled)"
+        echo -e "  ${YELLOW}○${NC} Cursor (disabled)"
     fi
 
     if [[ "$codex_enabled" == "true" ]]; then
         echo -e "  ${GREEN}✓${NC} Codex"
     else
-        echo -e "  ${RED}✗${NC} Codex (disabled)"
+        echo -e "  ${YELLOW}○${NC} Codex (disabled)"
     fi
 
     if [[ "$antigravity_enabled" == "true" ]]; then
         echo -e "  ${GREEN}✓${NC} Antigravity"
     else
-        echo -e "  ${RED}✗${NC} Antigravity (disabled)"
+        echo -e "  ${YELLOW}○${NC} Antigravity (disabled)"
     fi
 
     if [[ $enabled_count -lt 2 ]]; then


### PR DESCRIPTION
💡 What: Updated CLI summary table to use a three-color semantic system, replacing red error crosses (`✗`) with yellow warning circles (`○`) for intentionally disabled services.
🎯 Why: To provide nuanced visual feedback that accurately reflects intermediate states rather than a binary green/red scheme. A disabled service is a user choice, not a blocked error state.
📸 Before/After: Before: `${RED}✗${NC} Claude (disabled)`, After: `${YELLOW}○${NC} Claude (disabled)`
♿ Accessibility: Improves color communication and reduces cognitive overload by reserving red solely for critical errors (`BLOCKED`), adhering to standard semantic mapping.

---
*PR created automatically by Jules for task [596379793438770062](https://jules.google.com/task/596379793438770062) started by @RB-chrismandich*