### PR TITLE
🎨 Palette: Add elapsed time to CLI spinner

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,9 @@ intermediate states like warnings or manual review requests, confusing users
 when a process didn't fully fail but isn't fully approved.
 **Action:** Use a three-color semantic system (green=success, yellow=warning/review,
 red=error/blocked) for validation verdicts to provide nuanced visual feedback.
+
+## 2026-06-25 - Add Time Elapsed Column to Spinner
+
+**Learning:** Users lack visibility into duration of CLI background tasks and may prematurely abort them.
+**Action:** Always include an elapsed time indicator like `TimeElapsedColumn` alongside progress spinners to
+provide continuous feedback.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -19,7 +19,7 @@ try:
     from rich.console import Console
     from rich.live import Live
     from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
     from rich.table import Table
 except ImportError:
     print("Error: Missing dependencies. Install with: pip install -r requirements.txt")
@@ -142,6 +142,7 @@ class Orchestrator:
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
             console=self.console,
             transient=True,
         ) as progress:


### PR DESCRIPTION
💡 What: Added `TimeElapsedColumn` to the CLI spinner in `orchestrator.py`.
🎯 Why: Continuous visual feedback during long-running background tasks prevents users from prematurely aborting operations.
📸 Before/After: Before: Spinner only. After: Spinner with an elapsed time counter.
♿ Accessibility: Improves system status visibility for CLI users.

---
*PR created automatically by Jules for task [7090505688146146523](https://jules.google.com/task/7090505688146146523) started by @RB-chrismandich*