### PR TITLE
🎨 Palette: Add elapsed time indicator to CLI spinner

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,11 @@ intermediate states like warnings or manual review requests, confusing users
 when a process didn't fully fail but isn't fully approved.
 **Action:** Use a three-color semantic system (green=success, yellow=warning/review,
 red=error/blocked) for validation verdicts to provide nuanced visual feedback.
+
+## 2026-06-21 - Elapsed time for CLI spinners
+
+**Learning:** For long-running CLI tasks (like orchestrating multiple agents),
+users need continuous visual feedback beyond just a spinner to prevent them from
+assuming the process is hung and prematurely aborting it.
+**Action:** Always include an elapsed time indicator (e.g., `TimeElapsedColumn()`
+in `rich.progress`) alongside CLI spinners.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -19,7 +19,7 @@ try:
     from rich.console import Console
     from rich.live import Live
     from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
     from rich.table import Table
 except ImportError:
     print("Error: Missing dependencies. Install with: pip install -r requirements.txt")
@@ -142,6 +142,7 @@ class Orchestrator:
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
             console=self.console,
             transient=True,
         ) as progress:


### PR DESCRIPTION
💡 What: Added `TimeElapsedColumn` to the CLI spinner in the `_execute_without_streaming` method of the orchestrator.
🎯 Why: Long-running agent orchestrations lack feedback, causing users to potentially think the process has hung and abort.
📸 Before/After: Before, just a spinner with text. After, a spinner with text and a timer (e.g., `0:05`).
♿ Accessibility: Provides necessary ongoing visual status updates to cognitive users indicating that processing is still intentionally ongoing.

---
*PR created automatically by Jules for task [4856207195034500278](https://jules.google.com/task/4856207195034500278) started by @RB-chrismandich*