### PR TITLE
🎨 Palette: Add elapsed time to CLI spinner

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,11 @@ intermediate states like warnings or manual review requests, confusing users
 when a process didn't fully fail but isn't fully approved.
 **Action:** Use a three-color semantic system (green=success, yellow=warning/review,
 red=error/blocked) for validation verdicts to provide nuanced visual feedback.
+
+## 2026-06-25 - [Add elapsed time to CLI spinner]
+
+**Learning:** For long-running CLI tasks, adding a time elapsed indicator alongside a spinner provides continuous
+visual feedback and prevents users from prematurely aborting operations by clearly indicating ongoing activity and
+duration.
+**Action:** Always include an elapsed time indicator (like TimeElapsedColumn) alongside CLI spinners for potentially
+lengthy processes.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -19,7 +19,7 @@ try:
     from rich.console import Console
     from rich.live import Live
     from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
     from rich.table import Table
 except ImportError:
     print("Error: Missing dependencies. Install with: pip install -r requirements.txt")
@@ -142,6 +142,7 @@ class Orchestrator:
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
             console=self.console,
             transient=True,
         ) as progress:


### PR DESCRIPTION
- 💡 What: Added a `TimeElapsedColumn()` to the `Progress` spinner in the `_execute_without_streaming` function of `orchestrator.py`.
- 🎯 Why: To provide continuous visual feedback for long-running tasks, giving users an idea of how much time has passed and preventing premature abortion.
- 📸 Before/After: Visual changes apply to CLI output during non-streaming agent executions.
- ♿ Accessibility: Improves CLI feedback predictability for visually tracking long operations.

---
*PR created automatically by Jules for task [13026499741248180020](https://jules.google.com/task/13026499741248180020) started by @RB-chrismandich*