### PR TITLE
🛠️ Forge: Remove brittle JSON parsing heuristics

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -48,3 +48,15 @@ for invalid CLI output or IPC is inefficient.
 if the first character is a valid JSON opening char like '{', '[', '"', 't', 'f', 'n', or a digit) before calling
 `json.loads` to bypass exception overhead for obvious non-JSON strings. Ensure exceptions are not silently swallowed
 by debug-only loggers.
+
+## 2024-06-25 - Performance Optimization (Python Try/Except & Parsing)
+
+**Learning:** Replacing standard, robust try/except blocks (like
+`json.JSONDecodeError`) with brittle heuristic fast-paths (like
+checking if the first character is in `"{["`) degrades maintainability
+and violates the 'boring over clever' architectural philosophy. We should let
+native JSON parsers raise `JSONDecodeError` rather than implementing manual
+lookahead string checks.
+**Action:** Audit python scripts for `stdout_str[0] not in "{["` or
+`raw_input[0] not in "{["` checks and remove them, delegating entirely to
+standard `try ... except json.JSONDecodeError` blocks.

--- a/.skillshare/skills/ai-hooks-integration/scripts/runtime/unified_hook.py
+++ b/.skillshare/skills/ai-hooks-integration/scripts/runtime/unified_hook.py
@@ -260,10 +260,6 @@ def main() -> None:
     raw_input = sys.stdin.read().strip()
     payload = {}
     if raw_input:
-        if raw_input[0] not in "{[":
-            print("Invalid input JSON: not a JSON object/array", file=sys.stderr)
-            print(json.dumps(allow_response(args.event_type)))
-            return
         try:
             payload = json.loads(raw_input)
         except json.JSONDecodeError as e:

--- a/.skillshare/skills/repo-hygiene/scripts/hygiene_gather.py
+++ b/.skillshare/skills/repo-hygiene/scripts/hygiene_gather.py
@@ -73,8 +73,8 @@ def gh_refs(state: str, errors: list[str]) -> dict[str, int]:
         return {}
 
     stdout_str = (r.stdout or "").strip()
-    if not stdout_str or stdout_str[0] not in "{[":
-        errors.append(f"gh pr list --state {state} returned invalid JSON: not a JSON object/array")
+    if not stdout_str:
+        errors.append(f"gh pr list --state {state} returned empty output")
         return {}
 
     try:
@@ -95,8 +95,8 @@ def gh_open_sizes(errors: list[str]) -> dict[int, dict]:
         return {}
 
     stdout_str = (r.stdout or "").strip()
-    if not stdout_str or stdout_str[0] not in "{[":
-        errors.append(f"gh pr list sizes returned invalid JSON: not a JSON object/array")
+    if not stdout_str:
+        errors.append(f"gh pr list sizes returned empty output")
         return {}
 
     try:
@@ -125,8 +125,8 @@ def glab_refs(flag: str, errors: list[str]) -> dict[str, int]:
         return {}
 
     stdout_str = (r.stdout or "").strip()
-    if not stdout_str or stdout_str[0] not in "{[":
-        errors.append(f"glab mr list {flag} returned invalid JSON: not a JSON object/array")
+    if not stdout_str:
+        errors.append(f"glab mr list {flag} returned empty output")
         return {}
 
     try:


### PR DESCRIPTION
🛠️ Forge: Removed brittle JSON parsing heuristics.
Replaced raw string lookaheads (like checking if the first character is in "{[") with standard `try/except json.JSONDecodeError` blocks. This ensures native JSON parsers handle validation, maintaining code reliability and adhering to our architectural standard of relying on native exception handling instead of manual heuristics.

---
*PR created automatically by Jules for task [15762589822438377726](https://jules.google.com/task/15762589822438377726) started by @RB-chrismandich*