### PR TITLE
🎨 Palette: Add elapsed time to CLI agent execution spinner

### DIFF
--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -19,7 +19,7 @@ try:
     from rich.console import Console
     from rich.live import Live
     from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
     from rich.table import Table
 except ImportError:
     print("Error: Missing dependencies. Install with: pip install -r requirements.txt")
@@ -142,6 +142,7 @@ class Orchestrator:
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
             console=self.console,
             transient=True,
         ) as progress:


### PR DESCRIPTION
💡 What: Added an elapsed time indicator (`TimeElapsedColumn`) to the CLI spinner during agent execution in `orchestrator.py`.
🎯 Why: Long-running agent executions without continuous progress feedback can cause users to assume the process hung and prematurely abort it. Adding an elapsed time indicator provides continuous visual feedback that the process is still active.
📸 Before/After: Before, just a spinner with description. After, a spinner with description and `[00:0X]` elapsed time format.
♿ Accessibility: Improves CLI usability and user feedback, reducing anxiety and preventing accidental early termination of scripts.

---
*PR created automatically by Jules for task [17687817090238150770](https://jules.google.com/task/17687817090238150770) started by @RB-chrismandich*