### PR TITLE
🎨 Palette: Add elapsed time to CLI spinner

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,11 @@ intermediate states like warnings or manual review requests, confusing users
 when a process didn't fully fail but isn't fully approved.
 **Action:** Use a three-color semantic system (green=success, yellow=warning/review,
 red=error/blocked) for validation verdicts to provide nuanced visual feedback.
+
+## 2026-06-26 - Added Elapsed Time to CLI Spinner
+
+**Learning:** Users abort long-running terminal tasks when there is no continuous visual feedback of progress,
+even when a spinner is active.
+
+**Action:** Always include an elapsed time indicator (like `TimeElapsedColumn()` in rich) alongside CLI
+spinners to provide continuous feedback and prevent premature aborts.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -19,7 +19,7 @@ try:
     from rich.console import Console
     from rich.live import Live
     from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
     from rich.table import Table
 except ImportError:
     print("Error: Missing dependencies. Install with: pip install -r requirements.txt")
@@ -142,6 +142,7 @@ class Orchestrator:
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
             console=self.console,
             transient=True,
         ) as progress:


### PR DESCRIPTION
💡 What: Added an elapsed time indicator (`TimeElapsedColumn`) to the CLI spinner in the parallel agent orchestrator.
🎯 Why: To provide continuous visual feedback for long-running AI generation tasks, preventing users from prematurely aborting operations when they think the process is stalled.
📸 Before/After: Visual update in terminal output; spinner now includes a running MM:SS timer next to the text.
♿ Accessibility: Improves cognitive accessibility by providing concrete temporal context to background tasks.

---
*PR created automatically by Jules for task [7305546831083540233](https://jules.google.com/task/7305546831083540233) started by @RB-chrismandich*