### PR TITLE
🎨 Palette: Add elapsed time to CLI spinner

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,10 @@ intermediate states like warnings or manual review requests, confusing users
 when a process didn't fully fail but isn't fully approved.
 **Action:** Use a three-color semantic system (green=success, yellow=warning/review,
 red=error/blocked) for validation verdicts to provide nuanced visual feedback.
+
+## 2026-06-27 - CLI Spinner Elapsed Time Indicator
+
+**Learning:** When designing CLI spinners for long-running tasks, missing an elapsed time indicator can cause
+users to prematurely abort the operation because they lack continuous visual feedback.
+**Action:** Always include an elapsed time indicator (like `TimeElapsedColumn()`) alongside the spinner to provide
+continuous visual feedback.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -19,7 +19,7 @@ try:
     from rich.console import Console
     from rich.live import Live
     from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
     from rich.table import Table
 except ImportError:
     print("Error: Missing dependencies. Install with: pip install -r requirements.txt")
@@ -142,6 +142,7 @@ class Orchestrator:
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
             console=self.console,
             transient=True,
         ) as progress:


### PR DESCRIPTION
💡 What: Added `TimeElapsedColumn()` to the agent execution `rich.progress` spinner.
🎯 Why: When designing CLI spinners for long-running tasks, an elapsed time indicator gives continuous visual feedback, preventing users from prematurely aborting.
📸 Before/After: Visual change in the console spinner to show duration.
♿ Accessibility: Better feedback during asynchronous operations.

---
*PR created automatically by Jules for task [3783231965966393749](https://jules.google.com/task/3783231965966393749) started by @RB-chrismandich*