### PR TITLE
🎨 Palette: Add elapsed time to CLI spinner

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,10 @@ intermediate states like warnings or manual review requests, confusing users
 when a process didn't fully fail but isn't fully approved.
 **Action:** Use a three-color semantic system (green=success, yellow=warning/review,
 red=error/blocked) for validation verdicts to provide nuanced visual feedback.
+
+## 2026-06-27 - Add Elapsed Time to CLI Spinner
+
+**Learning:** For long-running CLI tasks, a simple spinner might feel stuck or
+frozen, causing users to prematurely abort the operation.
+**Action:** Always include an elapsed time indicator (like `TimeElapsedColumn()`)
+alongside the spinner to provide continuous visual feedback.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -19,7 +19,7 @@ try:
     from rich.console import Console
     from rich.live import Live
     from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
     from rich.table import Table
 except ImportError:
     print("Error: Missing dependencies. Install with: pip install -r requirements.txt")
@@ -142,6 +142,7 @@ class Orchestrator:
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
             console=self.console,
             transient=True,
         ) as progress:


### PR DESCRIPTION
💡 What: Added `TimeElapsedColumn` to the CLI spinner in the orchestrator.
🎯 Why: Provides continuous visual feedback during long-running tasks, preventing users from prematurely aborting the operation when the spinner feels stuck.
📸 Before/After: N/A (CLI update)
♿ Accessibility: Improves usability by ensuring continuous feedback for indeterminate progress states.

---
*PR created automatically by Jules for task [18048678738611314387](https://jules.google.com/task/18048678738611314387) started by @RB-chrismandich*