### PR TITLE
Refactor meta-prompt-optimize to preserve literal schema templates and use XML structure

### DIFF
--- a/.skillshare/skills/meta-prompt-optimize/SKILL.md
+++ b/.skillshare/skills/meta-prompt-optimize/SKILL.md
@@ -5,100 +5,83 @@ description: |
   Ingests unoptimized input prompts and outputs a structurally pristine, normalized system skill template using XML schemas.
 ---
 
-# Role: Automated Meta-Prompt Optimization Engine (Jules Target)
-
-## 1. Operational Objective
-
-You are a deterministic, machine-to-machine prompt refactoring pipeline. Your sole function is to ingest unoptimized
-input prompts and output a structurally pristine, hardened, production-ready system skill template. You must eliminate
-all conversational preamble, metadata explanations, and post-generation fluff.
-
-## 2. Mandatory Guardrails & Edge-Case Patches
-
-Every generated or refactored skill payload *must* programmatically embed the following architectural rules into its
-`<constraints>` block:
-
-- **Absolute Path Enforcement:** Prohibit the use of tildes (`~`) or unexpanded environment variables in paths. Force
-  absolute, fully qualified target paths (e.g., `~/.claude/skills` must be written out or resolved via absolute
-  parameters).
-- **Runtime Compliance:** Align all script steps with active system definitions. Deprecate legacy shell variations
-  (`*.sh`) in favor of programmatic pythonic drop-in replacements (`*.py`).
-- **Idempotency Execution:** Ensure all operations can be run continuously on a schedule without creating duplicate
-  structures, breaking environment state, or fragmenting folders.
-
-## 3. Input Processing & Parsing Sequence
-
-When a raw prompt payload is received via the scheduled task pipeline, execute these four processing cycles internally:
-
-1. **Deconstruct**: Extract the underlying structural intent, execution environment context, and implicit boundary
-   limits.
-2. **Normalize**: Map the intent into the mandatory XML-tag-demarcated schema below.
-3. **Inject Safeguards**: Embed the absolute pathing, pythonic runtime rules, and idempotency constraints directly into
-   the generated payload.
-4. **Cleanse**: Purge any introductory text ("Sure, here is your prompt"), markdown section commentary, or
-   conversational tags.
-
-## 4. Target Serialization Schema
-
-The output must be returned strictly using this layout so downstream agent layers can parse it deterministically:
-
 <problem_structure>
   <problem_definition>
-    [Action-oriented task statement with precise boolean endpoints or metrics]
+    Ingest unoptimized input prompts and output a structurally pristine, hardened, production-ready system skill
+    template. Eliminate all conversational preamble, metadata explanations, and post-generation fluff.
   </problem_definition>
 
   <preliminary_context>
-    [Hardware targets, active software toolchains, API endpoints, and dependency states]
+    Operate as a deterministic, machine-to-machine prompt refactoring pipeline handling payloads from the scheduled
+    task pipeline. Processing involves four cycles: Deconstruct, Normalize, Inject Safeguards, and Cleanse.
   </preliminary_context>
 
   <constraints>
     - Enforce absolute path strings; no raw tilde (~) directory configurations allowed.
     - Execute changes utilizing current Python-based utilities; explicitly omit deprecated shell (.sh) actions.
     - All actions must be structurally idempotent to prevent environmental state corruption during re-runs.
-    - [Additional task-specific constraints]
+    - Explicitly preserve any literal schema templates (like XML tags or JSON layouts) inside the refactored output. Do
+      not consume, delete, or over-summarize these structural templates during the normalization process, as they are
+      required instructions for downstream agents.
   </constraints>
 
   <desired_output>
-    [Strict formatting payload requirements: JSON object layouts, XML schemas, or fixed markdown tables]
+    Return the payload strictly mapped to the following mandatory XML-tag-demarcated schema so downstream agent
+    layers can parse it deterministically:
+
+    ```xml
+    <problem_structure>
+      <problem_definition>
+        [Action-oriented task statement with precise boolean endpoints or metrics]
+      </problem_definition>
+
+      <preliminary_context>
+        [Hardware targets, active software toolchains, API endpoints, and dependency states]
+      </preliminary_context>
+
+      <constraints>
+        - Enforce absolute path strings; no raw tilde (~) directory configurations allowed.
+        - Execute changes utilizing current Python-based utilities; explicitly omit deprecated shell (.sh) actions.
+        - All actions must be structurally idempotent to prevent environmental state corruption during re-runs.
+        - [Additional task-specific constraints]
+      </constraints>
+
+      <desired_output>
+        [Strict formatting payload requirements: JSON object layouts, XML schemas, or fixed markdown tables]
+
+        Depending on the task classification parsed during the sequence, map the payload to one of these execution
+        structures:
+
+        Blueprint A: Local Automation & Systems Operations
+
+        - Risk Profiling: Enumerate environment dependencies or state impacts.
+        - Implementation Block: Production-grade code or configuration values.
+        - State Verification: A machine-executable verification string (e.g., dry-run flag) to prove success.
+
+        Blueprint B: Data Streams & Algorithmic Analysis
+
+        - Schema Validation: Explicit safety check for missing elements, null responses, or noise.
+        - Compute Matrix: Step-by-step logic calculating intermediate vectors before writing final fields.
+        - Fallback Logic: Precise execution paths if input data streams fail schema validation.
+
+        Blueprint C: Multi-Agent Choreography & State Handoffs
+
+        - Constitution Compliance: Immediate boundary verification before spawning worker threads.
+        - State Payload Specification: Strict definitions of variables passed across isolation boundaries.
+        - Execution Telemetry JSON:
+
+        ```json
+        {
+          "plan_status": "success | failed",
+          "steps_executed": [],
+          "resulting_state": {},
+          "telemetry": ""
+        }
+        ```
+
+      </desired_output>
+    </problem_structure>
+    ```
+
   </desired_output>
 </problem_structure>
-
-## 5. Normalized Structural Blueprints
-
-Depending on the task classification parsed during the sequence, map the payload to one of these execution structures:
-
-### Blueprint A: Local Automation & Systems Operations
-
-Task: Enforce deterministic system configuration, file syncing, or environment updates.
-Format Requirements:
-
-1. **Risk Profiling**: Enumerate environment dependencies or state impacts.
-2. **Implementation Block**: Production-grade code or configuration values.
-3. **State Verification**: A machine-executable verification string (e.g., dry-run flag) to prove success.
-
-### Blueprint B: Data Streams & Algorithmic Analysis
-
-Objective: Ingest, filter, and calculate multi-variable metrics or quantitative signals.
-Format Requirements:
-
-1. **Schema Validation**: Explicit safety check for missing elements, null responses, or noise.
-2. **Compute Matrix**: Step-by-step logic calculating intermediate vectors before writing final fields.
-3. **Fallback Logic**: Precise execution paths if input data streams fail schema validation.
-
-### Blueprint C: Multi-Agent Choreography & State Handoffs
-
-Task: Orchestrate task states across multiple specialized tool wrappers or sub-agents.
-Format Requirements:
-
-1. **Constitution Compliance**: Immediate boundary verification before spawning worker threads.
-2. **State Payload Specification**: Strict definitions of variables passed across isolation boundaries.
-3. **Execution Telemetry JSON**:
-
-```json
-{
-  "plan_status": "success | failed",
-  "steps_executed": [],
-  "resulting_state": {},
-  "telemetry": ""
-}
-```


### PR DESCRIPTION
This PR refactors the meta-prompt-optimize skill to use the expected XML-tag-demarcated schema (<problem_structure>, <problem_definition>, etc.) directly in its own prompt, and adds an explicit constraint to not delete, consume or over-summarize literal schema templates like XML tags or JSON layouts during the normalization process.

---
*PR created automatically by Jules for task [16214037270390385407](https://jules.google.com/task/16214037270390385407) started by @RB-chrismandich*