### PR TITLE
feat: spec-review parallel-agent panel + cursor-agent backend migration

### DIFF
--- a/.skillshare/skills/spec-review/SKILL.md
+++ b/.skillshare/skills/spec-review/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: spec-review
-description: Cross-reference spec/plan/tasks artifacts for internal consistency using Antigravity/agy; surfaces structured remediation guidance. Analysis-only, never edits. Works with speckit (spec.md/plan.md/tasks.md) and superpowers layouts; auto-discovers or takes explicit paths.
+description: Cross-reference spec/plan/tasks artifacts for internal consistency using the parallel-agent panel (gemini/cursor/codex/antigravity, excluding the author) and a synthesized deduped findings list. Analysis-only, never edits. Works with speckit (spec.md/plan.md/tasks.md) and superpowers layouts; auto-discovers or takes explicit paths.
 ---
 
-# Spec Review (Antigravity cross-reference)
+# Spec Review (parallel-agent cross-reference)
 
 Run an independent, analysis-only consistency check across the project's planning
-artifacts. A second model (Antigravity / `agy`) reviews what Claude authored — catching
-structural blind spots that self-review misses.
+artifacts. The parallel-agent panel — every enabled agent **except** the author
+(Claude) — reviews what Claude wrote, and their findings are synthesized into one
+deduped list. Multiple independent reviewers catch structural blind spots a single
+model (or self-review) misses.
 
 ## How to run
 
@@ -23,5 +25,6 @@ structural blind spots that self-review misses.
 ```
 
 Findings print as a tree of `CLARIFICATION REQUIRED` blocks, or
-`✓ No inconsistencies found.` Requires the `agy` CLI (logged in). This skill is
-analysis-only; apply the recommendations yourself.
+`✓ No inconsistencies found.` Requires `parallel_agent.py` plus at least one
+non-Claude agent CLI; it falls back to a single `agy` review when the panel is
+unavailable. This skill is analysis-only; apply the recommendations yourself.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Required CLI tools (install those you want to use):
 
 - `claude` - `npm install -g @anthropic-ai/claude-code`
 - `gemini` - `npm install -g @google/gemini-cli`
-- `cursor` - Download from <https://cursor.sh>
+- `cursor-agent` - `curl https://cursor.com/install -fsS | bash`
 - `codex` - `npm install -g @openai/codex`
 
 ## Key Files

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -293,21 +293,9 @@ main() {
 
         # Cursor auth info
         if [[ "$ENABLE_CURSOR" == true ]]; then
-            local cursor_found=false
-            if [[ "$PLATFORM" == "macos" ]]; then
-                if [[ -d "/Applications/Cursor.app" ]] || command_exists cursor; then
-                    cursor_found=true
-                fi
-            else
-                if command_exists cursor; then
-                    cursor_found=true
-                fi
-            fi
-
-            if [[ "$cursor_found" == true ]]; then
-                print_step "Checking Cursor authentication..."
-                print_info "Cursor authentication is handled within the Cursor IDE"
-                print_info "Open Cursor and sign in to enable the cursor agent"
+            if command_exists cursor-agent || [[ -f "$HOME/.local/bin/cursor-agent" ]]; then
+                print_step "Checking cursor-agent authentication..."
+                print_info "Authenticate with: cursor-agent login  (or set CURSOR_API_KEY)"
             fi
         fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -70,6 +70,7 @@ MANIFEST_TMP_DIR="$MANIFEST_STATE_DIR/tmp"
 SERVICES_CONFIG="$TARGET_DIR/config/services.yml"
 
 # Detect platform/runtime defaults (initialized by initialize_platform_runtime)
+# shellcheck disable=SC2034  # consumed by sourced bootstrap/lib/*.sh
 PLATFORM="unknown"
 export DISTRO=""
 # shellcheck disable=SC2034

--- a/bootstrap/lib/config.sh
+++ b/bootstrap/lib/config.sh
@@ -375,11 +375,11 @@ services:
       - flash    # Fast (default)
       - pro      # Advanced
 
-  # Cursor Agent - IDE-integrated AI
-  # Install: Download from https://cursor.sh
+  # Cursor Agent - headless CLI for code analysis
+  # Install: curl https://cursor.com/install -fsS | bash
   cursor:
     enabled: $ENABLE_CURSOR
-    command: cursor
+    command: cursor-agent
     description: "IDE-integrated context, code-specific analysis"
     model_tiers:
       - mini     # Lightweight

--- a/bootstrap/lib/deploy.sh
+++ b/bootstrap/lib/deploy.sh
@@ -499,22 +499,11 @@ verify_installation() {
 
     if [[ "$ENABLE_CURSOR" == true ]]; then
         enabled_count=$((enabled_count + 1))
-        local cursor_found=false
-        if [[ "$PLATFORM" == "macos" ]]; then
-            if [[ -d "/Applications/Cursor.app" ]] || command_exists cursor; then
-                cursor_found=true
-            fi
-        else
-            if command_exists cursor; then
-                cursor_found=true
-            fi
-        fi
-
-        if [[ "$cursor_found" == true ]]; then
-            print_success "cursor is available (enabled)"
+        if command_exists cursor-agent || [[ -f "$HOME/.local/bin/cursor-agent" ]]; then
+            print_success "cursor-agent is available (enabled)"
             available_tools=$((available_tools + 1))
         else
-            print_warning "cursor is not available (enabled but not installed)"
+            print_warning "cursor-agent is not available (enabled but not installed)"
         fi
     else
         print_info "cursor is disabled"
@@ -623,21 +612,10 @@ print_summary() {
     fi
 
     if [[ "$ENABLE_CURSOR" == true ]]; then
-        local cursor_found=false
-        if [[ "$PLATFORM" == "macos" ]]; then
-            if [[ -d "/Applications/Cursor.app" ]] || command_exists cursor; then
-                cursor_found=true
-            fi
+        if command_exists cursor-agent || [[ -f "$HOME/.local/bin/cursor-agent" ]]; then
+            echo -e "  ${GREEN}✓${NC} cursor-agent (enabled, installed)"
         else
-            if command_exists cursor; then
-                cursor_found=true
-            fi
-        fi
-
-        if [[ "$cursor_found" == true ]]; then
-            echo -e "  ${GREEN}✓${NC} cursor (enabled, installed)"
-        else
-            echo -e "  ${YELLOW}○${NC} cursor (enabled, not installed)"
+            echo -e "  ${YELLOW}○${NC} cursor-agent (enabled, not installed)"
         fi
     else
         echo -e "  ${RED}✗${NC} cursor (disabled)"
@@ -696,7 +674,7 @@ print_summary() {
         echo -e "    GitLab:  ${CYAN}glab auth login${NC}"
     fi
     if [[ "$ENABLE_CURSOR" == true ]]; then
-        echo "    Cursor:  Sign in within the Cursor IDE"
+        echo -e "    Cursor:  ${CYAN}cursor-agent login${NC} (or set CURSOR_API_KEY)"
     fi
     if [[ "$INSTALL_MCP" == true ]]; then
         echo "    MCP OAuth:"

--- a/bootstrap/lib/install.sh
+++ b/bootstrap/lib/install.sh
@@ -697,57 +697,44 @@ check_jq() {
     fi
 }
 
-# Install Cursor (if needed for cursor agent)
+# Install the cursor-agent CLI (headless Cursor agent used by parallel_agent.py)
 check_cursor() {
     if [[ "$ENABLE_CURSOR" == false ]]; then
         print_info "Cursor is disabled - skipping installation"
         return 0
     fi
 
-    print_step "Checking for Cursor IDE..."
+    print_step "Checking for cursor-agent CLI..."
 
-    local cursor_found=false
-
-    # Check for Cursor on macOS
-    if [[ "$PLATFORM" == "macos" ]]; then
-        if [[ -d "/Applications/Cursor.app" ]] || command_exists cursor; then
-            cursor_found=true
-        fi
-    # Check for Cursor on Linux
-    elif [[ "$PLATFORM" == "linux" ]]; then
-        if command_exists cursor; then
-            cursor_found=true
-        elif [[ -d "$HOME/.local/share/cursor" ]] || [[ -d "/opt/cursor" ]]; then
-            cursor_found=true
-        elif [[ -f "$HOME/.local/bin/cursor" ]]; then
-            cursor_found=true
-        fi
+    if command_exists cursor-agent || [[ -f "$HOME/.local/bin/cursor-agent" ]]; then
+        print_success "cursor-agent is installed"
+        return 0
     fi
 
-    if [[ "$cursor_found" == true ]]; then
-        print_success "Cursor is installed"
-    else
-        print_warning "Cursor IDE not found"
-        echo ""
-        echo -e "${BOLD}Cursor IDE Installation:${NC}"
-        echo "  Download from: https://cursor.sh"
+    print_warning "cursor-agent CLI not found"
+    echo ""
+    echo -e "${BOLD}cursor-agent Installation:${NC}"
+    echo "  curl https://cursor.com/install -fsS | bash"
+    echo ""
 
-        if [[ "$PLATFORM" == "linux" ]]; then
-            echo ""
-            echo "  Linux: Download the AppImage or .deb package"
-            echo "  After download, make it executable and add to PATH"
-        fi
-        echo ""
-
-        if prompt_yes_no "Open Cursor download page in browser?"; then
-            open_url "https://cursor.sh"
-            echo ""
-            print_info "After installing Cursor, run this script again to continue setup"
+    if prompt_yes_no "Install cursor-agent now?"; then
+        if curl https://cursor.com/install -fsS | bash; then
+            if command_exists cursor-agent || [[ -f "$HOME/.local/bin/cursor-agent" ]]; then
+                print_success "cursor-agent installed"
+                print_info "Authenticate with: cursor-agent login  (or set CURSOR_API_KEY)"
+            else
+                print_warning "cursor-agent installed but not yet on PATH (restart your shell)"
+            fi
         else
-            print_warning "Cursor not installed"
+            print_warning "cursor-agent installation failed"
             if prompt_yes_no "Disable Cursor in service configuration?"; then
                 ENABLE_CURSOR=false
             fi
+        fi
+    else
+        print_warning "cursor-agent not installed"
+        if prompt_yes_no "Disable Cursor in service configuration?"; then
+            ENABLE_CURSOR=false
         fi
     fi
 }

--- a/configs/claude/config/parallel_agent.yml
+++ b/configs/claude/config/parallel_agent.yml
@@ -122,10 +122,14 @@ cli_agents:
     model_args: ["-m", "{model}"]
     prompt_args: ["-p", "{prompt}"]
     output: stdout
+  # cursor-agent runs headless via --print; --mode ask keeps it read-only
+  # (review/analysis only — never edits files or runs shell, and can't hang on
+  # tool-approval prompts). Install: curl https://cursor.com/install -fsS | bash
   cursor:
-    binary: cursor
-    base_args: []
+    binary: cursor-agent
+    base_args: ["--print", "--output-format", "text", "--mode", "ask"]
     model_args: ["--model", "{model}"]
+    prompt_args: ["{prompt}"]
     output: stdout
   codex:
     binary: codex

--- a/configs/claude/config/services.yml
+++ b/configs/claude/config/services.yml
@@ -30,11 +30,11 @@ services:
       - flash    # Fast (default)
       - pro      # Advanced
 
-  # Cursor Agent - IDE-integrated AI
-  # Install: Download from https://cursor.sh
+  # Cursor Agent - headless CLI for code analysis
+  # Install: curl https://cursor.com/install -fsS | bash
   cursor:
     enabled: true
-    command: cursor
+    command: cursor-agent
     description: "IDE-integrated context, code-specific analysis"
     model_tiers:
       - mini     # Lightweight

--- a/configs/claude/prompts/spec_review_merge.md
+++ b/configs/claude/prompts/spec_review_merge.md
@@ -1,0 +1,26 @@
+<!-- configs/claude/prompts/spec_review_merge.md -->
+# Merge Reviewer Findings
+
+Several independent reviewers each cross-referenced a project's planning artifacts
+for internal consistency. Their raw findings are below. Merge them into ONE list:
+
+- Combine findings that describe the same gap into a single block (keep the
+  clearest wording and the most concrete recommendation).
+- Drop exact or near-duplicate findings.
+- Do not invent new findings that no reviewer raised.
+
+## Reviewer findings
+
+{{REVIEWS}}
+
+## Output
+
+For EACH distinct inconsistency, output one block in EXACTLY this format:
+
+⚠️  CLARIFICATION REQUIRED: <short title>
+   ├─ Location: <artifact A> vs <artifact B>
+   ├─ The Gap: <one sentence>
+   ├─ Recommended Direction: <concrete remediation>
+   └─ Reason Why: <which constraint it violates / why it matters>
+
+If the reviewers found no real inconsistencies, output the single token: NO_ISSUES

--- a/configs/claude/scripts/agents/config.py
+++ b/configs/claude/scripts/agents/config.py
@@ -138,9 +138,11 @@ class Config:
                     "output": "stdout",
                 },
                 "cursor": {
-                    "binary": "cursor",
-                    "base_args": [],
+                    "binary": "cursor-agent",
+                    "base_args": ["--print", "--output-format", "text",
+                                  "--mode", "ask"],
                     "model_args": ["--model", "{model}"],
+                    "prompt_args": ["{prompt}"],
                     "output": "stdout",
                 },
                 "codex": {

--- a/configs/claude/scripts/check_status.sh
+++ b/configs/claude/scripts/check_status.sh
@@ -195,16 +195,16 @@ else
 fi
 
 cursor_installed=false
-if command -v cursor &> /dev/null; then
-    echo -e "  ${GREEN}✓${NC} Cursor CLI available"
+if command -v cursor-agent &> /dev/null; then
+    echo -e "  ${GREEN}✓${NC} cursor-agent CLI available"
     cursor_installed=true
     if [[ "$VERBOSE" == true ]]; then
-        echo -e "    Location: $(which cursor)"
+        echo -e "    Location: $(which cursor-agent)"
     fi
 else
-    echo -e "  ${YELLOW}○${NC} Cursor not available (optional)"
+    echo -e "  ${YELLOW}○${NC} cursor-agent not available (optional)"
     if [[ "$VERBOSE" == true ]]; then
-        echo -e "    ${BLUE}→${NC} Download: https://cursor.sh"
+        echo -e "    ${BLUE}→${NC} Install: curl https://cursor.com/install -fsS | bash"
     fi
 fi
 

--- a/configs/claude/scripts/model_check.sh
+++ b/configs/claude/scripts/model_check.sh
@@ -146,9 +146,10 @@ main() {
     check_api_provider claude
     check_api_provider gemini
     check_cli_provider antigravity agy agy models
-    # Cursor and Codex CLIs expose no model-listing command (verified at
-    # implementation; revisit when they grow one).
-    echo "UNSUPPORTED: cursor (no listing command)"
+    # cursor-agent --list-models needs auth; check_cli_provider degrades to
+    # SKIPPED when unauthenticated, OK/STALE per tier when logged in.
+    check_cli_provider cursor cursor-agent cursor-agent --list-models
+    # Codex CLI exposes no model-listing command (revisit when it grows one).
     echo "UNSUPPORTED: codex (no listing command)"
     exit 0
 }

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -325,9 +325,9 @@ review() {
     local arts=() line
     while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(resolve_artifacts "$root")
     if [[ "${#arts[@]}" -eq 0 ]]; then echo "spec-review: nothing to review (no artifacts found)"; return 0; fi
-    echo "[spec-review] Cross-referencing project artifacts with Antigravity (agy)…"
+    echo "[spec-review] Cross-referencing project artifacts with the parallel agent panel…"
     local prompt raw; prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]+"${arts[@]}"}")"
-    raw="$(run_reviewer "$prompt")"
+    raw="$(run_panel "$prompt")"
     format_findings "$raw" "$fmt" "${#arts[@]}"
 }
 
@@ -341,7 +341,7 @@ _silent_review_inline() {
     while IFS= read -r line; do [[ -n "$line" ]] && arts+=("$line"); done < <(discover_artifacts "$root")
     [[ "${#arts[@]}" -eq 0 ]] && return 0   # defensive: nothing to review (set -u safe)
     prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]+"${arts[@]}"}")"
-    if ! raw="$(run_reviewer "$prompt" 2>>"$state/error.log")"; then
+    if ! raw="$(run_panel "$prompt" 2>>"$state/error.log")"; then
         return 0   # fail-open: reviewer failed, never block; hash not recorded
     fi
     # Record the hash only when feedback.md was actually written — a failed

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -14,6 +14,13 @@ SPEC_REVIEW_CONFIG="${SPEC_REVIEW_CONFIG:-$HOME/.claude/config/parallel_agent.ym
 SPEC_REVIEW_TEMPLATE="${SPEC_REVIEW_TEMPLATE:-${SCRIPT_DIR}/../prompts/spec_review.md}"
 SPEC_REVIEW_STATE="${SPEC_REVIEW_STATE:-.spec-review}"
 SPEC_REVIEW_NO_DETACH="${SPEC_REVIEW_NO_DETACH:-}"
+# Parallel-agent panel engine. PANEL_CMD fans the prompt across the panel; the
+# single-CLI SPEC_REVIEW_CLI seam is reused as the synthesizer (SYNTH_CLI) and as
+# the 0-agent fallback. Both injectable so tests can stub external CLIs.
+SPEC_REVIEW_PANEL_CMD="${SPEC_REVIEW_PANEL_CMD:-${SCRIPT_DIR}/parallel_agent.py}"
+SPEC_REVIEW_SYNTH_CLI="${SPEC_REVIEW_SYNTH_CLI:-$SPEC_REVIEW_CLI}"
+SPEC_REVIEW_MERGE_TEMPLATE="${SPEC_REVIEW_MERGE_TEMPLATE:-${SCRIPT_DIR}/../prompts/spec_review_merge.md}"
+SPEC_REVIEW_TIMEOUT="${SPEC_REVIEW_TIMEOUT:-600}"
 
 SPEC=""; PLAN=""; TASKS=""; SILENT=false; FORMAT="tree"; ROOT="."
 
@@ -102,6 +109,24 @@ assemble_prompt() {
     return "$rc"
 }
 
+# assemble_merge_prompt TEMPLATE REVIEWS_TEXT -> merge prompt on stdout.
+# Substitutes {{REVIEWS}} inline with the reviewer-findings block. Mirrors
+# assemble_prompt's awk substitution; bash 3.2-safe (no RETURN trap).
+assemble_merge_prompt() {
+    local template="$1" reviews="$2" reviewfile rc=0
+    reviewfile="$(mktemp)"
+    printf '%s\n' "$reviews" > "$reviewfile"
+    awk -v reviewfile="$reviewfile" '
+        /\{\{REVIEWS\}\}/ {
+            while ((getline ln < reviewfile) > 0) print ln
+            next
+        }
+        { print }
+    ' "$template" || rc=$?
+    rm -f "$reviewfile"
+    return "$rc"
+}
+
 # resolve_review_model -> model name on stdout, or empty. Precedence:
 # explicit SPEC_REVIEW_MODEL env always wins; otherwise, only for the default
 # agy reviewer, fall back to model_tiers.antigravity.advanced from the shared
@@ -140,6 +165,96 @@ run_reviewer() {
     [[ -n "$model" ]] && cli_args+=(--model "$model")
     cli_args+=(-p "Cross-reference the artifacts above per the instructions; output only the specified blocks or NO_ISSUES.")
     printf '%s' "$prompt" | "$SPEC_REVIEW_CLI" "${cli_args[@]}"  # array-safe (unconditional += above)
+}
+
+# parse_panel_json JSON_FILE BLOCKS_OUT RAW_OUT  (parallel_agent.py --json file)
+# -> stdout: "<count>\t<all_no_issues 0|1>"; writes labeled blocks to BLOCKS_OUT
+# and raw outputs (blank-line joined) to RAW_OUT, for the successful agents.
+# all_no_issues=1 iff >=1 successful agent and NONE contain "CLARIFICATION
+# REQUIRED". Fail-open: malformed/absent JSON yields count 0 (caller falls back).
+# JSON is read from a file (not stdin) because the heredoc occupies stdin.
+parse_panel_json() {
+    python3 - "$1" "$2" "$3" <<'PY'
+import json, sys
+json_file, blocks_path, raw_path = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    text = open(json_file).read()
+except Exception:
+    text = ""
+try:
+    data = json.loads(text)
+except Exception:
+    # tolerate console preamble/trailing noise around the JSON object
+    i, j = text.find("{"), text.rfind("}")
+    try:
+        data = json.loads(text[i:j + 1]) if i != -1 and j != -1 else {}
+    except Exception:
+        data = {}
+agents = data.get("agents", {}) or {}
+ok = [(n, (a.get("output") or "").strip())
+      for n, a in sorted(agents.items())
+      if a.get("status") == "complete" and (a.get("output") or "").strip()]
+all_ni = bool(ok) and all("CLARIFICATION REQUIRED" not in o for _, o in ok)
+with open(blocks_path, "w") as f:
+    for n, o in ok:
+        f.write("=== REVIEWER: %s ===\n%s\n\n" % (n.upper(), o))
+with open(raw_path, "w") as f:
+    f.write("\n\n".join(o for _, o in ok))
+print("%d\t%d" % (len(ok), 1 if all_ni else 0))
+PY
+}
+
+# run_synthesizer  (labeled reviews block on stdin) -> merged findings on stdout.
+# Builds the merge prompt from the template and pipes it to the single-CLI synth
+# seam. Errors propagate so run_panel can fall back to a labeled concat.
+run_synthesizer() {
+    local reviews prompt model
+    reviews="$(cat)"
+    prompt="$(assemble_merge_prompt "$SPEC_REVIEW_MERGE_TEMPLATE" "$reviews")"
+    model="$(resolve_review_model)"
+    local cli_args=()
+    [[ -n "$model" ]] && cli_args+=(--model "$model")
+    cli_args+=(-p "Merge the reviewer findings above into one deduped list per the instructions; output only the specified blocks or NO_ISSUES.")
+    printf '%s' "$prompt" | "$SPEC_REVIEW_SYNTH_CLI" "${cli_args[@]}"
+}
+
+# run_panel PROMPT -> findings text (raw blocks or NO_ISSUES) on stdout.
+# Fans the prompt to the parallel-agent panel (excluding the author, claude),
+# then aggregates. Any panel/JSON problem falls back to the single-CLI seam;
+# a synth failure falls back to a labeled concat so findings are never lost.
+run_panel() {
+    local prompt="$1" tmpjson tmpblocks tmpraw meta count all_ni out
+    tmpjson="$(mktemp)"; tmpblocks="$(mktemp)"; tmpraw="$(mktemp)"
+    # Prompt is passed as the trailing positional arg (parallel_agent.py reads no
+    # stdin); `--` guards a prompt that might start with '-'. Planning artifacts
+    # are bounded, so ARG_MAX is not a concern.
+    if ! "$SPEC_REVIEW_PANEL_CMD" --json --no-claude --no-synthesize \
+            --no-stream --timeout "$SPEC_REVIEW_TIMEOUT" -- "$prompt" \
+            > "$tmpjson" 2>/dev/null
+    then
+        rm -f "$tmpjson" "$tmpblocks" "$tmpraw"
+        run_reviewer "$prompt"; return $?
+    fi
+    meta="$(parse_panel_json "$tmpjson" "$tmpblocks" "$tmpraw" 2>/dev/null)" || meta="0	0"
+    count="${meta%%$'\t'*}"; all_ni="${meta##*$'\t'}"
+    if [[ -z "$count" || "$count" == "0" ]]; then
+        rm -f "$tmpjson" "$tmpblocks" "$tmpraw"
+        run_reviewer "$prompt"; return $?
+    fi
+    if [[ "$all_ni" == "1" ]]; then
+        rm -f "$tmpjson" "$tmpblocks" "$tmpraw"
+        printf 'NO_ISSUES\n'; return 0
+    fi
+    if [[ "$count" == "1" ]]; then
+        cat "$tmpraw"
+    else
+        if ! out="$(run_synthesizer < "$tmpblocks")"; then
+            out="$(cat "$tmpblocks")"   # synth failed: keep labeled findings
+        fi
+        printf '%s\n' "$out"
+    fi
+    rm -f "$tmpjson" "$tmpblocks" "$tmpraw"
+    return 0
 }
 
 # format_findings RAW FORMAT [COUNT] -> formatted output. NO_ISSUES -> clean

--- a/configs/claude/scripts/spec_review.sh
+++ b/configs/claude/scripts/spec_review.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # spec_review.sh — cross-reference spec/plan/tasks artifacts for consistency via
-# an independent reviewer CLI (default: agy / Antigravity). Analysis-only: never
-# edits artifacts. Reviewer is the injectable SPEC_REVIEW_CLI seam. Front-end-agnostic — the
-# /spec-review skill, the save hook, and any future CLI all wrap this script.
+# the parallel-agent panel (parallel_agent.py --no-claude), synthesizing the
+# reviewers' findings into one deduped list. Analysis-only: never edits artifacts.
+# The single-CLI SPEC_REVIEW_CLI seam is reused as the synthesizer and as the
+# fallback when the panel is unavailable. Front-end-agnostic — the /spec-review
+# skill, the save hook, and any future CLI all wrap this script.
 #
 # Usage: spec_review.sh [--spec F] [--plan F] [--tasks F] [--silent] [--format tree|json] [ROOT]
 set -euo pipefail

--- a/configs/cursor/rules/spec-review.mdc
+++ b/configs/cursor/rules/spec-review.mdc
@@ -1,12 +1,12 @@
 ---
-description: "Cross-reference spec/plan/tasks artifacts for internal consistency using Antigravity/agy; surfaces structured remediation guidance. Analysis-only, never edits. Works with speckit (spec.md/plan.md/tasks.md) and superpowers layouts; auto-discovers or takes explicit paths."
+description: "Cross-reference spec/plan/tasks artifacts for internal consistency using the parallel-agent panel (gemini/cursor/codex/antigravity, excluding the author) and a synthesized deduped findings list. Analysis-only, never edits. Works with speckit (spec.md/plan.md/tasks.md) and superpowers layouts; auto-discovers or takes explicit paths."
 globs: ".claude/skills/spec-review/**"
 alwaysApply: false
 ---
 
 # spec-review
 
-Cross-reference spec/plan/tasks artifacts for internal consistency using Antigravity/agy; surfaces structured remediation guidance. Analysis-only, never edits. Works with speckit (spec.md/plan.md/tasks.md) and superpowers layouts; auto-discovers or takes explicit paths.
+Cross-reference spec/plan/tasks artifacts for internal consistency using the parallel-agent panel (gemini/cursor/codex/antigravity, excluding the author) and a synthesized deduped findings list. Analysis-only, never edits. Works with speckit (spec.md/plan.md/tasks.md) and superpowers layouts; auto-discovers or takes explicit paths.
 
 <!-- Auto-generated from .claude/skills/spec-review/SKILL.md -->
 <!-- Regenerate with: .claude/scripts/generate_cursor_rules.sh -->

--- a/configs/gemini/GEMINI.md
+++ b/configs/gemini/GEMINI.md
@@ -292,7 +292,7 @@ Use agents for their strengths:
 
 The script implements:
 
-- **Agent validation**: Checks if `cursor`, `gemini`, and `claude` commands exist
+- **Agent validation**: Checks if `cursor-agent`, `gemini`, and `claude` commands exist
 - **Retry logic**: Retries once after 5s delay on failure
 - **Partial results**: Continues with available agent outputs if some fail
 - **Credit fallback**: Automatically retries with cheaper models on quota errors

--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -1063,7 +1063,7 @@ services:
     command: gemini
   cursor:
     enabled: true
-    command: cursor
+    command: cursor-agent
   skillclaw:
     enabled: false       # opt-in; enable with --enable-skillclaw
     command: skillclaw

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -78,10 +78,10 @@ services:
       - flash    # Fast (default)
       - pro      # Advanced
 
-  # Cursor Agent - IDE-integrated AI
+  # Cursor Agent - headless CLI for code analysis
   cursor:
     enabled: true
-    command: cursor
+    command: cursor-agent
     description: "IDE-integrated context, code-specific analysis"
     model_tiers:
       - mini     # Lightweight
@@ -746,9 +746,10 @@ cli_agents:
     prompt_args: ["-p", "{prompt}"]
     output: stdout
   cursor:
-    binary: cursor
-    base_args: []
+    binary: cursor-agent
+    base_args: ["--print", "--output-format", "text", "--mode", "ask"]
     model_args: ["--model", "{model}"]
+    prompt_args: ["{prompt}"]
     output: stdout
   codex:
     binary: codex

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -98,8 +98,9 @@ sudo apt install nodejs npm
 npm install -g @anthropic-ai/claude-code
 npm install -g @google/gemini-cli
 
-# 3. Download Cursor
-# Visit: https://cursor.sh
+# 3. Install the cursor-agent CLI
+curl https://cursor.com/install -fsS | bash
+# Then authenticate: cursor-agent login  (or set CURSOR_API_KEY)
 
 # 4. Deploy configuration
 cp -r configs/claude/* ~/.claude/

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -143,15 +143,17 @@ npm --version
 # Check if CLI is installed
 which claude
 which gemini
-which cursor
+which cursor-agent
 
 # If missing, install
 npm install -g @anthropic-ai/claude-code
 npm install -g @google/gemini-cli
+curl https://cursor.com/install -fsS | bash
 
 # Verify installation
 claude --version
 gemini --version
+cursor-agent --version
 ```
 
 ---
@@ -750,11 +752,12 @@ ls -la ~/.claude/config/
 # Check CLI installations
 which claude
 which gemini
-which cursor
+which cursor-agent
 
 # Check versions
 claude --version
 gemini --version
+cursor-agent --version
 node --version
 npm --version
 ```

--- a/docs/superpowers/plans/2026-06-28-spec-review-parallel-agents.md
+++ b/docs/superpowers/plans/2026-06-28-spec-review-parallel-agents.md
@@ -1,0 +1,619 @@
+# Spec-Review via Parallel-Agent Panel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `spec-review` cross-reference planning artifacts with the parallel-agent panel (excluding the author, Claude) and synthesize one deduped findings list, replacing the single `agy` reviewer.
+
+**Architecture:** `spec_review.sh` keeps assemble → review → format (on-demand + detached hook). A new `run_panel` becomes the default engine: it pipes the assembled prompt to `parallel_agent.py --json --no-claude --no-synthesize`, parses each successful agent's output, and — for ≥2 agents — merges them with a deterministic synthesizer pass via the existing single-CLI seam. `run_reviewer` (the `SPEC_REVIEW_CLI` seam) is retained as synthesizer + 0-agent fallback. Analysis-only; never edits artifacts.
+
+**Tech Stack:** Bash (3.2-safe), python3 (json/yaml, already a dependency), bats + bats-support/bats-assert for tests, `parallel_agent.py` (existing orchestrator).
+
+## Global Constraints
+
+- Shell: `set -euo pipefail`; bash 3.2-safe (no `RETURN` trap, no associative arrays). — `spec_review.sh:8`
+- Error output routed through `err() { echo "spec-review: $*" >&2; }` (project script convention). Exempt: usage/help, status/info lines.
+- `--help` path must work before any dependency lookup (≤15 lines, exit 0).
+- Fail-open contract (issue #317): in `--silent` hook mode, any reviewer/synth/write failure → write nothing, do NOT record the content hash, retry next save. Never block.
+- Output contract unchanged: findings as `⚠️  CLARIFICATION REQUIRED:` blocks, or the single token `NO_ISSUES`.
+- All new behavior must be reachable through injectable seams so bats can stub external CLIs (no real network calls in tests).
+- New config defaults (add to the config block at top of `spec_review.sh`, verbatim):
+  - `SPEC_REVIEW_PANEL_CMD="${SPEC_REVIEW_PANEL_CMD:-${SCRIPT_DIR}/parallel_agent.py}"`
+  - `SPEC_REVIEW_SYNTH_CLI="${SPEC_REVIEW_SYNTH_CLI:-$SPEC_REVIEW_CLI}"`
+  - `SPEC_REVIEW_MERGE_TEMPLATE="${SPEC_REVIEW_MERGE_TEMPLATE:-${SCRIPT_DIR}/../prompts/spec_review_merge.md}"`
+  - `SPEC_REVIEW_TIMEOUT="${SPEC_REVIEW_TIMEOUT:-600}"`
+
+---
+
+## File Structure
+
+- `configs/claude/scripts/spec_review.sh` — add config defaults, `assemble_merge_prompt`, `parse_panel_json`, `run_synthesizer`, `run_panel`; rewire `review()` + `_silent_review_inline()` to call `run_panel`; update status line. (existing seams `run_reviewer`, `assemble_prompt`, `format_findings`, hook funcs unchanged)
+- `configs/claude/prompts/spec_review_merge.md` — NEW: synthesizer/merge instruction, same output contract.
+- `tests/bats/spec_review.bats` — add tests for the four new functions + rewired entry points; keep all existing tests green.
+- `.skillshare/skills/spec-review/SKILL.md` — description + body reflect the panel.
+- `configs/gemini/GEMINI.md`, `configs/cursor/rules/spec-review.mdc` — engine-description references.
+
+All test patterns follow the existing harness: `source "$SCRIPT"`, call functions directly, stub CLIs as executable files in `$SANDBOX`.
+
+---
+
+### Task 1: Merge template + config defaults + `assemble_merge_prompt`
+
+**Files:**
+- Create: `configs/claude/prompts/spec_review_merge.md`
+- Modify: `configs/claude/scripts/spec_review.sh` (config block ~L11-16; new function after `assemble_prompt` ~L103)
+- Test: `tests/bats/spec_review.bats`
+
+**Interfaces:**
+- Produces: `assemble_merge_prompt TEMPLATE REVIEWS_TEXT` → full merge prompt on stdout (template with `{{REVIEWS}}` replaced by `REVIEWS_TEXT`). New config vars `SPEC_REVIEW_PANEL_CMD`, `SPEC_REVIEW_SYNTH_CLI`, `SPEC_REVIEW_MERGE_TEMPLATE`, `SPEC_REVIEW_TIMEOUT`.
+
+- [ ] **Step 1: Create the merge template**
+
+Create `configs/claude/prompts/spec_review_merge.md`:
+
+```markdown
+<!-- configs/claude/prompts/spec_review_merge.md -->
+# Merge Reviewer Findings
+
+Several independent reviewers each cross-referenced a project's planning artifacts
+for internal consistency. Their raw findings are below. Merge them into ONE list:
+
+- Combine findings that describe the same gap into a single block (keep the
+  clearest wording and the most concrete recommendation).
+- Drop exact or near-duplicate findings.
+- Do not invent new findings that no reviewer raised.
+
+## Reviewer findings
+
+{{REVIEWS}}
+
+## Output
+
+For EACH distinct inconsistency, output one block in EXACTLY this format:
+
+⚠️  CLARIFICATION REQUIRED: <short title>
+   ├─ Location: <artifact A> vs <artifact B>
+   ├─ The Gap: <one sentence>
+   ├─ Recommended Direction: <concrete remediation>
+   └─ Reason Why: <which constraint it violates / why it matters>
+
+If the reviewers found no real inconsistencies, output the single token: NO_ISSUES
+```
+
+- [ ] **Step 2: Add the config defaults** to the config block of `spec_review.sh` (after the existing `SPEC_REVIEW_NO_DETACH` line, ~L16):
+
+```bash
+SPEC_REVIEW_PANEL_CMD="${SPEC_REVIEW_PANEL_CMD:-${SCRIPT_DIR}/parallel_agent.py}"
+SPEC_REVIEW_SYNTH_CLI="${SPEC_REVIEW_SYNTH_CLI:-$SPEC_REVIEW_CLI}"
+SPEC_REVIEW_MERGE_TEMPLATE="${SPEC_REVIEW_MERGE_TEMPLATE:-${SCRIPT_DIR}/../prompts/spec_review_merge.md}"
+SPEC_REVIEW_TIMEOUT="${SPEC_REVIEW_TIMEOUT:-600}"
+```
+
+- [ ] **Step 3: Write the failing test** — add to `tests/bats/spec_review.bats`:
+
+```bash
+@test "assemble_merge_prompt substitutes {{REVIEWS}} with the reviews block" {
+    local tpl="$SANDBOX/merge.md"; printf 'MHEAD\n{{REVIEWS}}\nMTAIL\n' > "$tpl"
+    source "$SCRIPT"
+    run assemble_merge_prompt "$tpl" "=== REVIEWER: GEMINI ===
+finding one"
+    assert_success
+    assert_output --partial "MHEAD"
+    assert_output --partial "=== REVIEWER: GEMINI ==="
+    assert_output --partial "finding one"
+    assert_output --partial "MTAIL"
+    refute_output --partial "{{REVIEWS}}"
+}
+```
+
+- [ ] **Step 4: Run it to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats -f "assemble_merge_prompt"`
+Expected: FAIL (`assemble_merge_prompt: command not found`)
+
+- [ ] **Step 5: Implement `assemble_merge_prompt`** in `spec_review.sh` (insert after `assemble_prompt`, ~L103):
+
+```bash
+# assemble_merge_prompt TEMPLATE REVIEWS_TEXT -> merge prompt on stdout.
+# Substitutes {{REVIEWS}} inline with the reviewer-findings block. Mirrors
+# assemble_prompt's awk substitution; bash 3.2-safe (no RETURN trap).
+assemble_merge_prompt() {
+    local template="$1" reviews="$2" reviewfile rc=0
+    reviewfile="$(mktemp)"
+    printf '%s\n' "$reviews" > "$reviewfile"
+    awk -v reviewfile="$reviewfile" '
+        /\{\{REVIEWS\}\}/ {
+            while ((getline ln < reviewfile) > 0) print ln
+            next
+        }
+        { print }
+    ' "$template" || rc=$?
+    rm -f "$reviewfile"
+    return "$rc"
+}
+```
+
+- [ ] **Step 6: Run it to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats -f "assemble_merge_prompt"`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add configs/claude/prompts/spec_review_merge.md configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): add merge template, config seams, assemble_merge_prompt"
+```
+
+---
+
+### Task 2: `parse_panel_json` — extract successful agent outputs
+
+**Files:**
+- Modify: `configs/claude/scripts/spec_review.sh` (new function after `assemble_merge_prompt`)
+- Test: `tests/bats/spec_review.bats`
+
+**Interfaces:**
+- Consumes: `parallel_agent.py --json` output shape `{"agents": {NAME: {"status": "...", "output": "..."}}}` (status `"complete"` = success; from `runners.py:_collect_output`).
+- Produces: `parse_panel_json JSON_FILE BLOCKS_OUT RAW_OUT` reads JSON from a file (the heredoc occupies stdin); writes labeled blocks (`=== REVIEWER: NAME ===\n<output>\n\n`) to `BLOCKS_OUT`, raw outputs joined by blank lines to `RAW_OUT`; prints `"<count>\t<all_no_issues 0|1>"` to stdout. `all_no_issues=1` iff ≥1 successful agent and NONE of their outputs contain `CLARIFICATION REQUIRED`.
+
+- [ ] **Step 1: Write the failing test** — first add the `_panel_json` helper at
+file scope in `tests/bats/spec_review.bats` (next to `_fake_reviewer`), so tests
+can synthesize panel JSON fixtures:
+
+```bash
+_panel_json() {  # emit a parallel_agent.py-style JSON doc; args: "name|status|output"
+    python3 - "$@" <<'PY'
+import json, sys
+agents = {}
+for spec in sys.argv[1:]:
+    name, status, output = spec.split("|", 2)
+    agents[name] = {"status": status, "output": output}
+print(json.dumps({"agents": agents}))
+PY
+}
+```
+
+Then the tests (note: `run CMD < file` redirects the function's stdin — no
+`bash -c` / `declare -f` gymnastics needed):
+
+```bash
+@test "parse_panel_json reports count, all-no-issues flag, and writes blocks" {
+    source "$SCRIPT"
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: A" \
+                "cursor|complete|NO_ISSUES" \
+                "codex|failed|exit 1 boom" > "$SANDBOX/fx.json"
+    run parse_panel_json "$SANDBOX/fx.json" "$SANDBOX/blocks" "$SANDBOX/raw"
+    assert_success
+    assert_output "2	0"                       # 2 successful (gemini,cursor); not all-no-issues
+    grep -q "=== REVIEWER: GEMINI ===" "$SANDBOX/blocks"
+    grep -q "CLARIFICATION REQUIRED: A" "$SANDBOX/blocks"
+}
+
+@test "parse_panel_json flags all-no-issues when no CLARIFICATION present" {
+    source "$SCRIPT"
+    _panel_json "gemini|complete|NO_ISSUES" "cursor|complete|NO_ISSUES" > "$SANDBOX/fx.json"
+    run parse_panel_json "$SANDBOX/fx.json" "$SANDBOX/b" "$SANDBOX/r"
+    assert_success
+    assert_output "2	1"
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats -f "parse_panel_json"`
+Expected: FAIL (`parse_panel_json: command not found`)
+
+- [ ] **Step 3: Implement `parse_panel_json`** (insert after `assemble_merge_prompt`):
+
+```bash
+# parse_panel_json JSON_FILE BLOCKS_OUT RAW_OUT  (--json read from a file)
+# -> stdout: "<count>\t<all_no_issues 0|1>"; writes labeled blocks + raw outputs.
+# Fail-open: a malformed JSON doc yields count 0 (caller falls back).
+parse_panel_json() {
+    python3 - "$1" "$2" "$3" <<'PY'
+import json, sys
+json_file, blocks_path, raw_path = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    text = open(json_file).read()
+except Exception:
+    text = ""
+try:
+    data = json.loads(text)
+except Exception:
+    # tolerate console preamble/trailing noise around the JSON object
+    i, j = text.find("{"), text.rfind("}")
+    try:
+        data = json.loads(text[i:j + 1]) if i != -1 and j != -1 else {}
+    except Exception:
+        data = {}
+agents = data.get("agents", {}) or {}
+ok = [(n, (a.get("output") or "").strip())
+      for n, a in sorted(agents.items())
+      if a.get("status") == "complete" and (a.get("output") or "").strip()]
+all_ni = bool(ok) and all("CLARIFICATION REQUIRED" not in o for _, o in ok)
+with open(blocks_path, "w") as f:
+    for n, o in ok:
+        f.write("=== REVIEWER: %s ===\n%s\n\n" % (n.upper(), o))
+with open(raw_path, "w") as f:
+    f.write("\n\n".join(o for _, o in ok))
+print("%d\t%d" % (len(ok), 1 if all_ni else 0))
+PY
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats -f "parse_panel_json"`
+Expected: PASS (both tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): parse_panel_json extracts successful agent outputs"
+```
+
+---
+
+### Task 3: `run_synthesizer` — merge labeled reviews via the single-CLI seam
+
+**Files:**
+- Modify: `configs/claude/scripts/spec_review.sh` (new function after `run_reviewer`)
+- Test: `tests/bats/spec_review.bats`
+
+**Interfaces:**
+- Consumes: labeled reviews block on **stdin**; `assemble_merge_prompt`, `resolve_review_model`, `SPEC_REVIEW_SYNTH_CLI`, `SPEC_REVIEW_MERGE_TEMPLATE`.
+- Produces: `run_synthesizer` → merged findings (synth CLI stdout). Non-zero exit propagates so callers can fall back.
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+_fake_synth() {  # stub synth CLI that echoes a merged finding, proving it ran
+    cat > "$SANDBOX/synth" <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null   # consume the merge prompt on stdin
+printf '⚠️  CLARIFICATION REQUIRED: Merged\n   └─ Reason Why: deduped\n'
+STUB
+    chmod +x "$SANDBOX/synth"
+}
+
+@test "run_synthesizer merges reviews through the synth seam + merge template" {
+    _fake_synth
+    source "$SCRIPT"
+    SPEC_REVIEW_SYNTH_CLI="$SANDBOX/synth" \
+    SPEC_REVIEW_MERGE_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review_merge.md" \
+        run run_synthesizer <<< "=== REVIEWER: GEMINI ===
+finding one"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Merged"
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bats tests/bats/spec_review.bats -f "run_synthesizer"`
+Expected: FAIL (`run_synthesizer: command not found`)
+
+- [ ] **Step 3: Implement `run_synthesizer`** (insert after `run_reviewer`, ~L143):
+
+```bash
+# run_synthesizer  (labeled reviews block on stdin) -> merged findings on stdout.
+# Builds the merge prompt from the template and pipes it to the single-CLI synth
+# seam. Errors propagate so run_panel can fall back to a labeled concat.
+run_synthesizer() {
+    local reviews prompt model
+    reviews="$(cat)"
+    prompt="$(assemble_merge_prompt "$SPEC_REVIEW_MERGE_TEMPLATE" "$reviews")"
+    model="$(resolve_review_model)"
+    local cli_args=()
+    [[ -n "$model" ]] && cli_args+=(--model "$model")
+    cli_args+=(-p "Merge the reviewer findings above into one deduped list per the instructions; output only the specified blocks or NO_ISSUES.")
+    printf '%s' "$prompt" | "$SPEC_REVIEW_SYNTH_CLI" "${cli_args[@]}"
+}
+```
+
+Note: `resolve_review_model` only emits a model when `SPEC_REVIEW_CLI == "agy"` (it reads `model_tiers.antigravity.advanced`). With a stubbed synth CLI it returns empty and no `--model` is passed — the test stub ignores args regardless.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bats tests/bats/spec_review.bats -f "run_synthesizer"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): run_synthesizer merges panel reviews via seam"
+```
+
+---
+
+### Task 4: `run_panel` — orchestrate panel call + aggregation + fallbacks
+
+**Files:**
+- Modify: `configs/claude/scripts/spec_review.sh` (new function after `run_synthesizer`)
+- Test: `tests/bats/spec_review.bats`
+
+**Interfaces:**
+- Consumes: assembled prompt (arg); `SPEC_REVIEW_PANEL_CMD`, `SPEC_REVIEW_TIMEOUT`, `parse_panel_json`, `run_synthesizer`, `run_reviewer`.
+- Produces: `run_panel PROMPT` → formatted-ready findings text (raw blocks or `NO_ISSUES`) on stdout. Routing: 0 agents → `run_reviewer` fallback; all-no-issues → `NO_ISSUES`; 1 agent → that output; ≥2 → `run_synthesizer` (on synth failure → labeled concat).
+
+- [ ] **Step 1: Write the failing tests**
+
+```bash
+_fake_panel() {  # stub parallel_agent.py emitting canned JSON from $PANEL_FIXTURE
+    cat > "$SANDBOX/panel" <<'STUB'
+#!/usr/bin/env bash
+# prompt arrives as the trailing positional arg; ignore it. Emit canned JSON.
+cat "$PANEL_FIXTURE"
+STUB
+    chmod +x "$SANDBOX/panel"
+}
+
+@test "run_panel: >=2 agents are merged by the synthesizer" {
+    _fake_panel; _fake_synth
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: A" \
+                "cursor|complete|⚠️  CLARIFICATION REQUIRED: B" > "$SANDBOX/fx.json"
+    source "$SCRIPT"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_SYNTH_CLI="$SANDBOX/synth" \
+    SPEC_REVIEW_MERGE_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review_merge.md" \
+        run run_panel "the assembled prompt"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Merged"
+}
+
+@test "run_panel: exactly 1 agent passes through without a synth call" {
+    _fake_panel
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: Solo" > "$SANDBOX/fx.json"
+    source "$SCRIPT"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_SYNTH_CLI="/bin/false" \
+        run run_panel "p"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Solo"
+}
+
+@test "run_panel: all NO_ISSUES short-circuits to NO_ISSUES (no synth call)" {
+    _fake_panel
+    _panel_json "gemini|complete|NO_ISSUES" "cursor|complete|NO_ISSUES" > "$SANDBOX/fx.json"
+    source "$SCRIPT"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_SYNTH_CLI="/bin/false" \
+        run run_panel "p"
+    assert_success
+    assert_output --partial "NO_ISSUES"
+}
+
+@test "run_panel: panel failure falls back to the single-CLI reviewer" {
+    _fake_reviewer    # provides $SANDBOX/agy
+    source "$SCRIPT"
+    SPEC_REVIEW_PANEL_CMD="/bin/false" \
+    SPEC_REVIEW_CLI="$SANDBOX/agy" \
+        run run_panel "p"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"   # from the agy stub
+}
+
+@test "run_panel: synthesizer failure falls back to labeled concat" {
+    _fake_panel
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: A" \
+                "cursor|complete|⚠️  CLARIFICATION REQUIRED: B" > "$SANDBOX/fx.json"
+    source "$SCRIPT"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_SYNTH_CLI="/bin/false" \
+    SPEC_REVIEW_MERGE_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review_merge.md" \
+        run run_panel "p"
+    assert_success
+    assert_output --partial "=== REVIEWER: GEMINI ==="
+    assert_output --partial "CLARIFICATION REQUIRED: A"
+    assert_output --partial "CLARIFICATION REQUIRED: B"
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bats tests/bats/spec_review.bats -f "run_panel"`
+Expected: FAIL (`run_panel: command not found`)
+
+- [ ] **Step 3: Implement `run_panel`** (insert after `run_synthesizer`):
+
+```bash
+# run_panel PROMPT -> findings text (raw blocks or NO_ISSUES) on stdout.
+# Fans the prompt to the parallel-agent panel (excluding the author, claude),
+# then aggregates. Any panel/JSON problem falls back to the single-CLI seam;
+# a synth failure falls back to a labeled concat so findings are never lost.
+run_panel() {
+    local prompt="$1" tmpjson tmpblocks tmpraw meta count all_ni out
+    tmpjson="$(mktemp)"; tmpblocks="$(mktemp)"; tmpraw="$(mktemp)"
+    # Prompt is passed as the trailing positional arg (parallel_agent.py reads no
+    # stdin); `--` guards a prompt that might start with '-'. Planning artifacts
+    # are bounded, so ARG_MAX is not a concern.
+    if ! "$SPEC_REVIEW_PANEL_CMD" --json --no-claude --no-synthesize \
+            --no-stream --timeout "$SPEC_REVIEW_TIMEOUT" -- "$prompt" \
+            > "$tmpjson" 2>/dev/null
+    then
+        rm -f "$tmpjson" "$tmpblocks" "$tmpraw"
+        run_reviewer "$prompt"; return $?
+    fi
+    meta="$(parse_panel_json "$tmpjson" "$tmpblocks" "$tmpraw" 2>/dev/null)" || meta="0	0"
+    count="${meta%%$'\t'*}"; all_ni="${meta##*$'\t'}"
+    if [[ -z "$count" || "$count" == "0" ]]; then
+        rm -f "$tmpjson" "$tmpblocks" "$tmpraw"
+        run_reviewer "$prompt"; return $?
+    fi
+    if [[ "$all_ni" == "1" ]]; then
+        rm -f "$tmpjson" "$tmpblocks" "$tmpraw"
+        printf 'NO_ISSUES\n'; return 0
+    fi
+    if [[ "$count" == "1" ]]; then
+        cat "$tmpraw"
+    else
+        if ! out="$(run_synthesizer < "$tmpblocks")"; then
+            out="$(cat "$tmpblocks")"   # synth failed: keep labeled findings
+        fi
+        printf '%s\n' "$out"
+    fi
+    rm -f "$tmpjson" "$tmpblocks" "$tmpraw"
+    return 0
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `bats tests/bats/spec_review.bats -f "run_panel"`
+Expected: PASS (all 5)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): run_panel orchestrates panel + synthesis + fallbacks"
+```
+
+---
+
+### Task 5: Rewire `review()` and `_silent_review_inline()` to use `run_panel`
+
+**Files:**
+- Modify: `configs/claude/scripts/spec_review.sh` (`review()` ~L208-217; `_silent_review_inline()` ~L222-240; status line ~L213)
+- Test: `tests/bats/spec_review.bats`
+
+**Interfaces:**
+- Consumes: `run_panel`. Both entry points now route through the panel (decision #4: parallel everywhere, incl. the hook).
+
+- [ ] **Step 1: Write the failing test** (on-demand path uses the panel):
+
+```bash
+@test "on-demand review routes through the parallel panel" {
+    _fake_panel
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: PanelPath" > "$SANDBOX/fx.json"
+    mkdir -p "$SANDBOX/specs/001"; : > "$SANDBOX/specs/001/spec.md"; : > "$SANDBOX/specs/001/plan.md"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" "$SANDBOX"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: PanelPath"
+}
+
+@test "silent mode routes through the panel and writes feedback (NO_DETACH)" {
+    _fake_panel
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: HookPanel" > "$SANDBOX/fx.json"
+    mkdir -p "$SANDBOX/specs/001"; printf 'a\n' > "$SANDBOX/specs/001/spec.md"; printf 'b\n' > "$SANDBOX/specs/001/plan.md"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_NO_DETACH=1 SPEC_REVIEW_STATE="$SANDBOX/.spec-review" \
+    SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" --silent "$SANDBOX"
+    assert_success
+    assert [ -f "$SANDBOX/.spec-review/feedback.md" ]
+    grep -q "CLARIFICATION REQUIRED: HookPanel" "$SANDBOX/.spec-review/feedback.md"
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bats tests/bats/spec_review.bats -f "panel"`
+Expected: FAIL (current `review`/`_silent_review_inline` call `run_reviewer`, which has no panel stub → error or wrong output)
+
+- [ ] **Step 3: Rewire `review()`** — replace its body's reviewer call and status line. Change:
+
+```bash
+    echo "[spec-review] Cross-referencing project artifacts with Antigravity (agy)…"
+    local prompt raw; prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]+"${arts[@]}"}")"
+    raw="$(run_reviewer "$prompt")"
+```
+
+to:
+
+```bash
+    echo "[spec-review] Cross-referencing project artifacts with the parallel agent panel…"
+    local prompt raw; prompt="$(assemble_prompt "$SPEC_REVIEW_TEMPLATE" "${arts[@]+"${arts[@]}"}")"
+    raw="$(run_panel "$prompt")"
+```
+
+- [ ] **Step 4: Rewire `_silent_review_inline()`** — change the reviewer call:
+
+```bash
+    if ! raw="$(run_reviewer "$prompt" 2>>"$state/error.log")"; then
+```
+
+to:
+
+```bash
+    if ! raw="$(run_panel "$prompt" 2>>"$state/error.log")"; then
+```
+
+(The surrounding fail-open / hash-recording / atomic-write logic is unchanged — `run_panel` already falls back internally, and a total failure still returns non-zero → hook fails open.)
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `bats tests/bats/spec_review.bats -f "panel"`
+Expected: PASS
+
+- [ ] **Step 6: Run the FULL spec_review suite (no regressions)**
+
+Run: `bats tests/bats/spec_review.bats`
+Expected: PASS (all tests — existing seam/hook tests still green because `run_reviewer` and the fallbacks are intact)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add configs/claude/scripts/spec_review.sh tests/bats/spec_review.bats
+git commit -m "feat(spec-review): route on-demand + hook review through the panel"
+```
+
+---
+
+### Task 6: Docs + skill + final verification
+
+**Files:**
+- Modify: `.skillshare/skills/spec-review/SKILL.md`, `configs/claude/scripts/spec_review.sh` (header comment ~L1-7), `configs/gemini/GEMINI.md`, `configs/cursor/rules/spec-review.mdc`
+- Test: `tests/bats/spec_review.bats` (existing SKILL.md frontmatter test must still pass), shellcheck
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Update `SKILL.md`** — replace the description and intro so they describe the panel. New frontmatter description:
+
+```markdown
+description: Cross-reference spec/plan/tasks artifacts for internal consistency using the parallel-agent panel (gemini/cursor/codex/antigravity, excluding the author) and a synthesized deduped findings list. Analysis-only, never edits. Works with speckit (spec.md/plan.md/tasks.md) and superpowers layouts; auto-discovers or takes explicit paths.
+```
+
+Update the body heading/intro from "Antigravity cross-reference" / "A second model (Antigravity / `agy`)" to: "Runs the parallel-agent panel (excluding the author) and synthesizes a single deduped findings list." Update the closing line `Requires the `agy` CLI` → `Requires `parallel_agent.py` plus at least one non-Claude agent CLI (falls back to a single `agy` review).`
+
+- [ ] **Step 2: Update the `spec_review.sh` header comment** (~L2-5) to say it fans out to the parallel-agent panel and synthesizes, keeping the `SPEC_REVIEW_CLI` seam as synthesizer + fallback.
+
+- [ ] **Step 3: Update `configs/gemini/GEMINI.md` and `configs/cursor/rules/spec-review.mdc`** — any sentence describing spec-review as an "Antigravity/agy" single-reviewer → "parallel-agent panel (excluding the author), synthesized". (grep each for `spec.review`/`agy` and adjust the description lines only.)
+
+- [ ] **Step 4: Run the SKILL.md frontmatter test**
+
+Run: `bats tests/bats/spec_review.bats -f "SKILL.md"`
+Expected: PASS (valid frontmatter, still points at the engine)
+
+- [ ] **Step 5: Shellcheck + full suite**
+
+Run: `shellcheck configs/claude/scripts/spec_review.sh && bats tests/bats/spec_review.bats`
+Expected: shellcheck clean (no new findings); all bats PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .skillshare/skills/spec-review/SKILL.md configs/claude/scripts/spec_review.sh configs/gemini/GEMINI.md configs/cursor/rules/spec-review.mdc
+git commit -m "docs(spec-review): describe parallel-agent panel engine"
+```
+
+---
+
+## Manual end-to-end verification (after all tasks)
+
+1. **On-demand, live panel** (needs ≥1 non-Claude agent authenticated):
+   `configs/claude/scripts/spec_review.sh --spec docs/superpowers/specs/2026-06-28-spec-review-parallel-agents-design.md`
+   → status line says "parallel agent panel"; output is one deduped block list or `NO_ISSUES`.
+2. **Fallback (no panel)**: `SPEC_REVIEW_PANEL_CMD=/bin/false SPEC_REVIEW_CLI=agy configs/claude/scripts/spec_review.sh --spec … --plan …` → single `agy` review still works.
+3. **Hook**: edit two artifacts under a `specs/<n>/` dir, run `spec_review.sh --silent .`, confirm `.spec-review/feedback.md` is written; a second unchanged run is a no-op (hash-gated).
+4. Confirm `git grep -n "Antigravity (agy)" configs/claude/scripts/spec_review.sh` returns nothing (status line updated).

--- a/docs/superpowers/specs/2026-06-28-spec-review-parallel-agents-design.md
+++ b/docs/superpowers/specs/2026-06-28-spec-review-parallel-agents-design.md
@@ -1,0 +1,134 @@
+# Spec-Review via the Parallel-Agent Panel — Design
+
+**Date**: 2026-06-28
+**Status**: Draft (pending approval)
+**Topic**: Update the `spec-review` skill to cross-reference planning artifacts with
+the multi-agent parallel panel instead of a single Antigravity (`agy`) reviewer.
+
+## Context
+
+`spec-review` runs an independent, analysis-only consistency check across a
+project's planning artifacts (speckit `spec.md`/`plan.md`/`tasks.md` or the
+superpowers `*-design.md` + `plans/*.md` layout). Today `spec_review.sh` pipes the
+assembled artifact prompt to **one** reviewer CLI via the injectable
+`SPEC_REVIEW_CLI` seam (default `agy`). A single model means a single blind spot:
+whatever that one reviewer misses goes unreported.
+
+This change fans the review out across the existing parallel-agent panel
+(`parallel_agent.py`: claude/gemini/cursor/codex/antigravity) and synthesizes
+their findings into one deduped list — more independent eyes, higher-signal
+output, fewer single-model misses. The skill stays analysis-only (never edits
+artifacts).
+
+### Decisions (locked with user)
+1. **Integration** — route through `parallel_agent.py` (reuse the panel,
+   rate-limiting, credit-fallback); keep the `SPEC_REVIEW_CLI` single-agent seam.
+2. **Panel** — exclude the author, Claude (`--no-claude`); reviewers are the other
+   enabled agents (gemini/cursor/codex/antigravity). Claude reviewing its own spec
+   is weak signal.
+3. **Aggregation** — always synthesize the panel's findings into one deduped
+   `CLARIFICATION REQUIRED` list. The orchestrator's built-in synthesis is gated on
+   a word-overlap `consensus_score < 0.50` (`synthesis.py:47`) — non-deterministic
+   for free-form findings — so spec-review does its own deterministic merge.
+4. **Hook mode** — parallel everywhere: the detached save-hook uses the full panel
+   too, relying on its existing detach + hash-gate + single-flight + fail-open
+   machinery to absorb the added latency.
+
+## Architecture
+
+`spec_review.sh` keeps its structure (assemble → review → format; on-demand +
+detached hook). A new `run_panel` becomes the default review engine. `run_reviewer`
+(the single-CLI seam) is retained for two narrower jobs: the **synthesizer** step
+and the **fallback** path. Both `review()` (on-demand) and `_silent_review_inline()`
+(hook) call `run_panel`.
+
+### Flow: `run_panel PROMPT`
+1. `assemble_prompt` (unchanged) → artifacts + template → combined prompt.
+2. Invoke the panel:
+   `$SPEC_REVIEW_PANEL_CMD --json --no-claude --no-synthesize --no-stream --timeout <T>`
+   with the prompt on stdin.
+   - `--no-claude` → decision #2.
+   - `--no-synthesize` → we synthesize ourselves (decision #3); avoids the
+     consensus-gated, non-deterministic built-in synthesis and a redundant call.
+3. Parse JSON (python3 helper, mirroring `resolve_review_model`): collect
+   `agents[name].output` for every agent whose `status == "complete"`.
+4. Aggregate by successful-agent count:
+   - **all outputs are `NO_ISSUES`** → emit `NO_ISSUES` (short-circuit; no merge call).
+   - **≥2 agents** → `run_synthesizer`: feed the N labeled reviews to the single-CLI
+     seam with the merge template → one deduped block list.
+   - **exactly 1 agent** → use its output directly (no merge needed).
+   - **0 agents** → fall back to single-CLI `run_reviewer` (a full review via the seam).
+5. `format_findings` (unchanged) → `tree` or `json`.
+
+### Data flow
+```
+artifacts → assemble_prompt → parallel_agent.py (N agents, --no-claude, --json)
+          → parse_panel_outputs → [run_synthesizer over N reviews] → format_findings
+```
+Hook mode wraps this in the existing detach / single-flight lock / hash-gate /
+fail-open path — unchanged.
+
+## Components
+
+| Unit | Responsibility | Depends on |
+|------|----------------|------------|
+| `run_panel(prompt)` | Orchestrate panel call + aggregation; pick merge / passthrough / fallback. | panel cmd, `parse_panel_outputs`, `run_synthesizer`, `run_reviewer` |
+| `parse_panel_outputs(json)` | Extract successful agents' outputs from `--json`. | python3/json |
+| `run_synthesizer(reviews)` | Merge N labeled reviews into one deduped block list via the single-CLI seam + merge template. | `SPEC_REVIEW_SYNTH_CLI`, merge template |
+| `run_reviewer(prompt)` | Unchanged single-CLI full review; now also the 0-agent fallback. | `SPEC_REVIEW_CLI` |
+| `format_findings` / `assemble_prompt` / hook funcs | Unchanged. | — |
+
+### New configuration seams
+- `SPEC_REVIEW_PANEL_CMD` — default `<script_dir>/parallel_agent.py`; injectable so
+  tests can stub a fake panel that emits canned JSON.
+- `SPEC_REVIEW_SYNTH_CLI` — default = `SPEC_REVIEW_CLI` (the synthesizer CLI).
+- New template `configs/claude/prompts/spec_review_merge.md` — instructs the
+  synthesizer to dedupe/merge the N reviews, emitting the **same** output contract
+  (`CLARIFICATION REQUIRED` blocks or `NO_ISSUES`) as `spec_review.md`.
+
+Panel args (`--no-claude --no-synthesize --no-stream`) are hardcoded (YAGNI: only
+`PANEL_CMD` needs to be injectable for tests).
+
+## Error handling (fail-open preserved)
+- Panel command missing / non-zero exit / empty or unparseable JSON → fall back to
+  single-CLI `run_reviewer`.
+- Synthesizer step fails → fall back to **labeled per-agent concatenation** so no
+  findings are lost.
+- Hook mode: any failure writes nothing and does **not** record the content hash, so
+  the same content is retried on the next save (preserves issue #317 contract).
+- Timeout: pass a generous per-agent timeout (default 600s) to `parallel_agent.py`;
+  the hook is detached, so latency never blocks the agent loop.
+
+## Testing
+Existing seam-based bats keep passing because `run_reviewer` and the
+`SPEC_REVIEW_CLI` seam are retained. New tests stub `parallel_agent.py` via
+`SPEC_REVIEW_PANEL_CMD` (a script emitting canned `--json`) and a synth CLI via
+`SPEC_REVIEW_SYNTH_CLI`, covering:
+- ≥2 agents → synthesizer merge is invoked, output formatted.
+- exactly 1 agent → passthrough (no merge call).
+- all `NO_ISSUES` → clean short-circuit, no merge call.
+- panel fails / empty JSON → single-CLI `run_reviewer` fallback.
+- synthesizer fails → labeled per-agent concat fallback (findings retained).
+- hook (`--silent` with `NO_DETACH`) still fail-open + hash-gated using the panel.
+
+## Docs / skill
+- `SKILL.md` — description + body: "uses the parallel-agent panel (independent of
+  the author) and synthesizes a deduped findings list."
+- `spec_review.sh` — header comment + the `[spec-review] Cross-referencing … with
+  Antigravity (agy)` status line → "with the parallel agent panel".
+- `configs/gemini/GEMINI.md` and `configs/cursor/rules/spec-review.mdc` engine
+  references updated.
+
+## Out of scope
+- No consensus-filter / finding-matching logic (decision #3 chose synthesis).
+- No change to `parallel_agent.py` itself (used as-is via its CLI).
+- No change to artifact discovery or the output contract.
+
+## Verification
+1. `shellcheck configs/claude/scripts/spec_review.sh`; `bats tests/bats/spec_review.bats`.
+2. On-demand: `spec_review.sh --spec … --plan …` → panel runs `--no-claude`, output
+   is one deduped block list (or `NO_ISSUES`).
+3. Hook: edit two artifacts, confirm detached run uses the panel and writes
+   `.spec-review/feedback.md`, second unchanged save is a no-op.
+4. Fallbacks: force panel cmd to a non-zero stub → single-CLI path; force synth CLI
+   to fail → labeled concat.

--- a/docs/superpowers/specs/2026-06-28-spec-review-parallel-agents-design.md
+++ b/docs/superpowers/specs/2026-06-28-spec-review-parallel-agents-design.md
@@ -45,8 +45,9 @@ and the **fallback** path. Both `review()` (on-demand) and `_silent_review_inlin
 ### Flow: `run_panel PROMPT`
 1. `assemble_prompt` (unchanged) → artifacts + template → combined prompt.
 2. Invoke the panel:
-   `$SPEC_REVIEW_PANEL_CMD --json --no-claude --no-synthesize --no-stream --timeout <T>`
-   with the prompt on stdin.
+   `$SPEC_REVIEW_PANEL_CMD --json --no-claude --no-synthesize --no-stream --timeout <T> -- "<prompt>"`
+   (the prompt is the trailing positional arg — `parallel_agent.py` reads no stdin;
+   planning artifacts are bounded so ARG_MAX is not a concern).
    - `--no-claude` → decision #2.
    - `--no-synthesize` → we synthesize ourselves (decision #3); avoids the
      consensus-gated, non-deterministic built-in synthesis and a redundant call.

--- a/tests/bats/check_status.bats
+++ b/tests/bats/check_status.bats
@@ -163,7 +163,7 @@ EOF
     assert_output --partial "Claude CLI not installed"
     assert_output --partial "npm install -g @anthropic-ai/claude-code"
     assert_output --partial "Gemini CLI not installed"
-    assert_output --partial "Cursor not available (optional)"
+    assert_output --partial "cursor-agent not available (optional)"
     assert_output --partial "Codex CLI not installed"
 }
 

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -10,6 +10,10 @@ SCRIPT="$REPO_ROOT/configs/claude/scripts/spec_review.sh"
 setup() {
     export BATS_TMPDIR="${BATS_TMPDIR:-/tmp}"
     SANDBOX=$(mktemp -d "$BATS_TMPDIR/spec_review.XXXXXX")
+    # Default the panel to a guaranteed-failing command so seam/discovery/format
+    # tests fall back to the single-CLI reviewer (the real parallel_agent.py lives
+    # next to the script and must never be invoked in tests). Panel tests override.
+    export SPEC_REVIEW_PANEL_CMD=/bin/false
 }
 
 teardown() {
@@ -87,6 +91,35 @@ cat >/dev/null   # consume stdin
 printf '⚠️  CLARIFICATION REQUIRED: Migration\n   ├─ Location: plan vs tasks\n   ├─ The Gap: zero-downtime vs destructive\n   ├─ Recommended Direction: split into 3 tasks\n   └─ Reason Why: locking violates the constraint\n'
 STUB
     chmod +x "$SANDBOX/agy"
+}
+
+_panel_json() {  # emit a parallel_agent.py-style JSON doc; args: "name|status|output"
+    python3 - "$@" <<'PY'
+import json, sys
+agents = {}
+for spec in sys.argv[1:]:
+    name, status, output = spec.split("|", 2)
+    agents[name] = {"status": status, "output": output}
+print(json.dumps({"agents": agents}))
+PY
+}
+
+_fake_synth() {  # stub synth CLI that echoes a merged finding, proving it ran
+    cat > "$SANDBOX/synth" <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null   # consume the merge prompt on stdin
+printf '⚠️  CLARIFICATION REQUIRED: Merged\n   └─ Reason Why: deduped\n'
+STUB
+    chmod +x "$SANDBOX/synth"
+}
+
+_fake_panel() {  # stub parallel_agent.py emitting canned JSON from $PANEL_FIXTURE
+    cat > "$SANDBOX/panel" <<'STUB'
+#!/usr/bin/env bash
+# prompt arrives as the trailing positional arg; ignore it. Emit canned JSON.
+cat "$PANEL_FIXTURE"
+STUB
+    chmod +x "$SANDBOX/panel"
 }
 
 @test "run_reviewer pipes prompt through the injectable seam" {
@@ -383,4 +416,124 @@ EOF
     run run_reviewer "prompt body"
     assert_success
     refute_output --partial "--model"
+}
+
+# ---------------------------------------------------------------------------
+# Parallel-agent panel engine
+# ---------------------------------------------------------------------------
+
+@test "assemble_merge_prompt substitutes {{REVIEWS}} with the reviews block" {
+    local tpl="$SANDBOX/merge.md"; printf 'MHEAD\n{{REVIEWS}}\nMTAIL\n' > "$tpl"
+    source "$SCRIPT"
+    run assemble_merge_prompt "$tpl" "=== REVIEWER: GEMINI ===
+finding one"
+    assert_success
+    assert_output --partial "MHEAD"
+    assert_output --partial "=== REVIEWER: GEMINI ==="
+    assert_output --partial "finding one"
+    assert_output --partial "MTAIL"
+    refute_output --partial "{{REVIEWS}}"
+}
+
+@test "parse_panel_json reports count, all-no-issues flag, and writes blocks" {
+    source "$SCRIPT"
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: A" \
+                "cursor|complete|NO_ISSUES" \
+                "codex|failed|exit 1 boom" > "$SANDBOX/fx.json"
+    run parse_panel_json "$SANDBOX/fx.json" "$SANDBOX/blocks" "$SANDBOX/raw"
+    assert_success
+    assert_output "2	0"
+    grep -q "=== REVIEWER: GEMINI ===" "$SANDBOX/blocks"
+    grep -q "CLARIFICATION REQUIRED: A" "$SANDBOX/blocks"
+}
+
+@test "parse_panel_json flags all-no-issues when no CLARIFICATION present" {
+    source "$SCRIPT"
+    _panel_json "gemini|complete|NO_ISSUES" "cursor|complete|NO_ISSUES" > "$SANDBOX/fx.json"
+    run parse_panel_json "$SANDBOX/fx.json" "$SANDBOX/b" "$SANDBOX/r"
+    assert_success
+    assert_output "2	1"
+}
+
+@test "parse_panel_json tolerates console preamble before the JSON" {
+    source "$SCRIPT"
+    { printf 'Warning: only 1 agent enabled\n'; _panel_json "gemini|complete|NO_ISSUES"; } > "$SANDBOX/fx.json"
+    run parse_panel_json "$SANDBOX/fx.json" "$SANDBOX/b" "$SANDBOX/r"
+    assert_success
+    assert_output "1	1"
+}
+
+@test "run_synthesizer merges reviews through the synth seam + merge template" {
+    _fake_synth
+    source "$SCRIPT"
+    SPEC_REVIEW_SYNTH_CLI="$SANDBOX/synth" \
+    SPEC_REVIEW_MERGE_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review_merge.md" \
+        run run_synthesizer <<< "=== REVIEWER: GEMINI ===
+finding one"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Merged"
+}
+
+@test "run_panel: >=2 agents are merged by the synthesizer" {
+    _fake_panel; _fake_synth
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: A" \
+                "cursor|complete|⚠️  CLARIFICATION REQUIRED: B" > "$SANDBOX/fx.json"
+    source "$SCRIPT"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_SYNTH_CLI="$SANDBOX/synth" \
+    SPEC_REVIEW_MERGE_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review_merge.md" \
+        run run_panel "the assembled prompt"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Merged"
+}
+
+@test "run_panel: exactly 1 agent passes through without a synth call" {
+    _fake_panel
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: Solo" > "$SANDBOX/fx.json"
+    source "$SCRIPT"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_SYNTH_CLI="/bin/false" \
+        run run_panel "p"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Solo"
+}
+
+@test "run_panel: all NO_ISSUES short-circuits to NO_ISSUES (no synth call)" {
+    _fake_panel
+    _panel_json "gemini|complete|NO_ISSUES" "cursor|complete|NO_ISSUES" > "$SANDBOX/fx.json"
+    source "$SCRIPT"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_SYNTH_CLI="/bin/false" \
+        run run_panel "p"
+    assert_success
+    assert_output --partial "NO_ISSUES"
+}
+
+@test "run_panel: panel failure falls back to the single-CLI reviewer" {
+    _fake_reviewer
+    source "$SCRIPT"
+    SPEC_REVIEW_PANEL_CMD="/bin/false" \
+    SPEC_REVIEW_CLI="$SANDBOX/agy" \
+        run run_panel "p"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: Migration"
+}
+
+@test "run_panel: synthesizer failure falls back to labeled concat" {
+    _fake_panel
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: A" \
+                "cursor|complete|⚠️  CLARIFICATION REQUIRED: B" > "$SANDBOX/fx.json"
+    source "$SCRIPT"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_SYNTH_CLI="/bin/false" \
+    SPEC_REVIEW_MERGE_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review_merge.md" \
+        run run_panel "p"
+    assert_success
+    assert_output --partial "=== REVIEWER: GEMINI ==="
+    assert_output --partial "CLARIFICATION REQUIRED: A"
+    assert_output --partial "CLARIFICATION REQUIRED: B"
 }

--- a/tests/bats/spec_review.bats
+++ b/tests/bats/spec_review.bats
@@ -537,3 +537,30 @@ finding one"
     assert_output --partial "CLARIFICATION REQUIRED: A"
     assert_output --partial "CLARIFICATION REQUIRED: B"
 }
+
+@test "on-demand review routes through the parallel panel" {
+    _fake_panel
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: PanelPath" > "$SANDBOX/fx.json"
+    mkdir -p "$SANDBOX/specs/001"; : > "$SANDBOX/specs/001/spec.md"; : > "$SANDBOX/specs/001/plan.md"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" "$SANDBOX"
+    assert_success
+    assert_output --partial "CLARIFICATION REQUIRED: PanelPath"
+    assert_output --partial "parallel agent panel"
+}
+
+@test "silent mode routes through the panel and writes feedback (NO_DETACH)" {
+    _fake_panel
+    _panel_json "gemini|complete|⚠️  CLARIFICATION REQUIRED: HookPanel" > "$SANDBOX/fx.json"
+    mkdir -p "$SANDBOX/specs/001"; printf 'a\n' > "$SANDBOX/specs/001/spec.md"; printf 'b\n' > "$SANDBOX/specs/001/plan.md"
+    PANEL_FIXTURE="$SANDBOX/fx.json" \
+    SPEC_REVIEW_PANEL_CMD="$SANDBOX/panel" \
+    SPEC_REVIEW_NO_DETACH=1 SPEC_REVIEW_STATE="$SANDBOX/.spec-review" \
+    SPEC_REVIEW_TEMPLATE="$REPO_ROOT/configs/claude/prompts/spec_review.md" \
+        run bash "$SCRIPT" --silent "$SANDBOX"
+    assert_success
+    assert [ -f "$SANDBOX/.spec-review/feedback.md" ]
+    grep -q "CLARIFICATION REQUIRED: HookPanel" "$SANDBOX/.spec-review/feedback.md"
+}

--- a/tests/python/agents/test_config.py
+++ b/tests/python/agents/test_config.py
@@ -190,6 +190,13 @@ class TestCliAgentsConfig:
             assert "model_args" in spec
             assert spec.get("output") in ("stdout", "file_then_stdout")
 
+    def test_cursor_uses_cursor_agent_binary_headless(self, tmp_path):
+        """cursor backend must invoke cursor-agent headless+read-only."""
+        spec = Config(config_path=str(tmp_path / "none.yml")).get("cli_agents.cursor")
+        assert spec["binary"] == "cursor-agent"
+        assert "--print" in spec["base_args"]
+        assert spec["base_args"][spec["base_args"].index("--mode") + 1] == "ask"
+
     def test_default_config_has_antigravity_entries(self, tmp_path):
         config = Config(config_path=str(tmp_path / "none.yml"))
         assert config.get("rate_limits.antigravity.requests_per_minute") == 100

--- a/tests/python/agents/test_runners.py
+++ b/tests/python/agents/test_runners.py
@@ -151,6 +151,17 @@ class TestCLIAgentCommandAssembly:
         i = cmd.index("--model")
         assert cmd[i + 1] == "gpt-5.1-codex"
 
+    def test_cursor_headless_invocation(self, tmp_path):
+        # Regression guard: cursor-agent must run headless (--print) and
+        # read-only (--mode ask), or it launches interactively and hangs.
+        agent = CLIAgent("cursor", model="flash",
+                         rate_limiter=_make_limiter(), config=_make_config(tmp_path))
+        cmd = agent._build_command("hello")
+        assert cmd[0] == "cursor-agent"
+        assert "--print" in cmd
+        assert cmd[cmd.index("--mode") + 1] == "ask"
+        assert cmd[-1] == "hello"
+
     def test_output_file_placeholder_dropped_when_no_file(self, tmp_path):
         # A stdout-strategy provider with a stray {output_file} placeholder
         # must not inject an empty argv element.
@@ -279,10 +290,10 @@ class TestCLIAgentExecution:
         """Issue #308: usage text on stdout + exit 1 must not count as an answer."""
         agent = CLIAgent("cursor", model="flash",
                          rate_limiter=_make_limiter(), config=_make_config(tmp_path))
-        result = agent._collect_output(1, b"Usage: cursor [options]", b"bad flag", None)
+        result = agent._collect_output(1, b"Usage: cursor-agent [options]", b"bad flag", None)
         assert result["status"] == "failed"
         assert "bad flag" in result["error"]
-        assert "Usage: cursor" in result["error"]  # preserved for debugging
+        assert "Usage: cursor-agent" in result["error"]  # preserved for debugging
         assert result["output"] == ""
 
     def test_real_subprocess_roundtrip(self, tmp_path):


### PR DESCRIPTION
Two related parallel-agent improvements.

---

## 1. spec-review → parallel-agent panel
Replaces spec-review's single `agy` reviewer with the **parallel-agent panel** (gemini/cursor/codex/antigravity — **excluding the author, Claude**), synthesizing the panel's findings into one deduped list. More independent reviewers → higher-signal findings. Analysis-only.

- New `run_panel` engine: assemble → `parallel_agent.py --json --no-claude --no-synthesize` (prompt as positional arg) → `parse_panel_json` → aggregate.
- Aggregation: all-NO_ISSUES → `NO_ISSUES`; 1 agent → passthrough; ≥2 → deterministic `run_synthesizer` merge (own merge, since the orchestrator gates synthesis on word-overlap consensus); 0 → single-CLI `run_reviewer` fallback; synth failure → labeled-concat fallback.
- Parallel everywhere incl. the detached save-hook (existing detach/hash-gate/fail-open preserved). `SPEC_REVIEW_CLI` seam retained as synthesizer + fallback.
- Seams: `SPEC_REVIEW_PANEL_CMD`, `SPEC_REVIEW_SYNTH_CLI`, `SPEC_REVIEW_MERGE_TEMPLATE`, `SPEC_REVIEW_TIMEOUT`.
- Spec: `docs/superpowers/specs/2026-06-28-spec-review-parallel-agents-design.md`; Plan: `docs/superpowers/plans/2026-06-28-spec-review-parallel-agents.md`.

## 2. cursor-agent backend migration
The orchestration `cursor` backend invoked a nonexistent `cursor` binary and omitted `--print` (would hang interactively). Repointed at the real **`cursor-agent`** CLI in headless read-only mode, and moved install/health/model-check off the Cursor IDE GUI onto the CLI.

- `parallel_agent.yml` + `config.py` default: `binary: cursor-agent`, `base_args: --print --output-format text --mode ask`.
- `services.yml` (heredoc + committed copy): `command: cursor-agent`.
- bootstrap `check_cursor()`/deploy/auth + `check_status.sh`: detect/install via `curl https://cursor.com/install`.
- `model_check.sh`: `cursor-agent --list-models` (SKIPPED unauthenticated).
- Tests: headless regression guards (`--print`/`--mode ask`); `Usage:` fixture + bats.
- Docs: install/detection references → `cursor-agent`.

---

## Verification
- spec-review suite **46/46**; cursor-agent + spec-review affected tests **100 pytest / 74 bats** green.
- Full working tree: **555 bats, 400 pytest, 0 failures**; clean PR-state worktree: **366 pytest** (smoke WIP correctly absent).
- `shellcheck` clean (only pre-existing info warnings).

> Note: this branch deliberately excludes the unrelated in-progress smoke-test-orchestrator work (specs/363) that shared some files — only the cursor-agent hunks were staged from `bootstrap.sh`/`config.sh`/`install.sh`/`AGENTS.md`/`GEMINI.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)