### PR TITLE
fix(bootstrap): make skill deploy resilient when rsync is absent

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -240,6 +240,7 @@ main() {
         install_github_cli || install_failures=$((install_failures + 1))
         install_gitlab_cli || install_failures=$((install_failures + 1))
         check_jq || install_failures=$((install_failures + 1))
+        check_rsync || install_failures=$((install_failures + 1))
         check_cursor || install_failures=$((install_failures + 1))
         if [[ $install_failures -gt 0 ]]; then
             print_warning "$install_failures install step(s) failed — continuing with remaining setup"

--- a/bootstrap/lib/common.sh
+++ b/bootstrap/lib/common.sh
@@ -123,7 +123,16 @@ deploy_home_skills() {
     # compat symlink), drop it so we deploy into a real directory, not its target.
     [[ -L "$dest" ]] && rm -f "$dest"
     mkdir -p "$dest"
-    rsync -a "$src"/ "$dest"/
+    # Copy the skill tree. Prefer rsync; fall back to cp so a minimal host without
+    # rsync (some slim Linux images) still deploys skills instead of silently
+    # no-op'ing / hard-failing under set -e. `cp -R src/. dest/` copies CONTENTS
+    # into dest and preserves symlinks-as-symlinks, matching `rsync -a src/ dest/`
+    # for our merge-then-prune model (the prune step below handles removals).
+    if command -v rsync > /dev/null 2>&1; then
+        rsync -a "$src"/ "$dest"/
+    else
+        cp -R "$src"/. "$dest"/
+    fi
 
     # Prune previously-deployed skills now absent from the source.
     # Safety bounds: (a) an empty source (failed checkout / wrong path that

--- a/bootstrap/lib/install.sh
+++ b/bootstrap/lib/install.sh
@@ -697,6 +697,60 @@ check_jq() {
     fi
 }
 
+# Ensure rsync is available — the config/skill deploy in deploy.sh + common.sh
+# uses it (the config-tree copy and the skill copy). Best-effort auto-install;
+# non-fatal: deploy_home_skills already has a cp fallback, but the config-tree
+# rsync (with --exclude) prefers rsync, so we try to provide it. Every path
+# returns 0 so the unguarded caller is never aborted under set -e.
+check_rsync() {
+    if command_exists rsync; then
+        print_success "rsync is installed"
+        return 0
+    fi
+
+    print_step "Installing rsync (used by config/skill deploy)..."
+
+    case "$PLATFORM" in
+        macos)
+            if command_exists brew && brew install rsync; then
+                print_success "rsync installed"
+                return 0
+            fi
+            ;;
+        linux)
+            case "$PKG_MANAGER" in
+                apt)
+                    if sudo apt-get update -qq && sudo apt-get install -y -qq rsync; then
+                        print_success "rsync installed"
+                        return 0
+                    fi
+                    ;;
+                dnf | yum)
+                    if sudo "$PKG_MANAGER" install -y rsync; then
+                        print_success "rsync installed"
+                        return 0
+                    fi
+                    ;;
+                pacman)
+                    if sudo pacman -S --noconfirm rsync; then
+                        print_success "rsync installed"
+                        return 0
+                    fi
+                    ;;
+                zypper)
+                    if sudo zypper install -y rsync; then
+                        print_success "rsync installed"
+                        return 0
+                    fi
+                    ;;
+            esac
+            ;;
+    esac
+
+    print_warning "Could not install rsync automatically; skill deploy will fall back to cp. Install rsync for the full config-tree sync."
+    return 0
+}
+
 # Install the cursor-agent CLI (headless Cursor agent used by parallel_agent.py)
 check_cursor() {
     if [[ "$ENABLE_CURSOR" == false ]]; then

--- a/tests/bats/deploy_skills.bats
+++ b/tests/bats/deploy_skills.bats
@@ -139,6 +139,44 @@ teardown() {
     assert_output --partial "not found"
 }
 
+@test "deploy_home_skills falls back to cp when rsync is unavailable" {
+    # Minimal hosts (some slim Linux images) ship without rsync. The copy must
+    # still happen via cp rather than silently no-op or hard-fail under set -e.
+    mkdir -p "$SANDBOX/src/demo/sub"
+    echo body > "$SANDBOX/src/demo/SKILL.md"
+    echo leaf > "$SANDBOX/src/demo/sub/extra.md"
+
+    # Restricted PATH with the coreutils the function needs, but NO rsync.
+    local nobin="$SANDBOX/nobin"
+    mkdir -p "$nobin"
+    local t p
+    for t in rm mkdir cp find wc tr mv sed sort; do
+        p="$(command -v "$t")" && ln -s "$p" "$nobin/$t"
+    done
+
+    run env SRC="$SANDBOX/src" DEST="$SANDBOX/dest" NOBIN="$nobin" REPO="$REPO_ROOT" bash -c '
+        export PATH="$NOBIN"
+        # shellcheck disable=SC1090
+        source "$REPO/bootstrap/lib/common.sh"
+        command -v rsync >/dev/null 2>&1 && { echo "rsync STILL ON PATH"; exit 3; }
+        deploy_home_skills "$SRC" "$DEST"
+    '
+    assert_success
+    [ -f "$SANDBOX/dest/demo/SKILL.md" ]
+    [ -f "$SANDBOX/dest/demo/sub/extra.md" ]   # nested content copied too
+    assert_equal "$(cat "$SANDBOX/dest/demo/SKILL.md")" "body"
+}
+
+@test "check_rsync is a no-op success when rsync is already present" {
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/bootstrap/lib/install.sh"
+    PLATFORM=linux PKG_MANAGER=apt
+    command_exists rsync || skip "rsync not installed in this environment"
+    run check_rsync
+    assert_success
+    assert_output --partial "rsync is installed"
+}
+
 @test "deploy_configs (fresh) puts real skill dirs in TARGET and no '~' junk" {
     # Arrange an isolated TARGET and stub the heavy secondary deploys.
     export SCRIPT_DIR="$REPO_ROOT"


### PR DESCRIPTION
## Summary

`deploy_home_skills` (`bootstrap/lib/common.sh`) used `rsync -a` unconditionally. On a minimal host without `rsync` (e.g. slim Linux container images), the skill copy **silently no-ops**, so `~/.claude/skills` never gets populated — or, under `set -e`, the bootstrap hard-fails at the first `rsync`. This was surfaced while smoke-testing graphify on a fresh Debian container (PR #433); the issue is **pre-existing and independent of graphify**.

## Changes

- **`common.sh`** — `deploy_home_skills` falls back to `cp -R src/. dest/` when `rsync` is unavailable. Portable (GNU + BSD `cp`), preserves symlinks-as-symlinks, and the existing merge-then-prune model is unchanged.
- **`install.sh`** — new `check_rsync` best-effort-installs `rsync` (brew / apt / dnf / yum / pacman / zypper) so the config-tree copy in `deploy.sh` (which uses `rsync --exclude`, not just the skill copy) also benefits. Every path `return 0`, so it never aborts bootstrap under `set -e` (consistent with `check_jq`).
- **`bootstrap.sh`** — calls `check_rsync` in the install phase, next to `check_jq`.

## Why both a fallback *and* an installer

The `cp` fallback makes `deploy_home_skills` self-sufficient (it's also invoked standalone by the `sync-skills` CLI). `check_rsync` covers the broader deploy path (`deploy.sh`'s config-tree `rsync --exclude` copies) without rewriting that critical, well-tested path.

## Tests

- `deploy_home_skills falls back to cp when rsync is unavailable` — runs the function under a restricted `PATH` containing the needed coreutils but **no rsync**, asserts the (nested) skill tree still deploys.
- `check_rsync is a no-op success when rsync is already present`.
- shellcheck clean; full `deploy_skills.bats` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)