### PR TITLE
🎨 Palette: Semantic Colors for Disabled Services

### DIFF
--- a/bootstrap/lib/deploy.sh
+++ b/bootstrap/lib/deploy.sh
@@ -602,7 +602,7 @@ print_summary() {
             echo -e "  ${YELLOW}○${NC} claude (enabled, not installed)"
         fi
     else
-        echo -e "  ${RED}✗${NC} claude (disabled)"
+        echo -e "  ${YELLOW}○${NC} claude (disabled)"
     fi
 
     if [[ "$ENABLE_GEMINI" == true ]]; then
@@ -612,7 +612,7 @@ print_summary() {
             echo -e "  ${YELLOW}○${NC} gemini (enabled, not installed)"
         fi
     else
-        echo -e "  ${RED}✗${NC} gemini (disabled)"
+        echo -e "  ${YELLOW}○${NC} gemini (disabled)"
     fi
 
     if [[ "$ENABLE_CURSOR" == true ]]; then
@@ -622,7 +622,7 @@ print_summary() {
             echo -e "  ${YELLOW}○${NC} cursor-agent (enabled, not installed)"
         fi
     else
-        echo -e "  ${RED}✗${NC} cursor (disabled)"
+        echo -e "  ${YELLOW}○${NC} cursor (disabled)"
     fi
 
     if [[ "$ENABLE_CODEX" == true ]]; then
@@ -632,7 +632,7 @@ print_summary() {
             echo -e "  ${YELLOW}○${NC} codex (enabled, not installed)"
         fi
     else
-        echo -e "  ${RED}✗${NC} codex (disabled)"
+        echo -e "  ${YELLOW}○${NC} codex (disabled)"
     fi
 
     if [[ "$ENABLE_ANTIGRAVITY" == true ]]; then
@@ -654,7 +654,7 @@ print_summary() {
             echo -e "    ${BLUE}→${NC} Install via the Antigravity IDE, then run: agy install"
         fi
     else
-        echo -e "  ${RED}✗${NC} antigravity (disabled)"
+        echo -e "  ${YELLOW}○${NC} antigravity (disabled)"
     fi
     echo ""
 


### PR DESCRIPTION
💡 What: Replaced the red cross (✗) with a yellow circle (○) for intentionally disabled services in `bootstrap/lib/deploy.sh`.
🎯 Why: To provide a nuanced visual feedback and accurately reflect intermediate states in CLI status outputs, reducing cognitive overload by reserving red for true failures.
📸 Before/After: Not applicable (CLI output only).
♿ Accessibility: Improves CLI readability by not falsely alarming users about intentionally disabled services.

---
*PR created automatically by Jules for task [14078544770983160494](https://jules.google.com/task/14078544770983160494) started by @RB-chrismandich*