### PR TITLE
🎨 Palette: Semantic Colors for CLI States

### DIFF
--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -480,7 +480,7 @@ class Orchestrator:
             elif status in ("failed", "error"):
                 status_icon, status_color = "✗", "red"
             else:
-                status_icon, status_color = "⚠", "yellow"
+                status_icon, status_color = "○", "yellow"
             table.add_row(
                 agent_name.title(),
                 f"[{status_color}]{status_icon} {status}[/{status_color}]",


### PR DESCRIPTION
💡 What: Updated the CLI status table in `orchestrator.py` to use a yellow circle (`○`) instead of a warning (`⚠`) icon for neutral states (like missing agents).
🎯 Why: A warning icon incorrectly implies an error state for intentionally optional or missing components. Using a neutral yellow circle accurately reflects the non-error state, reducing cognitive load for users scanning the CLI output.
📸 Before/After: Visual update in terminal output from `⚠ missing` to `○ missing`.
♿ Accessibility: Improves semantic feedback by reserving more alarming icons strictly for true failure states.

---
*PR created automatically by Jules for task [126127467185247031](https://jules.google.com/task/126127467185247031) started by @RB-chrismandich*