### PR TITLE
feat(367): sub-agent dispatch guidance for skills

### DIFF
--- a/.skillshare/skills/a11y-audit/SKILL.md
+++ b/.skillshare/skills/a11y-audit/SKILL.md
@@ -139,3 +139,7 @@ Beyond WCAG, check for common ARIA misuse:
 - Skip minified and bundled files
 - Note checks that require manual verification (color contrast, cognitive load)
 - Cap findings at 100 per file
+
+## Sub-agent dispatch
+
+When ≥3 target files or pages need auditing, dispatch one sub-agent per file/page to audit it, then merge findings; below that, audit inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/a11y-audit/SKILL.md
+++ b/.skillshare/skills/a11y-audit/SKILL.md
@@ -142,4 +142,7 @@ Beyond WCAG, check for common ARIA misuse:
 
 ## Sub-agent dispatch
 
-When ≥3 target files or pages need auditing, dispatch one sub-agent per file/page to audit it, then merge findings; below that, audit inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 target files or pages need auditing, dispatch one sub-agent per file/page to audit it, then merge
+findings; below that, audit inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` /
+inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/bot-pr-triage/SKILL.md
+++ b/.skillshare/skills/bot-pr-triage/SKILL.md
@@ -14,3 +14,7 @@ Use when several automated PRs target the same file/region and you must decide m
 6. **Re-check mergeability against updated main between merges.** Sequential merges to the same file invalidate prior mergeability; `sleep` for recompute, re-query `mergeable`, then merge in order.
 7. **Sync and run the full suite after the batch.** Confirm the sequential merges composed cleanly (compile + tests). If new failures appear, rule out environment causes (e.g. signing-agent down failing temp-repo commits) before blaming a merge.
 8. **Flag the automation churn.** When a bot produced N PRs for one change, note it so the bot's dedup/conventions can be tightened upstream.
+
+## Sub-agent dispatch
+
+When ≥3 bot PRs are open, dispatch one sub-agent per PR (or batch) to triage it, then consolidate dispositions; below that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/bot-pr-triage/SKILL.md
+++ b/.skillshare/skills/bot-pr-triage/SKILL.md
@@ -4,17 +4,35 @@ description: Triage a queue of bot-generated PRs (Jules, Palette, Bolt, Copilot)
 ---
 # Bot-Generated PR Triage
 
-Use when several automated PRs target the same file/region and you must decide merge/close/hold per PR. Bots over-produce: duplicate one-line changes across many PRs and over-generalize narrow changes into blanket policy.
+Use when several automated PRs target the same file/region and you must decide merge/close/hold per PR.
+Bots over-produce: duplicate one-line changes across many PRs and over-generalize narrow changes into blanket policy.
 
-1. **List and group by touched file/region.** `gh pr list` then `gh pr diff <n>` for each. Bot descriptions are marketing — judge the diff, not the title.
-2. **Detect exact duplicates by blob, not by eyeball.** Compare the changed-blob hash across PRs (`gh pr diff` / `git ls-tree`); byte-identical blobs (same SHA) mean keep one, close the rest as duplicates. Keep the better-titled one.
-3. **Check for already-merged redundancy.** After merging one in a duplicate set, re-grep `main` for the change (e.g. `transient=True` already on the target line) — remaining PRs become no-ops; close them with an explanatory comment.
-4. **Verify each non-trivial diff is behavior-preserving before merging.** For refactors/opts (e.g. `Counter` rewrite, set-comprehension), read the surrounding code and confirm semantics are unchanged and final output still renders. Merge only when verified.
-5. **Hold PRs that contradict repo conventions.** Watch for over-generalized mandates (e.g. "deprecate all `.sh` for `.py`", "prohibit `~` in paths") that conflict with how the repo actually works. Post a review naming the specific blocking rules and what to change — do not merge.
-6. **Re-check mergeability against updated main between merges.** Sequential merges to the same file invalidate prior mergeability; `sleep` for recompute, re-query `mergeable`, then merge in order.
-7. **Sync and run the full suite after the batch.** Confirm the sequential merges composed cleanly (compile + tests). If new failures appear, rule out environment causes (e.g. signing-agent down failing temp-repo commits) before blaming a merge.
-8. **Flag the automation churn.** When a bot produced N PRs for one change, note it so the bot's dedup/conventions can be tightened upstream.
+1. **List and group by touched file/region.** `gh pr list` then `gh pr diff <n>` for each. Bot descriptions are
+   marketing — judge the diff, not the title.
+2. **Detect exact duplicates by blob, not by eyeball.** Compare the changed-blob hash across PRs
+   (`gh pr diff` / `git ls-tree`); byte-identical blobs (same SHA) mean keep one, close the rest as duplicates.
+   Keep the better-titled one.
+3. **Check for already-merged redundancy.** After merging one in a duplicate set, re-grep `main` for the change
+   (e.g. `transient=True` already on the target line) — remaining PRs become no-ops; close them with an
+   explanatory comment.
+4. **Verify each non-trivial diff is behavior-preserving before merging.** For refactors/opts (e.g. `Counter`
+   rewrite, set-comprehension), read the surrounding code and confirm semantics are unchanged and final output
+   still renders. Merge only when verified.
+5. **Hold PRs that contradict repo conventions.** Watch for over-generalized mandates (e.g. "deprecate all
+   `.sh` for `.py`", "prohibit `~` in paths") that conflict with how the repo actually works. Post a review
+   naming the specific blocking rules and what to change — do not merge.
+6. **Re-check mergeability against updated main between merges.** Sequential merges to the same file invalidate
+   prior mergeability; `sleep` for recompute, re-query `mergeable`, then merge in order.
+7. **Sync and run the full suite after the batch.** Confirm the sequential merges composed cleanly (compile
+   + tests). If new failures appear, rule out environment causes (e.g. signing-agent down failing temp-repo
+   commits) before blaming a merge.
+8. **Flag the automation churn.** When a bot produced N PRs for one change, note it so the bot's
+   dedup/conventions can be tightened upstream.
 
 ## Sub-agent dispatch
 
-When ≥3 bot PRs are open, dispatch one sub-agent per PR (or batch) to triage it, then consolidate dispositions; below that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 bot PRs are open, dispatch one sub-agent per PR (or batch) to triage it, then consolidate
+dispositions; below that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or
+`parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and
+do not re-dispatch.

--- a/.skillshare/skills/ci-workflow-trigger-security/SKILL.md
+++ b/.skillshare/skills/ci-workflow-trigger-security/SKILL.md
@@ -4,18 +4,71 @@ description: Audit a GitHub Actions / GitLab CI workflow on attacker-influenceab
 ---
 # Security-Review a CI Workflow on Untrusted Triggers
 
-Generic source→sink review (`diff-security-review`) and `mcp-server-security-audit` miss CI-specific escalations: the sink is a runner holding the **base repo's secrets**, the substitution happens in the runner's own `${{ }}`/shell semantics, and the attacker controls a fork PR's code or a comment's text while a privileged trigger runs in base-repo context. Apply this whenever a `.github/workflows/*.yml` (or `.gitlab-ci.yml`) fires on events an outsider can influence, or exposes `secrets.*`. To *build or lock down* such a workflow (CODEOWNERS, branch protection, environments), use `secure-comment-triggered-workflow`.
+Generic source→sink review (`diff-security-review`) and `mcp-server-security-audit` miss CI-specific
+escalations: the sink is a runner holding the **base repo's secrets**, the substitution happens in the
+runner's own `${{ }}`/shell semantics, and the attacker controls a fork PR's code or a comment's text while a
+privileged trigger runs in base-repo context. Apply this whenever a `.github/workflows/*.yml` (or
+`.gitlab-ci.yml`) fires on events an outsider can influence, or exposes `secrets.*`. To *build or lock down*
+such a workflow (CODEOWNERS, branch protection, environments), use `secure-comment-triggered-workflow`.
 
-1. **Classify the trigger's trust level.** `pull_request_target`, `issue_comment`, `issues`, `workflow_run`, and `discussion_comment` run with the **base repo's secrets and a writable token**, and are reachable by untrusted actors (any commenter, any fork-PR author). Plain `pull_request` from a fork runs **without** secrets and with a read-only token *by default* (a repo can opt to send secrets/write tokens to fork PRs; same-repo `pull_request` does get them). State which untrusted inputs the chosen trigger exposes; flag every secret-using job on the privileged triggers.
-2. **Enumerate attacker-controlled inputs.** Treat each as hostile: `github.event.comment.body`, `issue.title`/`issue.body`, `pull_request.title`/`body`/`head.ref`/`head.label`/`head.sha`, and branch/tag names.
-3. **Check what the `if:` gate actually authenticates.** `author_association ∈ {OWNER, MEMBER, COLLABORATOR}` is server-set and non-spoofable, but it has two gaps: (a) it gates the **commenter/actor — not the code/PR author** (a trusted maintainer commenting on an outsider's fork PR still passes the gate while the job points at fork-controlled content); and (b) it is **not a write-access check** — `COLLABORATOR` includes read-/triage-only collaborators and `MEMBER` is any org member, so a gate on this set can admit principals with no write access. For a privileged trigger, confirm the real permission level (e.g. `gh api repos/{owner}/{repo}/collaborators/{user}/permission` → `admin`/`write`) rather than `author_association` alone. Verify the gate covers the principal whose *code or data* the job consumes, not just who typed the trigger phrase.
-4. **Trace the ref/code the job operates on (pwn-request).** Look for a checkout or operation on `pull_request.head.ref`/`head.sha`. If a secret-bearing step (deploy, publish, an agent CLI with an API key, `gh` with a PAT, `npm install` running fork postinstall) acts on that fork-controlled tree (Makefile, postinstall, git filters, lint/CI configs) → **pwn-request, high severity**: attacker code executes with secrets in scope. Require `head.repo.full_name == base.repo.full_name` (or explicitly refuse fork PRs) before any checkout/operate step.
-5. **Hunt `${{ }}` expression injection.** Any `github.event.*` value interpolated directly into a `run:` block or a `with:`/`github-script` input is substituted into the YAML/shell **before** execution; a `"`, backtick, `$(...)`, or newline breaks quoting and can bleed into adjacent keys or execute commands. The fix is the distinction that matters: **bind the value to `env:` and reference the quoted `"$VAR"` inside `run:`** — once it arrives through the environment the `${{ }}` expansion never touches the script text, so it is data, not code (for `with:`/`github-script` inputs, read it from `process.env`/`core.getInput`, don't inline `${{ }}`). Flag the inline interpolation, not the env-bound passing. **Caveat — a `with:` input is only data if the *receiving* action doesn't shell-template it.** A composite action can re-introduce the injection by inline-templating an input into its own `run:` (e.g. `jq --arg x "${{ inputs.x }}"`), so an attacker-controlled value you hand off via `with:` (e.g. a fork PR's `head.ref` as a `starting_branch` input) still detonates inside the action. Fetch the action's metadata at the pinned SHA and read its `runs:` steps — the file is `action.yml` (GitHub's preferred name) or `action.yaml`, and a subdirectory action (`owner/repo/path@sha`) keeps it under that path, so derive the path from `uses:` and try both names: `gh api repos/OWNER/REPO/contents/PATH/action.yml?ref=SHA --jq .content | base64 -d` (retry with `action.yaml` on 404). Confirm each untrusted input it receives is env-bound, not interpolated — SHA-pinning fixes the version, not this. When in doubt, sanitize the value (strict allowlist, e.g. a ref against `^[A-Za-z0-9._/-]+$`) before the hand-off.
-6. **Audit `permissions:` and secret reach.** Demand least privilege (`contents: read` unless writes are needed); identify exactly which steps see `secrets.*`. A secret-bearing step gated only on untrusted input is the escalation target — narrow the gate or move the secret behind a manual approval / GitHub Environment.
-7. **Check the cheap hardening.** Trigger `types: [created]` only (no `edited` replay of an approved-looking comment), bot exclusion (`github.event.comment.user.type != 'Bot'` to stop self-trigger loops), and third-party actions pinned to a **full commit SHA**, not a mutable tag.
-8. **Prefer the structural remedy over a smarter gate.** Either refuse fork PRs before any secret is exposed (`head.repo.fork == true` → fail), or **split into two jobs**: an unprivileged job that builds/tests the fork code with no secrets, and a privileged job (triggered via `workflow_run` or gated on same-repo) that never checks out fork code. Don't rely on the author gate alone.
-9. **Report only findings with a concrete attacker path.** Rank pwn-request and secret-exfil as high; rank pure expression-injection without a secret/command sink as medium. For each, name the trigger, the untrusted input, and the sink it reaches.
+1. **Classify the trigger's trust level.** `pull_request_target`, `issue_comment`, `issues`, `workflow_run`,
+   and `discussion_comment` run with the **base repo's secrets and a writable token**, and are reachable by
+   untrusted actors (any commenter, any fork-PR author). Plain `pull_request` from a fork runs **without**
+   secrets and with a read-only token *by default* (a repo can opt to send secrets/write tokens to fork PRs;
+   same-repo `pull_request` does get them). State which untrusted inputs the chosen trigger exposes; flag
+   every secret-using job on the privileged triggers.
+2. **Enumerate attacker-controlled inputs.** Treat each as hostile: `github.event.comment.body`,
+   `issue.title`/`issue.body`, `pull_request.title`/`body`/`head.ref`/`head.label`/`head.sha`, and
+   branch/tag names.
+3. **Check what the `if:` gate actually authenticates.** `author_association ∈ {OWNER, MEMBER, COLLABORATOR}`
+   is server-set and non-spoofable, but it has two gaps: (a) it gates the **commenter/actor — not the code/PR
+   author** (a trusted maintainer commenting on an outsider's fork PR still passes the gate while the job
+   points at fork-controlled content); and (b) it is **not a write-access check** — `COLLABORATOR` includes
+   read-/triage-only collaborators and `MEMBER` is any org member, so a gate on this set can admit principals
+   with no write access. For a privileged trigger, confirm the real permission level (e.g. `gh api
+   repos/{owner}/{repo}/collaborators/{user}/permission` → `admin`/`write`) rather than `author_association`
+   alone. Verify the gate covers the principal whose *code or data* the job consumes, not just who typed the
+   trigger phrase.
+4. **Trace the ref/code the job operates on (pwn-request).** Look for a checkout or operation on
+   `pull_request.head.ref`/`head.sha`. If a secret-bearing step (deploy, publish, an agent CLI with an API
+   key, `gh` with a PAT, `npm install` running fork postinstall) acts on that fork-controlled tree (Makefile,
+   postinstall, git filters, lint/CI configs) → **pwn-request, high severity**: attacker code executes with
+   secrets in scope. Require `head.repo.full_name == base.repo.full_name` (or explicitly refuse fork PRs)
+   before any checkout/operate step.
+5. **Hunt `${{ }}` expression injection.** Any `github.event.*` value interpolated directly into a `run:`
+   block or a `with:`/`github-script` input is substituted into the YAML/shell **before** execution; a `"`,
+   backtick, `$(...)`, or newline breaks quoting and can bleed into adjacent keys or execute commands. The fix
+   is the distinction that matters: **bind the value to `env:` and reference the quoted `"$VAR"` inside
+   `run:`** — once it arrives through the environment the `${{ }}` expansion never touches the script text, so
+   it is data, not code (for `with:`/`github-script` inputs, read it from `process.env`/`core.getInput`, don't
+   inline `${{ }}`). Flag the inline interpolation, not the env-bound passing. **Caveat — a `with:` input is
+   only data if the *receiving* action doesn't shell-template it.** A composite action can re-introduce the
+   injection by inline-templating an input into its own `run:` (e.g. `jq --arg x "${{ inputs.x }}"`), so an
+   attacker-controlled value you hand off via `with:` (e.g. a fork PR's `head.ref` as a `starting_branch`
+   input) still detonates inside the action. Fetch the action's metadata at the pinned SHA and read its
+   `runs:` steps — the file is `action.yml` (GitHub's preferred name) or `action.yaml`, and a subdirectory
+   action (`owner/repo/path@sha`) keeps it under that path, so derive the path from `uses:` and try both
+   names: `gh api repos/OWNER/REPO/contents/PATH/action.yml?ref=SHA --jq .content | base64 -d` (retry with
+   `action.yaml` on 404). Confirm each untrusted input it receives is env-bound, not interpolated —
+   SHA-pinning fixes the version, not this. When in doubt, sanitize the value (strict allowlist, e.g. a ref
+   against `^[A-Za-z0-9._/-]+$`) before the hand-off.
+6. **Audit `permissions:` and secret reach.** Demand least privilege (`contents: read` unless writes are
+   needed); identify exactly which steps see `secrets.*`. A secret-bearing step gated only on untrusted input
+   is the escalation target — narrow the gate or move the secret behind a manual approval / GitHub Environment.
+7. **Check the cheap hardening.** Trigger `types: [created]` only (no `edited` replay of an approved-looking
+   comment), bot exclusion (`github.event.comment.user.type != 'Bot'` to stop self-trigger loops), and
+   third-party actions pinned to a **full commit SHA**, not a mutable tag.
+8. **Prefer the structural remedy over a smarter gate.** Either refuse fork PRs before any secret is exposed
+   (`head.repo.fork == true` → fail), or **split into two jobs**: an unprivileged job that builds/tests the
+   fork code with no secrets, and a privileged job (triggered via `workflow_run` or gated on same-repo) that
+   never checks out fork code. Don't rely on the author gate alone.
+9. **Report only findings with a concrete attacker path.** Rank pwn-request and secret-exfil as high; rank
+   pure expression-injection without a secret/command sink as medium. For each, name the trigger, the
+   untrusted input, and the sink it reaches.
 
 ## Sub-agent dispatch
 
-When ≥3 workflow files need auditing, dispatch one sub-agent per workflow to audit it, then merge findings; below that, audit inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 workflow files need auditing, dispatch one sub-agent per workflow to audit it, then merge findings;
+below that, audit inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` /
+inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/ci-workflow-trigger-security/SKILL.md
+++ b/.skillshare/skills/ci-workflow-trigger-security/SKILL.md
@@ -15,3 +15,7 @@ Generic source→sink review (`diff-security-review`) and `mcp-server-security-a
 7. **Check the cheap hardening.** Trigger `types: [created]` only (no `edited` replay of an approved-looking comment), bot exclusion (`github.event.comment.user.type != 'Bot'` to stop self-trigger loops), and third-party actions pinned to a **full commit SHA**, not a mutable tag.
 8. **Prefer the structural remedy over a smarter gate.** Either refuse fork PRs before any secret is exposed (`head.repo.fork == true` → fail), or **split into two jobs**: an unprivileged job that builds/tests the fork code with no secrets, and a privileged job (triggered via `workflow_run` or gated on same-repo) that never checks out fork code. Don't rely on the author gate alone.
 9. **Report only findings with a concrete attacker path.** Rank pwn-request and secret-exfil as high; rank pure expression-injection without a secret/command sink as medium. For each, name the trigger, the untrusted input, and the sink it reaches.
+
+## Sub-agent dispatch
+
+When ≥3 workflow files need auditing, dispatch one sub-agent per workflow to audit it, then merge findings; below that, audit inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/docs-all/SKILL.md
+++ b/.skillshare/skills/docs-all/SKILL.md
@@ -59,3 +59,7 @@ into one report.
 - If one of the three skills is unavailable, run the others and report the gap.
 - Verification scenario: see `specs/002-new-agent-skills/quickstart.md` (docs-all
   section) for how to confirm ordering, rationale, and failure-surfacing.
+
+## Sub-agent dispatch
+
+This skill always fans out: dispatch one sub-agent per docs sub-skill (docs-readme, docs-diagrams, docs-improve) and merge their reports. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/docs-all/SKILL.md
+++ b/.skillshare/skills/docs-all/SKILL.md
@@ -62,4 +62,7 @@ into one report.
 
 ## Sub-agent dispatch
 
-This skill always fans out: dispatch one sub-agent per docs sub-skill (docs-readme, docs-diagrams, docs-improve) and merge their reports. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+This skill always fans out: dispatch one sub-agent per docs sub-skill (docs-readme, docs-diagrams,
+docs-improve) and merge their reports. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` /
+inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/issue-prioritize/SKILL.md
+++ b/.skillshare/skills/issue-prioritize/SKILL.md
@@ -761,4 +761,7 @@ in the repository. The report includes:
 
 ## Sub-agent dispatch
 
-When ≥10 open issues need scoring, dispatch one sub-agent per issue batch to score them, then merge into one ranking; below that, score inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥10 open issues need scoring, dispatch one sub-agent per issue batch to score them, then merge into one ranking;
+below that, score inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline
+on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/issue-prioritize/SKILL.md
+++ b/.skillshare/skills/issue-prioritize/SKILL.md
@@ -758,3 +758,7 @@ in the repository. The report includes:
 - **Agent timeout**: Fall back to heuristic-only scores (Step 4)
 - **Agent parse failure**: Fall back to heuristic-only scores (Step 4)
 - **Empty body issues**: Score with defaults (readiness=2, risk=2)
+
+## Sub-agent dispatch
+
+When ≥10 open issues need scoring, dispatch one sub-agent per issue batch to score them, then merge into one ranking; below that, score inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/issue-triage/SKILL.md
+++ b/.skillshare/skills/issue-triage/SKILL.md
@@ -740,4 +740,7 @@ Consensus thresholds:
 
 ## Sub-agent dispatch
 
-When ≥3 issues need auditing, dispatch one sub-agent per issue batch to triage, then consolidate; below that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 issues need auditing, dispatch one sub-agent per issue batch to triage, then consolidate; below that, triage
+inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`):
+native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute
+their task directly and do not re-dispatch.

--- a/.skillshare/skills/issue-triage/SKILL.md
+++ b/.skillshare/skills/issue-triage/SKILL.md
@@ -737,3 +737,7 @@ Consensus thresholds:
 - 70-84%: RECOMMEND (require user approval)
 - 50-69%: HIGHLIGHT disagreements
 - <50%: ESCALATE to user
+
+## Sub-agent dispatch
+
+When ≥3 issues need auditing, dispatch one sub-agent per issue batch to triage, then consolidate; below that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/pr-review/SKILL.md
+++ b/.skillshare/skills/pr-review/SKILL.md
@@ -57,3 +57,7 @@ This skill is backed by `~/.claude/scripts/pr_review.sh`.
   difference between "no PRs" and "couldn't look".
 - To customize how PRs are fetched (internal mirrors, CI), set `PR_REVIEW_FETCH`
   to an executable that prints the normalized PR JSON array.
+
+## Sub-agent dispatch
+
+When ≥3 open PRs exist, dispatch one sub-agent per PR to assess mergeability, then consolidate; below that, review inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/pr-review/SKILL.md
+++ b/.skillshare/skills/pr-review/SKILL.md
@@ -60,4 +60,7 @@ This skill is backed by `~/.claude/scripts/pr_review.sh`.
 
 ## Sub-agent dispatch
 
-When ≥3 open PRs exist, dispatch one sub-agent per PR to assess mergeability, then consolidate; below that, review inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 open PRs exist, dispatch one sub-agent per PR to assess mergeability, then consolidate; below that, review
+inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` /
+inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/refactor-go/SKILL.md
+++ b/.skillshare/skills/refactor-go/SKILL.md
@@ -298,4 +298,8 @@ After completing the analysis, capture the most significant findings:
 
 ## Sub-agent dispatch
 
-When ≥3 independent packages or analysis dimensions exist, dispatch one sub-agent per package to analyze it, then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 independent packages or analysis dimensions exist, dispatch one sub-agent per package to analyze it,
+then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or
+`parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and
+do not re-dispatch.

--- a/.skillshare/skills/refactor-go/SKILL.md
+++ b/.skillshare/skills/refactor-go/SKILL.md
@@ -295,3 +295,7 @@ After completing the analysis, capture the most significant findings:
      ```
 
 3. This step is **non-blocking** -- failures in learning capture should not affect the analysis output.
+
+## Sub-agent dispatch
+
+When ≥3 independent packages or analysis dimensions exist, dispatch one sub-agent per package to analyze it, then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/refactor-node/SKILL.md
+++ b/.skillshare/skills/refactor-node/SKILL.md
@@ -247,3 +247,7 @@ After completing the analysis, capture the most significant findings:
      ```
 
 3. This step is **non-blocking** -- failures in learning capture should not affect the analysis output.
+
+## Sub-agent dispatch
+
+When ≥3 independent modules or analysis dimensions exist, dispatch one sub-agent per module to analyze it, then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/refactor-node/SKILL.md
+++ b/.skillshare/skills/refactor-node/SKILL.md
@@ -250,4 +250,8 @@ After completing the analysis, capture the most significant findings:
 
 ## Sub-agent dispatch
 
-When ≥3 independent modules or analysis dimensions exist, dispatch one sub-agent per module to analyze it, then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 independent modules or analysis dimensions exist, dispatch one sub-agent per module to analyze it,
+then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or
+`parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and
+do not re-dispatch.

--- a/.skillshare/skills/refactor-python/SKILL.md
+++ b/.skillshare/skills/refactor-python/SKILL.md
@@ -309,4 +309,8 @@ After completing the analysis, capture the most significant findings:
 
 ## Sub-agent dispatch
 
-When ≥3 independent modules or analysis dimensions exist, dispatch one sub-agent per module to analyze it, then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 independent modules or analysis dimensions exist, dispatch one sub-agent per module to analyze it,
+then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or
+`parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and
+do not re-dispatch.

--- a/.skillshare/skills/refactor-python/SKILL.md
+++ b/.skillshare/skills/refactor-python/SKILL.md
@@ -306,3 +306,7 @@ After completing the analysis, capture the most significant findings:
      ```
 
 3. This step is **non-blocking** -- failures in learning capture should not affect the analysis output.
+
+## Sub-agent dispatch
+
+When ≥3 independent modules or analysis dimensions exist, dispatch one sub-agent per module to analyze it, then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/refactor-shell/SKILL.md
+++ b/.skillshare/skills/refactor-shell/SKILL.md
@@ -457,4 +457,7 @@ After completing the analysis, capture the most significant findings:
 
 ## Sub-agent dispatch
 
-When ≥3 independent scripts exist, dispatch one sub-agent per script to analyze it, then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 independent scripts exist, dispatch one sub-agent per script to analyze it, then merge findings; below
+that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` /
+inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/refactor-shell/SKILL.md
+++ b/.skillshare/skills/refactor-shell/SKILL.md
@@ -454,3 +454,7 @@ After completing the analysis, capture the most significant findings:
      ```
 
 3. This step is **non-blocking** -- failures in learning capture should not affect the analysis output.
+
+## Sub-agent dispatch
+
+When ≥3 independent scripts exist, dispatch one sub-agent per script to analyze it, then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/refactor-terraform/SKILL.md
+++ b/.skillshare/skills/refactor-terraform/SKILL.md
@@ -227,3 +227,7 @@ After completing the analysis, capture the most significant findings:
      ```
 
 3. This step is **non-blocking** -- failures in learning capture should not affect the analysis output.
+
+## Sub-agent dispatch
+
+When ≥3 independent modules or stacks exist, dispatch one sub-agent per module to analyze it, then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/refactor-terraform/SKILL.md
+++ b/.skillshare/skills/refactor-terraform/SKILL.md
@@ -230,4 +230,7 @@ After completing the analysis, capture the most significant findings:
 
 ## Sub-agent dispatch
 
-When ≥3 independent modules or stacks exist, dispatch one sub-agent per module to analyze it, then merge findings; below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 independent modules or stacks exist, dispatch one sub-agent per module to analyze it, then merge findings;
+below that, analyze inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` /
+inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/repo-hygiene/SKILL.md
+++ b/.skillshare/skills/repo-hygiene/SKILL.md
@@ -211,3 +211,7 @@ Report the outcome per item (`closed` / `deleted` / `FAILED` + reason).
   the user there for blob-level dedup before this general sweep.
 - Issue backlog hygiene is a separate concern — see `issue-prioritize` /
   `issue-triage`.
+
+## Sub-agent dispatch
+
+When ≥3 open PRs or stale branches exist, dispatch one sub-agent per PR/branch batch to assess disposition, then consolidate; below that, sweep inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/repo-hygiene/SKILL.md
+++ b/.skillshare/skills/repo-hygiene/SKILL.md
@@ -214,4 +214,7 @@ Report the outcome per item (`closed` / `deleted` / `FAILED` + reason).
 
 ## Sub-agent dispatch
 
-When ≥3 open PRs or stale branches exist, dispatch one sub-agent per PR/branch batch to assess disposition, then consolidate; below that, sweep inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 open PRs or stale branches exist, dispatch one sub-agent per PR/branch batch to assess disposition, then
+consolidate; below that, sweep inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` /
+inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/research-validate-design/SKILL.md
+++ b/.skillshare/skills/research-validate-design/SKILL.md
@@ -14,3 +14,7 @@ Trigger: a design is drafted and the user says "research that this is the best a
 6. Fold confirmed improvements back into the design (e.g. drop a second dependency when one call suffices); for refuted assumptions, redesign before writing anything.
 7. Note any prerequisite the research surfaced that must be verified at build time (a published status-page slug must exist, a token must return data) and mark it build-and-verify.
 8. Only then write the spec, and state in it which choices were research-validated and which remain build-and-verify, with citations.
+
+## Sub-agent dispatch
+
+When ≥3 load-bearing assumptions need validation, dispatch one sub-agent per assumption to research it, then synthesize; below that, research inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/research-validate-design/SKILL.md
+++ b/.skillshare/skills/research-validate-design/SKILL.md
@@ -4,17 +4,30 @@ description: After drafting a design but before writing the spec, validate the d
 ---
 # Research-Validate Design Before Spec
 
-Trigger: a design is drafted and the user says "research that this is the best approach", or you are about to commit a spec that rests on unverified assumptions (an endpoint exists, a single-call alternative beats a two-call plan, a sidecar is the only path).
+Trigger: a design is drafted and the user says "research that this is the best approach", or you are about to
+commit a spec that rests on unverified assumptions (an endpoint exists, a single-call alternative beats a two-call
+plan, a sidecar is the only path).
 
-1. Extract every load-bearing assumption from the draft: claimed API capabilities, "X is the only way", data-source choices, library/tooling picks, rate-limit guesses. List them explicitly.
-2. Rank assumptions by blast radius — which ones, if wrong, force a redesign (vs cosmetic). Research the high-blast-radius ones first.
-3. For each, run a focused query (WebSearch / official docs / Context7 / client source). Prefer primary sources (vendor API reference, the actual client code) over blog posts.
-4. Look specifically for a SIMPLER path the draft missed — a single endpoint that returns current+forecast in one call, a built-in default that removes a subrequest, an existing connector in a sibling repo that already documents an undocumented endpoint.
+1. Extract every load-bearing assumption from the draft: claimed API capabilities, "X is the only way",
+   data-source choices, library/tooling picks, rate-limit guesses. List them explicitly.
+2. Rank assumptions by blast radius — which ones, if wrong, force a redesign (vs cosmetic). Research the
+   high-blast-radius ones first.
+3. For each, run a focused query (WebSearch / official docs / Context7 / client source). Prefer primary sources
+   (vendor API reference, the actual client code) over blog posts.
+4. Look specifically for a SIMPLER path the draft missed — a single endpoint that returns current+forecast in one
+   call, a built-in default that removes a subrequest, an existing connector in a sibling repo that already
+   documents an undocumented endpoint.
 5. For each assumption, record the verdict: confirmed / refuted / improved-alternative-found, with the source URL.
-6. Fold confirmed improvements back into the design (e.g. drop a second dependency when one call suffices); for refuted assumptions, redesign before writing anything.
-7. Note any prerequisite the research surfaced that must be verified at build time (a published status-page slug must exist, a token must return data) and mark it build-and-verify.
-8. Only then write the spec, and state in it which choices were research-validated and which remain build-and-verify, with citations.
+6. Fold confirmed improvements back into the design (e.g. drop a second dependency when one call suffices); for
+   refuted assumptions, redesign before writing anything.
+7. Note any prerequisite the research surfaced that must be verified at build time (a published status-page slug
+   must exist, a token must return data) and mark it build-and-verify.
+8. Only then write the spec, and state in it which choices were research-validated and which remain
+   build-and-verify, with citations.
 
 ## Sub-agent dispatch
 
-When ≥3 load-bearing assumptions need validation, dispatch one sub-agent per assumption to research it, then synthesize; below that, research inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 load-bearing assumptions need validation, dispatch one sub-agent per assumption to research it, then
+synthesize; below that, research inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` /
+inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/security-finding-refutation/SKILL.md
+++ b/.skillshare/skills/security-finding-refutation/SKILL.md
@@ -4,16 +4,42 @@ description: Adversarially verify a list of candidate security findings to cut f
 ---
 # Security Finding Refutation
 
-A second-pass verification stage: given candidate vulnerabilities (from a finder pass or another tool), try to *disprove* each one. Default to SURVIVES — refute only with cited evidence, never speculation. The goal is to eliminate plausible-but-wrong findings, not to agree.
+A second-pass verification stage: given candidate vulnerabilities (from a finder pass or another tool),
+try to *disprove* each one. Default to SURVIVES — refute only with cited evidence, never speculation. The goal is
+to eliminate plausible-but-wrong findings, not to agree.
 
-1. **Frame attacker vs victim first.** For each candidate, name who controls the malicious input (attacker) and who is harmed (victim). REFUTE if the only victim is the attacker on their own machine at their own privilege (input from env var, CLI arg, `$HOME` dotfile, OS-user config, self-gating advisory return). KEEP if the attacker is a legitimate user/tenant but the impact reaches *other* users, shared infra, or server-side resources.
-2. **Never apply the no-privilege-boundary refutation to:** SSRF/outbound-network sinks; LLM-agent capability gates (PreToolUse/PostToolUse hooks, bash allow/denylists, path jails — the model is the attacker, the user the victim); data-exposure findings (CWE-200/532, secrets-in-logs — the question is who READS the sink); project-working-directory config (repo author ≠ repo cloner); cross-process metadata (`/proc/<pid>`, `psutil.Process` — different owner = different principal).
-3. **Diff-anchor each candidate.** If the cited vulnerable code does NOT appear on a `+` line in the diff, it is pre-existing context the change did not introduce — refute as PRE-EXISTING. For findings whose sink is outside the diff (`off_diff`), demand stricter evidence: you must name the specific `+`/`-` line that *enables* the sink (a removed guard, a new caller, a changed argument). If you cannot name that line, refute it.
-4. **Read the cited file** and look for a refutation: a sanitizer/validator/authz check on the path; a non-dangerous sink (typed-schema decoder, hardcoded URL with non-path params, statically numeric/boolean value); delegated validation (credential forwarded to an upstream that validates); control-moved-to-library (the diff removes a control but bumps a dep documented to provide it); a config/feature-flag gate with no per-request user control.
-5. **Check for in-file documentation that reframes the finding.** A comment block can establish that a "removed control" was never functional, or was delegated elsewhere. (Real example: a finding claimed an HTTPS+basic-auth Docker endpoint was replaced by plaintext `tcp://...:2375`; an in-file comment documented that the client only ever supported `tcp://`/`unix://` so the HTTPS form was a non-functional placeholder, and the new endpoint rides a Tailscale/WireGuard tunnel providing encryption + device auth — both "removed controls" were delegated, not deleted.)
-6. **Process candidates in anchor order** (`in_diff` before `off_diff`), and refute any off_diff candidate whose sink is already covered by a surviving in_diff candidate.
-7. **Return two lists:** the indices that SURVIVED (could not be refuted) and `{idx, reason}` records for each refuted one, each reason citing concrete `file:line` evidence. An empty survived list is a valid, common outcome.
+1. **Frame attacker vs victim first.** For each candidate, name who controls the malicious input (attacker) and
+who is harmed (victim). REFUTE if the only victim is the attacker on their own machine at their own privilege
+(input from env var, CLI arg, `$HOME` dotfile, OS-user config, self-gating advisory return). KEEP if the attacker
+is a legitimate user/tenant but the impact reaches *other* users, shared infra, or server-side resources.
+2. **Never apply the no-privilege-boundary refutation to:** SSRF/outbound-network sinks; LLM-agent capability
+gates (PreToolUse/PostToolUse hooks, bash allow/denylists, path jails — the model is the attacker, the user the
+victim); data-exposure findings (CWE-200/532, secrets-in-logs — the question is who READS the sink);
+project-working-directory config (repo author ≠ repo cloner); cross-process metadata (`/proc/<pid>`,
+`psutil.Process` — different owner = different principal).
+3. **Diff-anchor each candidate.** If the cited vulnerable code does NOT appear on a `+` line in the diff, it is
+pre-existing context the change did not introduce — refute as PRE-EXISTING. For findings whose sink is outside
+the diff (`off_diff`), demand stricter evidence: you must name the specific `+`/`-` line that *enables* the sink
+(a removed guard, a new caller, a changed argument). If you cannot name that line, refute it.
+4. **Read the cited file** and look for a refutation: a sanitizer/validator/authz check on the path; a
+non-dangerous sink (typed-schema decoder, hardcoded URL with non-path params, statically numeric/boolean value);
+delegated validation (credential forwarded to an upstream that validates); control-moved-to-library (the diff
+removes a control but bumps a dep documented to provide it); a config/feature-flag gate with no per-request user
+control.
+5. **Check for in-file documentation that reframes the finding.** A comment block can establish that a "removed
+control" was never functional, or was delegated elsewhere. (Real example: a finding claimed an HTTPS+basic-auth
+Docker endpoint was replaced by plaintext `tcp://...:2375`; an in-file comment documented that the client only
+ever supported `tcp://`/`unix://` so the HTTPS form was a non-functional placeholder, and the new endpoint rides
+a Tailscale/WireGuard tunnel providing encryption + device auth — both "removed controls" were delegated, not
+deleted.)
+6. **Process candidates in anchor order** (`in_diff` before `off_diff`), and refute any off_diff candidate whose
+sink is already covered by a surviving in_diff candidate.
+7. **Return two lists:** the indices that SURVIVED (could not be refuted) and `{idx, reason}` records for each
+refuted one, each reason citing concrete `file:line` evidence. An empty survived list is a valid, common outcome.
 
 ## Sub-agent dispatch
 
-When ≥3 candidate findings need refutation, dispatch one sub-agent per finding to attempt refutation, then aggregate verdicts; below that, refute inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 candidate findings need refutation, dispatch one sub-agent per finding to attempt refutation, then
+aggregate verdicts; below that, refute inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` /
+inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/security-finding-refutation/SKILL.md
+++ b/.skillshare/skills/security-finding-refutation/SKILL.md
@@ -13,3 +13,7 @@ A second-pass verification stage: given candidate vulnerabilities (from a finder
 5. **Check for in-file documentation that reframes the finding.** A comment block can establish that a "removed control" was never functional, or was delegated elsewhere. (Real example: a finding claimed an HTTPS+basic-auth Docker endpoint was replaced by plaintext `tcp://...:2375`; an in-file comment documented that the client only ever supported `tcp://`/`unix://` so the HTTPS form was a non-functional placeholder, and the new endpoint rides a Tailscale/WireGuard tunnel providing encryption + device auth — both "removed controls" were delegated, not deleted.)
 6. **Process candidates in anchor order** (`in_diff` before `off_diff`), and refute any off_diff candidate whose sink is already covered by a surviving in_diff candidate.
 7. **Return two lists:** the indices that SURVIVED (could not be refuted) and `{idx, reason}` records for each refuted one, each reason citing concrete `file:line` evidence. An empty survived list is a valid, common outcome.
+
+## Sub-agent dispatch
+
+When ≥3 candidate findings need refutation, dispatch one sub-agent per finding to attempt refutation, then aggregate verdicts; below that, refute inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/security-finding-triage/SKILL.md
+++ b/.skillshare/skills/security-finding-triage/SKILL.md
@@ -4,24 +4,41 @@ description: Adversarially verify a list of candidate security findings before r
 ---
 # Adversarial Security Finding Triage
 
-Use after a vulnerability-finding pass produces candidates, to suppress false positives before they reach the user. The goal is to DISPROVE each candidate; default to SURVIVES only when you cannot.
+Use after a vulnerability-finding pass produces candidates, to suppress false positives before they reach the user. The
+goal is to DISPROVE each candidate; default to SURVIVES only when you cannot.
 
-1. **Establish attacker and victim first.** For each finding, name who controls the input and who is harmed. REFUTE if the only victim is the attacker on their own machine/account. KEEP if the attacker is a legitimate user/tenant but impact reaches other users, shared infra, or server-side resources.
+1. **Establish attacker and victim first.** For each finding, name who controls the input and who is harmed. REFUTE if
+the only victim is the attacker on their own machine/account. KEEP if the attacker is a legitimate user/tenant but
+impact reaches other users, shared infra, or server-side resources.
 
-2. **Process `in_diff` candidates before `off_diff`.** Sort so findings whose vulnerable code appears on a `+` line come first; they use the standard KEEP/REFUTE bar.
+2. **Process `in_diff` candidates before `off_diff`.** Sort so findings whose vulnerable code appears on a `+` line come
+first; they use the standard KEEP/REFUTE bar.
 
-3. **Hold `off_diff` candidates to a stricter bar.** You must name the specific `+`/`-` line that ENABLES the off-diff sink (a removed guard, a new caller, a changed argument). If you cannot cite that enabling line, REFUTE. Also REFUTE any off_diff candidate whose sink is already covered by a surviving in_diff candidate.
+3. **Hold `off_diff` candidates to a stricter bar.** You must name the specific `+`/`-` line that ENABLES the off-diff
+sink (a removed guard, a new caller, a changed argument). If you cannot cite that enabling line, REFUTE. Also REFUTE any
+off_diff candidate whose sink is already covered by a surviving in_diff candidate.
 
-4. **Read the cited file and check for refutation evidence.** REFUTE with `file:line` evidence if any holds: PRE-EXISTING (the vulnerableCode is unchanged context, not on a `+` line); a sanitizer/validator/authz check prevents the exploit; the sink is non-dangerous (typed-schema decoder, hardcoded URL, static number/boolean); or NO PRIVILEGE BOUNDARY (input from env var / CLI arg / dotfile at the same privilege as the writer).
+4. **Read the cited file and check for refutation evidence.** REFUTE with `file:line` evidence if any holds:
+PRE-EXISTING (the vulnerableCode is unchanged context, not on a `+` line); a sanitizer/validator/authz check prevents
+the exploit; the sink is non-dangerous (typed-schema decoder, hardcoded URL, static number/boolean); or NO PRIVILEGE
+BOUNDARY (input from env var / CLI arg / dotfile at the same privilege as the writer).
 
-5. **Never apply the no-privilege-boundary refutation to** SSRF/outbound sinks, LLM-agent capability gates, data-exposure findings (who READS the sink, not who controls input), project-working-directory config (repo author ≠ cloner), or cross-process metadata sources.
+5. **Never apply the no-privilege-boundary refutation to** SSRF/outbound sinks, LLM-agent capability gates,
+data-exposure findings (who READS the sink, not who controls input), project-working-directory config (repo author ≠
+cloner), or cross-process metadata sources.
 
-6. **Apply the remaining refutation gates** where evidence supports: trusted-header namespace, frontend-only gate with backend enforcement, delegated validation to a validating upstream, throwaway code under scripts/dev/test dirs, control-moved-to-library, config/feature-flag gating, protective-control polarity.
+6. **Apply the remaining refutation gates** where evidence supports: trusted-header namespace, frontend-only gate with
+backend enforcement, delegated validation to a validating upstream, throwaway code under scripts/dev/test dirs,
+control-moved-to-library, config/feature-flag gating, protective-control polarity.
 
 7. **Do not speculate.** Refute only with cited evidence; otherwise the finding survives.
 
-8. **Return two sets:** `survived` (indices you could not refute) and `refuted` (`{idx, reason}` with the cited evidence for each). An empty `survived` means every candidate was refuted.
+8. **Return two sets:** `survived` (indices you could not refute) and `refuted` (`{idx, reason}` with the cited evidence
+for each). An empty `survived` means every candidate was refuted.
 
 ## Sub-agent dispatch
 
-When ≥3 candidate findings need triage, dispatch one sub-agent per finding to verify it, then aggregate verdicts; below that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 candidate findings need triage, dispatch one sub-agent per finding to verify it, then aggregate verdicts; below
+that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline
+on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/security-finding-triage/SKILL.md
+++ b/.skillshare/skills/security-finding-triage/SKILL.md
@@ -21,3 +21,7 @@ Use after a vulnerability-finding pass produces candidates, to suppress false po
 7. **Do not speculate.** Refute only with cited evidence; otherwise the finding survives.
 
 8. **Return two sets:** `survived` (indices you could not refute) and `refuted` (`{idx, reason}` with the cited evidence for each). An empty `survived` means every candidate was refuted.
+
+## Sub-agent dispatch
+
+When ≥3 candidate findings need triage, dispatch one sub-agent per finding to verify it, then aggregate verdicts; below that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/speckit-implement-review/SKILL.md
+++ b/.skillshare/skills/speckit-implement-review/SKILL.md
@@ -82,3 +82,7 @@ ALWAYS use this structure so the gap between claimed and actual is unmistakable:
   the work is committed. It also runs standalone any time to re-audit.
 - Complements `/verify` (deterministic lint/test/scan) and `speckit-analyze` (artifact
   consistency): this skill is specifically about **did we actually finish every task**.
+
+## Sub-agent dispatch
+
+When ≥3 independent task groups need auditing, dispatch one sub-agent per group to verify completion, then merge; below that, audit inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/speckit-implement-review/SKILL.md
+++ b/.skillshare/skills/speckit-implement-review/SKILL.md
@@ -52,7 +52,7 @@ implementer's call — this skill's job is to tell the truth about what is actua
 
 ALWAYS use this structure so the gap between claimed and actual is unmistakable:
 
-```
+```text
 ## speckit-implement review — <FEATURE_DIR name>
 **Verdict:** <ALL VERIFIED | GAPS FOUND (<n> incomplete, <m> skipped)>
 
@@ -85,4 +85,7 @@ ALWAYS use this structure so the gap between claimed and actual is unmistakable:
 
 ## Sub-agent dispatch
 
-When ≥3 independent task groups need auditing, dispatch one sub-agent per group to verify completion, then merge; below that, audit inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 independent task groups need auditing, dispatch one sub-agent per group to verify completion, then merge;
+below that, audit inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` /
+inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/triage-bot-pr-flood/SKILL.md
+++ b/.skillshare/skills/triage-bot-pr-flood/SKILL.md
@@ -32,4 +32,7 @@ the marketing-prose descriptions.
 
 ## Sub-agent dispatch
 
-When ≥3 machine-generated PRs are open, dispatch one sub-agent per PR (or batch) to disposition it, then consolidate; below that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 machine-generated PRs are open, dispatch one sub-agent per PR (or batch) to disposition it, then consolidate;
+below that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline
+on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/triage-bot-pr-flood/SKILL.md
+++ b/.skillshare/skills/triage-bot-pr-flood/SKILL.md
@@ -29,3 +29,7 @@ the marketing-prose descriptions.
    re-poll until `CLEAN`), merge with the repo's convention (squash), delete branch.
 8. **Flag the automation** if it's generating churn — recommend tightening dedup
    and feeding it the repo conventions up front.
+
+## Sub-agent dispatch
+
+When ≥3 machine-generated PRs are open, dispatch one sub-agent per PR (or batch) to disposition it, then consolidate; below that, triage inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/ux-review/SKILL.md
+++ b/.skillshare/skills/ux-review/SKILL.md
@@ -147,3 +147,7 @@ Static analysis checks that indicate Core Web Vitals risk:
 - Read-only analysis -- never modify source files
 - Skip binary files and minified bundles
 - Cap findings at 100 per file to avoid context overflow
+
+## Sub-agent dispatch
+
+When ≥3 independent pages or flows need review, dispatch one sub-agent per page/flow to review it, then merge findings; below that, review inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.skillshare/skills/ux-review/SKILL.md
+++ b/.skillshare/skills/ux-review/SKILL.md
@@ -150,4 +150,7 @@ Static analysis checks that indicate Core Web Vitals risk:
 
 ## Sub-agent dispatch
 
-When ≥3 independent pages or flows need review, dispatch one sub-agent per page/flow to review it, then merge findings; below that, review inline. Pick the mechanism per the shared Sub-Agent Selection Rules (`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.
+When ≥3 independent pages or flows need review, dispatch one sub-agent per page/flow to review it, then merge findings;
+below that, review inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or `parallel_agent.py` / inline
+on other assistants. Dispatched sub-agents execute their task directly and do not re-dispatch.

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/366-coding-standards"
+  "feature_directory": "specs/367-sub-agent-dispatch-guidance"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,5 +240,5 @@ approaches), review stale plans, or archive/abandon completed work.
 <!-- SPECKIT START -->
 ## Active Spec Kit Feature
 
-- `366-coding-standards` — plan: [specs/366-coding-standards/plan.md](specs/366-coding-standards/plan.md)
+- `367-sub-agent-dispatch-guidance` — plan: [specs/367-sub-agent-dispatch-guidance/plan.md](specs/367-sub-agent-dispatch-guidance/plan.md)
 <!-- SPECKIT END -->

--- a/configs/claude/CLAUDE.md
+++ b/configs/claude/CLAUDE.md
@@ -69,7 +69,8 @@ Read on demand (NOT auto-loaded). You MUST read the reference before related tas
 - `~/.claude/references/orchestration.md` — Read when running multi-agent validation or debugging cross-verification failures.
 - `~/.claude/references/git-platform.md` — Read when automating PRs, branch detection, or git_ops failures.
 - `~/.claude/references/layout.md` — Read when modifying config trees or mapping file locations.
-- `~/.claude/references/sub-agent-dispatch.md` — Read before a skill dispatches sub-agents: native Task vs `parallel_agent.py`, when-to-dispatch threshold, cross-platform fallback.
+- `~/.claude/references/sub-agent-dispatch.md` — Read before a skill dispatches sub-agents: native Task vs
+  `parallel_agent.py`, when-to-dispatch threshold, cross-platform fallback.
 
 ---
 

--- a/configs/claude/CLAUDE.md
+++ b/configs/claude/CLAUDE.md
@@ -69,6 +69,7 @@ Read on demand (NOT auto-loaded). You MUST read the reference before related tas
 - `~/.claude/references/orchestration.md` — Read when running multi-agent validation or debugging cross-verification failures.
 - `~/.claude/references/git-platform.md` — Read when automating PRs, branch detection, or git_ops failures.
 - `~/.claude/references/layout.md` — Read when modifying config trees or mapping file locations.
+- `~/.claude/references/sub-agent-dispatch.md` — Read before a skill dispatches sub-agents: native Task vs `parallel_agent.py`, when-to-dispatch threshold, cross-platform fallback.
 
 ---
 

--- a/configs/claude/config/command_config.yml
+++ b/configs/claude/config/command_config.yml
@@ -59,6 +59,15 @@ synthesis_priority:
   - style           # Formatting and style
 
 # Tool policies per command
+#
+# Sub-agent fields (feature 367 — see configs/claude/references/sub-agent-dispatch.md):
+#   parallel_agents: always|conditional|never|gate-only  # external parallel_agent.py cross-verification
+#   trigger_condition: "<expr>"                           # scale gate for parallel_agents: conditional
+#   subagents:         always|conditional|never           # native Task/Agent sub-agents (Claude)
+#   subagent_trigger:  "<expr>"                            # REQUIRED when subagents: conditional; convention: independent_units >= 3
+#   subagent_rationale: "<one line>"                       # for subagents: never (or a `> Sub-agents: not used — <reason>.` note in SKILL.md)
+# Every skill directory with a SKILL.md MUST carry a `subagents` value (enforced by tests/bats/subagent_policy.bats).
+# command_config.yml is the canonical store; SKILL.md prose must agree and is verified by that test.
 tool_policies:
   auto-issue-dev:
     allowed:
@@ -75,6 +84,8 @@ tool_policies:
     parallel_agents: gate-only
     validation_tier: 1
 
+    subagents: never
+    subagent_rationale: Develops exactly one issue per invocation then stops; /loop handles iteration.
   post-pr-review-monitor:
     allowed:
       - Bash
@@ -85,6 +96,8 @@ tool_policies:
     parallel_agents: never        # orchestrates other skills; no cross-verification fan-out
     validation_tier: 1            # pushes commits + posts PR comments
 
+    subagents: never
+    subagent_rationale: Self-paced interactive loop babysitting a single PR sequentially.
   pr-regression-smoke:
     allowed:
       - Bash       # run_pr_regression.sh: lint/bats/pytest, bootstrap, check_status, parallel_agent
@@ -96,6 +109,8 @@ tool_policies:
     parallel_agents: never        # a CI-mirror gate runner, not a cross-verification fan-out
     validation_tier: 2            # verification skill; no source mutation
 
+    subagents: never
+    subagent_rationale: Single deterministic bundled runner executing sequential whole-repo gates.
   smoke-orchestrator:
     allowed:
       - Bash       # smoke_test.py append/run/list/prune; opt-in playwright install
@@ -107,6 +122,8 @@ tool_policies:
     parallel_agents: never        # an authoring/gate tool, not a cross-verification fan-out
     validation_tier: 1            # executes CLI/shell steps + handles env-injected secrets
 
+    subagents: never
+    subagent_rationale: Single config-driven engine runs the catalog sequentially via one script.
   pr-issue-sync:
     allowed:
       - Bash
@@ -119,6 +136,8 @@ tool_policies:
     enabled: false              # opt-in runtime gate (install_issue_hooks.sh --enable)
     hook_timeout_seconds: 5     # fail-open soft timeout bound
 
+    subagents: never
+    subagent_rationale: Single-PR fail-open hook mutating tracker issue state.
   commit-issue-sync:
     allowed:
       - Bash
@@ -132,6 +151,8 @@ tool_policies:
     hook_timeout_seconds: 5     # fail-open soft timeout bound
     commit_hook_mode: sync      # sync only in v1; 'background' reserved (falls back to sync)
 
+    subagents: never
+    subagent_rationale: Fail-open hook mutating one linked issue per commit; sequential shared-state.
   docs-readme:
     allowed:
       - Read
@@ -142,6 +163,8 @@ tool_policies:
     parallel_agents: never
     validation_tier: 2
 
+    subagents: never
+    subagent_rationale: 'Single-target: improves one README from code-derived facts.'
   refactor-python:
     allowed:
       - Read
@@ -157,6 +180,8 @@ tool_policies:
       - context7   # Python library/API documentation
       - deepwiki   # Dependency internals and upstream contracts
 
+    subagents: conditional
+    subagent_trigger: independent_units >= 3
   docs-diagrams:
     allowed:
       - Read
@@ -168,6 +193,8 @@ tool_policies:
     trigger_condition: unique_imports >= 5
     validation_tier: 2
 
+    subagents: never
+    subagent_rationale: One diagram doc for a single codebase; uses parallel_agent.py, not native fan-out.
   docs-improve:
     allowed:
       - Read
@@ -182,6 +209,8 @@ tool_policies:
       - deepwiki   # Cross-reference dependency docs for accuracy
       - context7   # Library/API docs for code examples in documentation
 
+    subagents: never
+    subagent_rationale: Holistic docs-set audit with one health score; not independent units.
   refactor-shell:
     allowed:
       - Read
@@ -196,6 +225,8 @@ tool_policies:
     security_cli:
       - semgrep    # Local SAST scanning via CLI (requires Bash)
 
+    subagents: conditional
+    subagent_trigger: independent_units >= 3
   refactor-node:
     allowed:
       - Read
@@ -211,6 +242,8 @@ tool_policies:
       - context7   # Node/TS library documentation
       - deepwiki   # Dependency internals and upstream contracts
 
+    subagents: conditional
+    subagent_trigger: independent_units >= 3
   refactor-go:
     allowed:
       - Read
@@ -226,6 +259,8 @@ tool_policies:
       - context7   # Go library documentation
       - deepwiki   # Dependency internals and upstream contracts
 
+    subagents: conditional
+    subagent_trigger: independent_units >= 3
   refactor-terraform:
     allowed:
       - Read
@@ -242,6 +277,8 @@ tool_policies:
     security_cli:
       - semgrep    # Local SAST scanning via CLI (requires Bash)
 
+    subagents: conditional
+    subagent_trigger: independent_units >= 3
   plan-manage:
     allowed:
       - Read
@@ -262,6 +299,8 @@ tool_policies:
       - glean      # Internal team knowledge, runbooks, ADRs
       - opentofu   # OpenTofu registry docs when planning IaC changes
 
+    subagents: never
+    subagent_rationale: Interactive plan-lifecycle management acting on one plan per action.
   code-quality:  # skill
     allowed:
       - Read
@@ -278,6 +317,8 @@ tool_policies:
     security_cli:
       - semgrep    # Local SAST scanning via CLI (requires Bash)
 
+    subagents: never
+    subagent_rationale: Auto-triggered inline review of a single detected file; non-blocking.
   issue-triage:
     allowed:
       - Read
@@ -296,6 +337,8 @@ tool_policies:
       - linear      # Primary: Linear MCP for issue operations
       - atlassian   # Alternative: Jira issues when project uses Atlassian
 
+    subagents: conditional
+    subagent_trigger: independent_units >= 3
   issue-prioritize:
     allowed:
       - Read
@@ -314,6 +357,8 @@ tool_policies:
       - linear      # Primary: Linear issue data
       - atlassian   # Alternative: Jira issues when project uses Atlassian
 
+    subagents: conditional
+    subagent_trigger: open_issues >= 10
   auto-dev-issue-prep:
     allowed:
       - Read
@@ -329,6 +374,8 @@ tool_policies:
     trigger_condition: scenario_based
     validation_tier: 2
 
+    subagents: never
+    subagent_rationale: Preps exactly one issue and mutates its labels/body; single-target.
   speckit-implement-review:
     allowed:
       - Read
@@ -343,6 +390,8 @@ tool_policies:
     trigger_condition: post_implement
     validation_tier: 2
 
+    subagents: conditional
+    subagent_trigger: independent_units >= 3
   health-check:
     allowed:
       - Read
@@ -356,6 +405,8 @@ tool_policies:
     parallel_agents: never
     validation_tier: 2
 
+    subagents: never
+    subagent_rationale: Diagnoses one environment into a single summary table; sequential checks.
   browser-test:  # skill
     allowed:
       - Read
@@ -372,6 +423,8 @@ tool_policies:
       - context7   # browser-use library documentation
       - deepwiki   # browser-use internals and API contracts
 
+    subagents: never
+    subagent_rationale: Deprecated single-target migration shim for legacy YAML prompts.
   sync-configs:
     allowed:
       - Read
@@ -385,6 +438,8 @@ tool_policies:
     parallel_agents: never
     validation_tier: 2
 
+    subagents: never
+    subagent_rationale: Single sequential audit collecting checks into one drift summary.
   token-economy:
     allowed:
       - Read
@@ -396,6 +451,8 @@ tool_policies:
     parallel_agents: never
     validation_tier: 2
 
+    subagents: never
+    subagent_rationale: Session-mode mutator that changes output behavior; nothing to dispatch.
   version-pin:
     allowed:
       - Read
@@ -407,6 +464,8 @@ tool_policies:
     parallel_agents: always   # Security-sensitive supply-chain change (Constitution II)
     validation_tier: 1
 
+    subagents: never
+    subagent_rationale: Thin wrapper running one tree-walking script that mutates files in place.
   docs-all:
     allowed:
       - Read
@@ -418,6 +477,7 @@ tool_policies:
     parallel_agents: conditional
     validation_tier: 2
 
+    subagents: always
   pr-review:
     allowed:
       - Read
@@ -430,6 +490,8 @@ tool_policies:
     parallel_agents: never
     validation_tier: 2
 
+    subagents: conditional
+    subagent_trigger: independent_units >= 3
   branch-clean:
     allowed:
       - Read
@@ -439,6 +501,8 @@ tool_policies:
     parallel_agents: conditional   # Tier 1 on the destructive --apply path
     validation_tier: 1
 
+    subagents: never
+    subagent_rationale: Single script run mutating the shared local branch set; parallelism unsafe.
   repo-hygiene:
     allowed:
       - Read
@@ -451,13 +515,190 @@ tool_policies:
     parallel_agents: conditional   # Tier 1 on the destructive close/prune path
     validation_tier: 1
 
+    subagents: conditional
+    subagent_trigger: independent_units >= 3
   token-benchmark:
     allowed:
       - Read
       - Bash
       - Write
     description: "Token benchmark harness — runs Python scripts and reads/writes result files"
-
+    subagents: never
+    subagent_rationale: Single benchmark harness run via one script; provider sweep handled internally.
+  a11y-audit:
+    subagents: conditional
+    subagent_trigger: target_files >= 3
+  address-pr-comments:
+    subagents: never
+    subagent_rationale: Single PR; fixes mutate one working tree and must be re-tested/pushed sequentially.
+  ai-hooks-integration:
+    subagents: never
+    subagent_rationale: Single hook-install operation editing shared config files; not a multi-item fan-out.
+  antipattern-detect:
+    subagents: never
+    subagent_rationale: Auto-triggered analyzer writing one shared knowledge_base.yml; parallel writes unsafe.
+  api-bulk-endpoint-optimization:
+    subagents: never
+    subagent_rationale: Single sequential optimization investigation of one API loop.
+  app-native-config-validation:
+    subagents: never
+    subagent_rationale: Single-app config validation gate; one parser run per config.
+  architecture-decision-tradeoff-table:
+    subagents: never
+    subagent_rationale: Single design decision producing one trade-off table.
+  bot-pr-triage:
+    subagents: conditional
+    subagent_trigger: bot_prs >= 3
+  checkpoint:
+    subagents: never
+    subagent_rationale: Summarizes the single current session; inherently sequential.
+  ci-lint-config-drift:
+    subagents: never
+    subagent_rationale: Diagnoses one CI lint-config mismatch through a linear root-cause-then-fix sequence.
+  ci-setup:
+    subagents: never
+    subagent_rationale: Configures CI for one repo, writing shared config files; sequential and mutating.
+  ci-workflow-trigger-security:
+    subagents: conditional
+    subagent_trigger: workflow_files >= 3
+  clean-pr-from-stale-base:
+    subagents: never
+    subagent_rationale: Single-branch git surgery mutating shared git state; sequential.
+  cli-help-before-dependency-checks:
+    subagents: never
+    subagent_rationale: Reorders one entry point's help path; edit-focused single target.
+  containerized-internal-service-probe:
+    subagents: never
+    subagent_rationale: Spawns a throwaway container to probe one internal service; sequential debugging.
+  dashboard:
+    subagents: never
+    subagent_rationale: Aggregates logs into one dashboard report; single sequential aggregation.
+  debug-layered-config-substitution:
+    subagents: never
+    subagent_rationale: Single sequential debugging investigation of one app's config layer.
+  deploy-drift-root-cause:
+    subagents: never
+    subagent_rationale: Single root-cause investigation mutating the source-of-truth deployer; sequential.
+  diagnose-stalled-background-process:
+    subagents: never
+    subagent_rationale: Single-target diagnosis of one stalled process; measure-classify-fix is sequential.
+  diff-security-review:
+    subagents: never
+    subagent_rationale: Reviews one diff as a coherent source-to-sink pass; single target.
+  docker-published-port-firewall-audit:
+    subagents: never
+    subagent_rationale: Single firewall/port audit of one deploy config; sequential chain analysis.
+  graphify:
+    subagents: never
+    subagent_rationale: Thin wrapper over a single graphify CLI invocation; sequential.
+  headless-llm-cli-seam:
+    subagents: never
+    subagent_rationale: Single coding pattern for wiring one LLM CLI call behind a stdin seam.
+  help:
+    subagents: never
+    subagent_rationale: Read-only interactive command discovery; single catalog query.
+  ingestion-table-idempotency:
+    subagents: never
+    subagent_rationale: Single design decision for one table; sequential reasoning.
+  learning-loop:
+    subagents: never
+    subagent_rationale: Interactive capture/query of one knowledge-base entry; mutates shared YAML.
+  live-data-validation:
+    subagents: never
+    subagent_rationale: Single end-to-end validation pass over one pipeline; sequential.
+  llm-output-path-traversal-audit:
+    subagents: never
+    subagent_rationale: Focused single-concern security audit of one code area; sequential.
+  locate-missing-artifact-across-git:
+    subagents: never
+    subagent_rationale: Ordered search-and-stop for one artifact; stops on first hit.
+  mcp-server-security-audit:
+    subagents: never
+    subagent_rationale: Single-target audit of one MCP server with ordered, dependent checks.
+  memory-log-compress:
+    subagents: never
+    subagent_rationale: Single document/log transformation; sequential text compression.
+  merge-stacked-pr-chain:
+    subagents: never
+    subagent_rationale: Strictly ordered bottom-up merge choreography mutating shared git/PR state.
+  meta-prompt-optimize:
+    subagents: never
+    subagent_rationale: Optimizes one prompt through a fixed sequential pipeline; single target.
+  out-of-band-cache-warm:
+    subagents: never
+    subagent_rationale: Single diagnose-then-remediate workflow warming one shared cache.
+  pass-cli:
+    subagents: never
+    subagent_rationale: Interactive single-secret retrieval requiring the user's auth step.
+  performance-check:
+    subagents: never
+    subagent_rationale: Single-project static perf audit; sequential phases into one report.
+  pin-known-bug-test-survives-fix:
+    subagents: never
+    subagent_rationale: 'Tiny single-target task: write one tolerant test assertion.'
+  project-commit:
+    subagents: never
+    subagent_rationale: Sequential commit pipeline with ordered phases that mutates the repo.
+  reproduce-gated-ci-failure-locally:
+    subagents: never
+    subagent_rationale: Single-target sequential diagnosis and reproduction of one failing CI step.
+  research-validate-design:
+    subagents: conditional
+    subagent_trigger: assumptions >= 3
+  reset-reapply-clean-pr:
+    subagents: never
+    subagent_rationale: Single-branch sequential git history surgery mutating shared state.
+  retire-component-cleanup:
+    subagents: never
+    subagent_rationale: Retires one component via sequential verification steps with confirmation gates.
+  scaffold:
+    subagents: never
+    subagent_rationale: Initializes one project sequentially; mutates a single directory.
+  secret-safe-upstream-proxy:
+    subagents: never
+    subagent_rationale: Single-service design guidance for building one proxy; sequential checklist.
+  secure-comment-triggered-workflow:
+    subagents: never
+    subagent_rationale: Builds/hardens one CI workflow via an ordered governance checklist.
+  security-finding-refutation:
+    subagents: conditional
+    subagent_trigger: candidate_findings >= 3
+  security-finding-triage:
+    subagents: conditional
+    subagent_trigger: candidate_findings >= 3
+  session-memory-compress:
+    subagents: never
+    subagent_rationale: Sequential compression of one memory artifact; mutates a single shared file.
+  shell-pipefail-subshell-audit:
+    subagents: never
+    subagent_rationale: Single-script audit; substitutions tightly coupled within one file.
+  shell-sete-silent-abort-audit:
+    subagents: never
+    subagent_rationale: Single-script/sourced-chain audit of coupled control-flow hazards; sequential.
+  skill-evolve:
+    subagents: never
+    subagent_rationale: Thin wrapper invoking one promote script (handles its own batching) and opens a PR.
+  spec-review:
+    subagents: never
+    subagent_rationale: Analysis-only; delegates to external parallel_agent.py for one combined review.
+  statistical-test-fixture-variance:
+    subagents: never
+    subagent_rationale: Single-target guidance checklist; no items to fan out.
+  triage-bot-pr-flood:
+    subagents: conditional
+    subagent_trigger: bot_prs >= 3
+  ux-review:
+    subagents: conditional
+    subagent_trigger: independent_units >= 3
+  verify:
+    subagents: never
+    subagent_rationale: Single target project; runs its own lint/test/scan chain internally.
+  verify-premise:
+    subagents: never
+    subagent_rationale: Verifies one load-bearing assumption against a source of truth; single-target.
+  wire-new-field-end-to-end:
+    subagents: never
+    subagent_rationale: Sequential trace of one field across three sites; single-target.
 
 # Version-pinning rule set (consumed by scripts/version_pin.sh).
 # Maps file globs to an ecosystem and hash form. Notes on the fields:

--- a/configs/claude/references/sub-agent-dispatch.md
+++ b/configs/claude/references/sub-agent-dispatch.md
@@ -1,0 +1,96 @@
+# Sub-Agent Dispatch & Selection Rules
+
+> Read-on-demand reference (NOT auto-loaded). Skills that fan work out link here instead of
+> restating these rules. Indexed from `configs/claude/CLAUDE.md` → "Reference Index".
+
+This repo has **two** sub-agent paradigms. A skill's `tool_policies` entry in
+`config/command_config.yml` records which it uses (`subagents` and/or `parallel_agents`); the skill
+body states the concrete trigger and links here.
+
+## The two mechanisms
+
+| Mechanism | What it is | Use for | Availability |
+|-----------|-----------|---------|--------------|
+| **Native Task/Agent sub-agents** | In-session sub-agents dispatched via the Task tool (Explore, general-purpose, …) | Parallel reads, fan-out research, independent per-item work, broad audits | **Claude only** |
+| **`parallel_agent.py`** | External multi-CLI cross-verification (Gemini/Cursor/Codex/Antigravity) with consensus scoring | Independent cross-model verification of one artifact/decision | Cross-platform |
+
+## Selection rules (by task type)
+
+| Task type | Mechanism | Notes |
+|-----------|-----------|-------|
+| Parallel information-gathering / research / broad audit (many independent items) | Native Task sub-agents | One sub-agent per item/batch. On non-Claude assistants → `parallel_agent.py` or inline. |
+| Independent cross-model verification of a security-sensitive, architectural, or >200-line change | `parallel_agent.py` | Required by the constitution's Tier-1 gate (Principle II). Not native sub-agents. |
+| Trivial / single-unit / fewer than the threshold | **Inline** | No dispatch — overhead is not justified. |
+
+## When to dispatch (the threshold)
+
+Dispatch only when **≥3 independent units of work** exist, OR an existing per-skill scale threshold
+is exceeded (e.g., `total_doc_lines >= 500`, `unique_imports >= 5`). Below that, do the work inline.
+This default keeps token-economy intact; the structured value lives in each skill's
+`subagent_trigger` in `command_config.yml` (authoritative), and the skill body's prose must agree.
+
+## No recursion
+
+A dispatched sub-agent performs its assigned task **directly** and does **not** itself fan out
+further sub-agents. This prevents agent-explosion.
+
+## Cross-platform fallback
+
+Native Task/Agent sub-agents exist only on Claude. On Cursor / Gemini / Codex / Antigravity a skill
+MUST either use `parallel_agent.py` (cross-platform) or run the work inline — never leave a non-Claude
+assistant without an executable path.
+
+---
+
+## Convention: adding (or declining) sub-agent guidance to a skill
+
+The durable contributor convention (this is the one documented place).
+
+### 1. Classify the skill
+
+| Does the work decompose into independent units? | `subagents` | Example |
+|--------------------------------------------------|-------------|---------|
+| Decomposition IS the job (always fan out) | `always` | `docs-all` |
+| Only above the threshold | `conditional` | `refactor-python` |
+| Single-step / sequential / mutates shared state | `never` | `checkpoint` |
+
+### 2. Record it in `config/command_config.yml` (canonical store)
+
+```yaml
+tool_policies:
+  <skill-name>:
+    subagents: conditional
+    subagent_trigger: "independent_units >= 3"   # only when conditional
+    # subagent_rationale: "<one line>"           # when never (or as a SKILL.md note, below)
+```
+
+For a `never` skill you may record the rationale either as `subagent_rationale` here **or** as a
+one-line marker in the `SKILL.md` body: `> Sub-agents: not used — <reason>.` The enforcement test
+accepts either form.
+
+### 3. Add the in-body trigger (always / conditional only)
+
+In the skill's `SKILL.md` **body** (never frontmatter — frontmatter is auto-loaded):
+
+```markdown
+## Sub-agent dispatch
+
+When ≥3 independent <units> exist, dispatch one sub-agent per <unit> to <task>, then merge.
+Below that, do it inline. Pick the mechanism per the shared Sub-Agent Selection Rules
+(`configs/claude/references/sub-agent-dispatch.md`): native Task sub-agents on Claude, or
+`parallel_agent.py` / inline on other assistants. Sub-agents execute directly and do not re-dispatch.
+```
+
+### 4. Do NOT restate these rules
+
+Link here; never copy. The selection rules and threshold live once, in this file.
+
+### 5. Verify
+
+```bash
+bats tests/bats/subagent_policy.bats        # coverage + consistency gate
+yamllint configs/claude/config/command_config.yml
+```
+
+A new skill with no `subagents` disposition fails the test until classified — the intended forcing
+function.

--- a/specs/367-sub-agent-dispatch-guidance/checklists/requirements.md
+++ b/specs/367-sub-agent-dispatch-guidance/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Sub-Agent Dispatch Guidance for Skills
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Both scope questions ("these" = all 89 skills; sub-agent = both paradigms) were resolved up front
+  via clarification, so no [NEEDS CLARIFICATION] markers remain.
+- Some named artifacts (`command_config.yml` `tool_policies`, `parallel_agent.py`,
+  `.skillshare/skills/`) are referenced as existing-system dependencies, not as implementation
+  prescriptions — they bound scope and integration points rather than dictate the solution.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/367-sub-agent-dispatch-guidance/contracts/enforcement-test.contract.md
+++ b/specs/367-sub-agent-dispatch-guidance/contracts/enforcement-test.contract.md
@@ -1,0 +1,34 @@
+# Contract: Enforcement test
+
+**File**: `tests/bats/subagent_policy.bats` (preferred — matches `context_budget.bats`,
+`commands_doc_drift.bats`) or `tests/python/test_subagent_policy.py` if assertions grow complex.
+**Wired into**: the same CI job that runs `bats tests/bats/` / `pytest tests/python/`.
+
+## Inputs (read at test time)
+
+- Live listing of `.skillshare/skills/*/` directories that contain a `SKILL.md` (counted
+  **dynamically** — no hardcoded total).
+- Parsed `tool_policies` from `configs/claude/config/command_config.yml`.
+- The body text of each `SKILL.md`.
+
+## Assertions
+
+| ID | Assertion | Spec link |
+|----|-----------|-----------|
+| T1 | Every skill dir with a `SKILL.md` has a `tool_policies` entry containing `subagents`. | SC-001, VR-1 |
+| T2 | `subagents` value ∈ {`always`,`conditional`,`never`}. | data-model |
+| T3 | `subagents: conditional` ⇒ non-empty `subagent_trigger`. | VR-2 |
+| T4 | `subagents: never` ⇒ rationale present (`subagent_rationale` or SKILL.md body marker). | SC-003, VR-3 |
+| T5 | `subagents: always|conditional` ⇒ SKILL.md body contains a dispatch trigger that links the shared rules. | SC-002, VR-4 |
+| T6 | No `subagents: never` skill body instructs dispatch (no contradiction). | SC-004, VR-5 |
+| T7 | (advisory) `subagent_trigger` uses `>= 3` or a recognized scale gate. | VR-6 |
+
+## Exit behavior
+
+- Any failed assertion → non-zero exit (blocks CI), naming the offending skill(s).
+- New skill added without a `subagents` disposition → T1 fails → forces the author to classify it.
+
+## Out of scope for the test
+
+- It does NOT evaluate whether a disposition is "correct" (a judgment call), only that it exists, is
+  well-formed, and is internally consistent with the prose.

--- a/specs/367-sub-agent-dispatch-guidance/contracts/skill-trigger.format.md
+++ b/specs/367-sub-agent-dispatch-guidance/contracts/skill-trigger.format.md
@@ -1,0 +1,45 @@
+# Contract: In-body dispatch trigger (SKILL.md)
+
+**Applies to**: the body of each `SKILL.md` whose `subagents` is `always` or `conditional`.
+**Location**: skill **body**, never frontmatter (frontmatter is auto-loaded into context; bodies are
+not).
+
+## Required form
+
+A directive, checkable instruction with these parts:
+
+1. **Condition** — a countable/measurable trigger (count, size, independence). Must match the
+   `subagent_trigger` in `tool_policies`.
+2. **Per-agent task** — what each dispatched sub-agent does.
+3. **Mechanism + link** — a pointer to the shared **Sub-Agent Selection Rules** in
+   `configs/claude/references/sub-agent-dispatch.md` (do NOT restate the rules).
+
+## Wording rules
+
+- Directive, not advisory: ✅ "When ≥3 independent targets exist, dispatch one sub-agent per target
+  to …" ❌ "consider using agents".
+- Mention the no-recursion rule by reference (sub-agents execute directly, never re-dispatch).
+- `never` skills: a single line such as `> Sub-agents: not used — <reason>.` (no trigger).
+
+## Template snippet (always / conditional)
+
+```markdown
+## Sub-agent dispatch
+
+When **<condition, e.g. ≥3 independent modules>**, dispatch **one sub-agent per <unit>** to
+**<per-agent task>**, then merge results. Below that threshold, do the work inline.
+
+Choose the mechanism per the shared **Sub-Agent Selection Rules**
+(`configs/claude/references/sub-agent-dispatch.md`) — native Task sub-agents vs. `parallel_agent.py`;
+cross-platform fallback. Dispatched sub-agents execute their task directly and do not re-dispatch.
+```
+
+> **Reference style**: use a deployment-stable *descriptive* pointer to the reference doc, NOT a
+> relative markdown link. `SKILL.md` lives three levels deep in source (`.skillshare/skills/<skill>/`)
+> and deploys to a different root than the reference (`~/.claude/skills/` vs
+> `~/.claude/references/`), so no relative path resolves in both places.
+
+## Consistency contract (verified by the test)
+
+- The body trigger's threshold MUST equal the `subagent_trigger` value in `tool_policies`.
+- A body that instructs dispatch MUST NOT belong to a `subagents: never` skill (VR-5).

--- a/specs/367-sub-agent-dispatch-guidance/contracts/tool_policies.subagents.schema.md
+++ b/specs/367-sub-agent-dispatch-guidance/contracts/tool_policies.subagents.schema.md
@@ -1,0 +1,54 @@
+# Contract: `tool_policies` subagents extension
+
+**Applies to**: every `tool_policies.<skill-name>` mapping in
+`configs/claude/config/command_config.yml`.
+
+## New fields
+
+```yaml
+tool_policies:
+  <skill-name>:
+    # ── existing fields (unchanged) ──
+    allowed: [ ... ]
+    forbidden: [ ... ]
+    parallel_agents: always | conditional | never | gate-only   # external parallel_agent.py
+    trigger_condition: "<expr>"        # only when parallel_agents: conditional
+    validation_tier: 1 | 2
+
+    # ── new in feature 367 ──
+    subagents: always | conditional | never        # REQUIRED for every skill — native Task sub-agents
+    subagent_trigger: "<expr>"                      # REQUIRED iff subagents == conditional
+    subagent_rationale: "<one line>"               # OPTIONAL; for subagents == never (or in SKILL.md)
+```
+
+## Field rules
+
+- `subagents` — **required, enum**. `always` = decomposition is the skill's core job (e.g.,
+  `docs-all`). `conditional` = fan out only above a threshold. `never` = single-step / inherently
+  sequential / mutating-shared-state.
+- `subagent_trigger` — **required when `conditional`**, else omitted. A checkable expression. Default
+  floor `independent_units >= 3`; may reuse an existing scale gate (`total_doc_lines >= 500`,
+  `unique_imports >= 5`).
+- `subagent_rationale` — present (here or as a `# comment` in the SKILL.md body) when `never`.
+
+## Examples
+
+```yaml
+  docs-all:
+    subagents: always               # orchestrates docs-readme/diagrams/improve as sub-agents
+
+  refactor-python:
+    subagents: conditional
+    subagent_trigger: "independent_modules >= 3"
+
+  checkpoint:
+    subagents: never
+    subagent_rationale: "single-session summarization; no independent units to fan out"
+```
+
+## Backward compatibility
+
+- Additive only — no existing field is renamed or removed.
+- `parallel_agents` keeps its current meaning (external harness); `subagents` is orthogonal.
+- A skill MAY be `parallel_agents: never` while `subagents: conditional` (different mechanisms,
+  different purposes).

--- a/specs/367-sub-agent-dispatch-guidance/data-model.md
+++ b/specs/367-sub-agent-dispatch-guidance/data-model.md
@@ -1,0 +1,70 @@
+# Phase 1 Data Model: Sub-Agent Dispatch Guidance
+
+This feature has no runtime data store. The "data model" is the config schema extension plus the
+structural shape of the guidance artifacts.
+
+## Entity: Skill Policy Entry (`tool_policies.<skill-name>`)
+
+One YAML mapping per skill under `tool_policies` in `command_config.yml`. **Existing** fields are
+unchanged; **new** fields are added by this feature.
+
+| Field | Status | Type | Values / Rule |
+|-------|--------|------|---------------|
+| `allowed` | existing | list | Tool names the skill may use |
+| `forbidden` | existing | list | Tool names the skill may not use |
+| `parallel_agents` | existing | enum | `always` \| `conditional` \| `never` \| `gate-only` — governs **external** `parallel_agent.py` |
+| `trigger_condition` | existing | string | Scale expr for `parallel_agents: conditional` (e.g., `total_doc_lines >= 500`) |
+| `validation_tier` | existing | int | `1` \| `2` |
+| `subagents` | **NEW** | enum | `always` \| `conditional` \| `never` — governs **native Task/Agent** sub-agents |
+| `subagent_trigger` | **NEW** | string | Required iff `subagents: conditional`. Checkable expr, default floor `independent_units >= 3` |
+| `subagent_rationale` | **NEW (optional)** | string | One-line why for `subagents: never` (may instead live as a SKILL.md comment) |
+
+### Validation rules
+
+- **VR-1**: Every skill directory with a `SKILL.md` MUST have a `tool_policies` entry with a
+  `subagents` value. (Coverage — SC-001)
+- **VR-2**: `subagents: conditional` ⇒ `subagent_trigger` present and non-empty.
+- **VR-3**: `subagents: never` ⇒ a rationale exists (in `subagent_rationale` or the SKILL.md body).
+- **VR-4**: `subagents: always|conditional` ⇒ the SKILL.md body contains a concrete dispatch trigger
+  that references the shared selection rules.
+- **VR-5**: A skill's prose trigger MUST NOT contradict its `subagents` value (e.g., a body that
+  says "dispatch one agent per X" while `subagents: never`). (Consistency — SC-004)
+- **VR-6**: `subagent_trigger` thresholds default to `>= 3` independent units unless an existing
+  per-skill scale threshold applies.
+
+### Disposition state (per skill)
+
+```text
+never  ──(work decomposes into ≥3 independent units, OR scale threshold)──▶ conditional
+conditional ──(decomposition is the skill's core job, e.g. docs-all)──▶ always
+```
+No runtime transitions; this is a one-time classification recorded in config.
+
+## Entity: Dispatch Trigger (in `SKILL.md` body)
+
+- **Where**: skill body (NOT frontmatter — frontmatter is auto-loaded; bodies are not).
+- **Shape**: a directive, checkable sentence + a link to the shared selection rules.
+- **Required parts**: condition (count/size/independence) · mechanism pointer · per-agent task ·
+  no-recursion note (inherited from shared rules).
+
+## Entity: Shared Selection Rules (in `configs/claude/references/sub-agent-dispatch.md`)
+
+- **Single instance** (read-on-demand reference, indexed from `configs/claude/CLAUDE.md`), referenced
+  by all dispatching skills.
+- **Contents**: native Task sub-agents vs `parallel_agent.py` decision logic; cross-platform
+  fallback; no-recursion rule; the ≥3-unit default floor.
+
+## Entity: Enforcement Test
+
+- **Where**: `tests/bats/subagent_policy.bats` (or `tests/python/test_subagent_policy.py`).
+- **Inputs**: the live `.skillshare/skills/` directory listing + parsed `tool_policies`.
+- **Asserts**: VR-1 … VR-5 (VR-6 advisory). Counts skills dynamically.
+
+## Relationships
+
+```text
+Skill (SKILL.md) ──1:1── Skill Policy Entry (tool_policies.<skill>)
+Skill Policy Entry ──refers to──▶ Shared Selection Rules (CLAUDE.md)  [for always|conditional]
+Dispatch Trigger (in body) ──must agree with──▶ subagents value       [VR-5]
+Enforcement Test ──verifies──▶ all of the above
+```

--- a/specs/367-sub-agent-dispatch-guidance/plan.md
+++ b/specs/367-sub-agent-dispatch-guidance/plan.md
@@ -1,0 +1,121 @@
+# Implementation Plan: Sub-Agent Dispatch Guidance for Skills
+
+**Branch**: `367-sub-agent-dispatch-guidance` | **Date**: 2026-06-28 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/367-sub-agent-dispatch-guidance/spec.md`
+
+## Summary
+
+Audit every skill in `.skillshare/skills/` and give each a sub-agent **disposition** plus, where it
+dispatches, a concrete in-body **trigger**. The existing `tool_policies` block in
+`command_config.yml` is the single canonical store: its `parallel_agents` field already governs the
+external `parallel_agent.py` harness; this feature adds a parallel `subagents` field (+ optional
+`subagent_trigger`) for Claude-native Task sub-agents. The native-vs-external **selection rules**
+(including the cross-platform fallback) live once in a referenced location and are linked from
+skills, not restated. A canonical fan-out threshold (≥3 independent units, or an existing per-skill
+scale threshold) keeps small inputs inline. An automated test wired into CI enforces that every
+skill has a disposition and that prose triggers never contradict the config.
+
+**Authoritative skill count**: **88** skill directories (each with a `SKILL.md`). The spec's "89"
+counted `.skillshare/skills/README.md` in an `ls`. The enforcement test counts skill directories
+**dynamically**, so coverage stays correct as skills are added or removed — no number is hardcoded.
+
+**Current gap**: `tool_policies` has 30 entries; **58 skills have no entry** and must be added.
+
+## Technical Context
+
+**Language/Version**: YAML (config), Markdown (skill bodies & docs), Bash (bats test) and/or
+Python 3 (pytest) for the enforcement test — matching existing `tests/bats/` + `tests/python/`.
+
+**Primary Dependencies**: `configs/claude/config/command_config.yml` (`tool_policies`), the
+orchestration guide `configs/claude/CLAUDE.md`, `.skillshare/skills/*/SKILL.md`, `parallel_agent.py`
+(referenced, not modified), the Task/Agent tool (Claude-native, referenced).
+
+**Storage**: Files only — config YAML, Markdown skill bodies, a shared reference doc, a test file.
+
+**Testing**: `bats tests/bats/` and `pytest tests/python/`; precedent: `tests/bats/context_budget.bats`.
+Lint via `yamllint` (YAML) and `shellcheck` (if bats helpers add shell).
+
+**Target Platform**: Cross-assistant config repo deployed to Claude / Cursor / Gemini / Codex /
+Antigravity via the existing symlink/rules deployment model.
+
+**Project Type**: Configuration-as-code repository (no application runtime).
+
+**Performance Goals**: N/A (authoring/config change). Indirect goal: skill guidance must not bloat
+auto-loaded context — only `SKILL.md` frontmatter is auto-loaded, so triggers go in bodies and
+selection rules are centralized + linked.
+
+**Constraints**: Single source of truth (extend `tool_policies`, no parallel store); no recursive
+sub-agent dispatch; respect token-economy (≥3-unit threshold); changes confined to skill bodies, the
+shared reference doc, `command_config.yml`, and the test (no change to `parallel_agent.py` or the
+Task tool itself).
+
+**Scale/Scope**: 88 skill dispositions (58 new + 30 reconciled), 1 schema extension, 1 shared
+selection-rules section, 1 enforcement test, 1 contributor-convention doc.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| I. Configuration-as-Code | **PASS** — all edits land in version-controlled `configs/` and `.skillshare/skills/`; deployed via `bootstrap.sh`. No manual edits to `~/.claude/`. |
+| II. Parallel Agent Orchestration | **APPLIES** — this is an architecture decision touching the whole skill library. The design itself was cross-verified via `/speckit-clarify` (4 locked decisions); the implementation PR MUST be cross-verified per the Tier-1 gate. The enforcement test additionally codifies the rule. |
+| III. Consensus-Driven Decisions | **PASS** — PR review applies the standard consensus thresholds; no bypass. |
+| IV. Skill-First Extensibility | **PASS** — no new behavior is absorbed into `parallel_agent.py`; guidance lives in skills + config + a reference doc. The enforcement test is a thin verifier, not a core-engine expansion. |
+| V. Bootstrap Reproducibility | **PASS** — config/doc edits deploy idempotently through existing mechanisms; no new install steps. |
+
+**Quality Gates**: Tier-1 (cross-verification, no secrets, error handling, no breaking changes) and
+Tier-2 (the new bats/pytest test) both satisfiable. No violations → **Complexity Tracking empty**.
+
+**Gate result**: PASS (no unjustified violations).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/367-sub-agent-dispatch-guidance/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output — tool_policies schema extension + entities
+├── quickstart.md        # Phase 1 output — how to add/decline sub-agent guidance to a skill
+├── contracts/           # Phase 1 output
+│   ├── tool_policies.subagents.schema.md   # extended-field contract
+│   ├── skill-trigger.format.md             # in-body trigger contract
+│   └── enforcement-test.contract.md        # what the CI test must assert
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+configs/claude/config/command_config.yml     # EXTEND tool_policies: add `subagents` (+ optional
+                                              #   `subagent_trigger`) to every skill; fill 58 missing
+
+configs/claude/references/sub-agent-dispatch.md  # NEW read-on-demand reference: shared "Sub-Agent
+                                              #   Selection Rules" (native vs parallel_agent.py +
+                                              #   cross-platform fallback) AND the contributor
+                                              #   convention (FR-013). Single source skills link to;
+                                              #   satisfies SC-007. Kept out of auto-loaded CLAUDE.md
+                                              #   for the context budget.
+
+configs/claude/CLAUDE.md                       # ADD ONE pointer line to the "Reference Index"
+                                              #   (only ~537 bytes headroom under context_budget.bats).
+
+.skillshare/skills/<skill>/SKILL.md            # For "always"/"conditional" skills: ADD a concrete
+                                              #   in-body dispatch trigger that links to the shared
+                                              #   rules. For "never": one-line rationale.
+
+tests/bats/subagent_policy.bats                # NEW enforcement test (or tests/python/ equivalent):
+   OR tests/python/test_subagent_policy.py     #   dynamic coverage + prose↔config consistency
+```
+
+**Structure Decision**: No new source tree — this is a config/docs/test change layered onto the
+existing repository. The canonical disposition store is the existing `tool_policies` block; the
+shared selection rules extend the existing orchestration guide; the enforcement test follows the
+`tests/bats/context_budget.bats` precedent.
+
+## Complexity Tracking
+
+> No constitution violations — table intentionally empty.

--- a/specs/367-sub-agent-dispatch-guidance/quickstart.md
+++ b/specs/367-sub-agent-dispatch-guidance/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart: Adding (or declining) sub-agent guidance to a skill
+
+This is the design-phase source for the durable convention (FR-013). At implementation time it is
+authored into the single location — `configs/claude/references/sub-agent-dispatch.md` (read-on-demand,
+indexed from `configs/claude/CLAUDE.md`), beneath the shared "Sub-Agent Selection Rules" (SC-007).
+Follow it when adding a new skill or auditing an existing one.
+
+## 1. Classify the skill
+
+Ask: **does this skill's work decompose into independent units?**
+
+| Answer | `subagents` | Example |
+|--------|-------------|---------|
+| Decomposition IS the job (always fan out) | `always` | `docs-all` (one sub-agent per docs skill) |
+| Only above a threshold | `conditional` | `refactor-python` (≥3 independent modules) |
+| Single-step / sequential / mutates shared state | `never` | `checkpoint`, `token-economy` |
+
+## 2. Record it in the canonical store
+
+Edit `configs/claude/config/command_config.yml` under `tool_policies.<skill-name>`:
+
+```yaml
+  <skill-name>:
+    subagents: conditional
+    subagent_trigger: "independent_units >= 3"     # only when conditional
+```
+
+For `never`, add a one-line `subagent_rationale:` (or a `# comment` in the SKILL.md body).
+
+## 3. Add the in-body trigger (only for always / conditional)
+
+In the skill's `SKILL.md` **body** (not frontmatter), per
+[contracts/skill-trigger.format.md](./contracts/skill-trigger.format.md):
+
+```markdown
+## Sub-agent dispatch
+
+When ≥3 independent <units> exist, dispatch one sub-agent per <unit> to <task>, then merge.
+Below that, do it inline. Pick the mechanism per the shared **Sub-Agent Selection Rules** in the
+selection-rules reference (`configs/claude/references/sub-agent-dispatch.md`).
+Sub-agents execute directly and do not re-dispatch.
+```
+
+## 4. Do NOT restate the selection rules
+
+Native Task sub-agents vs. `parallel_agent.py`, and the cross-platform fallback, live ONCE in
+`configs/claude/references/sub-agent-dispatch.md` → "Sub-Agent Selection Rules". Link to it; never copy it.
+
+## 5. Verify
+
+```bash
+bats tests/bats/subagent_policy.bats        # coverage + consistency gate
+yamllint configs/claude/config/command_config.yml
+```
+
+A new skill with no `subagents` disposition will FAIL the test until you classify it — that is the
+intended forcing function.
+
+## Mechanism cheat-sheet (summary of the shared rules)
+
+- **Parallel reads / research / fan-out audit** → native **Task sub-agents** (Claude). On non-Claude
+  assistants, run inline or use `parallel_agent.py`.
+- **Independent cross-model verification** of a security-sensitive / architectural / >200-line change
+  → **`parallel_agent.py`** (cross-platform; satisfies the constitution's Tier-1 gate).
+- **Trivial / single-unit / <3 independent items** → **inline**, no dispatch.

--- a/specs/367-sub-agent-dispatch-guidance/research.md
+++ b/specs/367-sub-agent-dispatch-guidance/research.md
@@ -1,0 +1,84 @@
+# Phase 0 Research: Sub-Agent Dispatch Guidance for Skills
+
+All four high-impact unknowns were resolved during `/speckit-clarify`. This file records those
+decisions plus the grounding facts gathered while planning. No `NEEDS CLARIFICATION` remain.
+
+## R1 — Disposition store
+
+- **Decision**: Extend the existing `tool_policies` block in `configs/claude/config/command_config.yml`.
+  Add a `subagents: always|conditional|never` field (and optional `subagent_trigger:` when
+  `conditional`) to each skill entry, alongside the existing `parallel_agents` field.
+- **Rationale**: `tool_policies` already encodes per-skill `parallel_agents: always|conditional|never`
+  with `trigger_condition` for scale gates. Reusing it gives one canonical store, one vocabulary, and
+  one place CI verifies. A second store would invite drift.
+- **Alternatives considered**: (a) per-skill SKILL.md frontmatter + a separate audit doc — rejected,
+  two stores to reconcile; (b) a brand-new registry doc — rejected, relocates existing data and
+  duplicates the schema.
+
+## R2 — Selection-rule location
+
+- **Decision**: Author the native-Task-subagent vs `parallel_agent.py` selection rules (with the
+  cross-platform fallback) once, as a section in `configs/claude/CLAUDE.md` (the deployed
+  orchestration guide). Skills link to it and carry only their own concrete trigger.
+- **Rationale**: Repeating ~15 lines of selection logic across 30+ skills bloats bodies and drifts.
+  Centralizing matches the repo convention ("MCP routing defined once in the orchestration guide").
+  Only `SKILL.md` *frontmatter* is auto-loaded, so per-skill bodies stay lean; the shared rules are
+  read on demand.
+- **Alternatives considered**: inline-in-every-skill (rejected: duplication/drift); guide-only with
+  no per-skill trigger (rejected: agents would not see a concrete "when" at the point of use).
+
+## R3 — Fan-out threshold
+
+- **Decision**: Canonical default — dispatch only when **≥3 independent units of work** exist, OR an
+  existing per-skill scale threshold is exceeded (e.g., `docs_improve_lines: 500`,
+  `unique_imports >= 5`). Fewer → inline.
+- **Rationale**: Sub-agent dispatch has fixed overhead; a uniform floor prevents fan-out on trivial
+  inputs (token-economy). Reusing existing `trigger_condition` thresholds keeps behavior consistent
+  with what `parallel_agents: conditional` skills already use.
+- **Alternatives considered**: ≥2 units (rejected: too eager, overhead on small inputs); per-skill
+  ad-hoc thresholds with no default (rejected: inconsistent, hard to verify uniformly).
+
+## R4 — Enforcement
+
+- **Decision**: Add an automated test (`tests/bats/subagent_policy.bats`, or a `tests/python/`
+  pytest if assertions get complex) wired into CI. It MUST (a) enumerate skill directories
+  dynamically and assert each has a `subagents` disposition in `tool_policies`; (b) assert every
+  `always`/`conditional` skill body contains a trigger and every `never` skill carries a rationale;
+  (c) assert no prose trigger contradicts its recorded disposition.
+- **Rationale**: The repo already gates invariants with bats (`context_budget.bats`,
+  `commands_doc_drift.bats`). A dynamic test makes SC-001 (coverage) and SC-004 (consistency)
+  self-maintaining as skills are added.
+- **Alternatives considered**: manual checklist (rejected: silently regresses); on-demand script not
+  in CI (rejected: not enforced per change).
+
+## R5 — Authoritative skill count (grounding)
+
+- **Decision**: There are **88** skill directories under `.skillshare/skills/` (each has a
+  `SKILL.md`). The spec's "89" came from an `ls` that counted `README.md`. The enforcement test
+  counts directories dynamically, so no count is hardcoded.
+- **Rationale**: Avoids a brittle magic number and a spec/impl mismatch.
+- **Alternatives considered**: hardcode 88 in the test (rejected: breaks on the next skill added).
+
+## R6 — Coverage gap (grounding)
+
+- **Finding**: `tool_policies` currently has **30** entries; **58** skill directories have none.
+  Implementation must add `subagents` to all 88 and backfill the 58 missing entries (with
+  `parallel_agents`/`allowed`/`forbidden`/`validation_tier` as appropriate).
+- **Implication**: The audit is a large, highly parallelizable classification task — a natural fit
+  for sub-agent fan-out during `/speckit-implement` (one agent per batch of skills), which also
+  dogfoods the very capability this feature documents.
+
+## R7 — Native sub-agent exemplar (grounding)
+
+- **Finding**: `docs-all` already dispatches Claude-native sub-agents via the Task tool (one per
+  docs skill, continue-on-failure, merged report). It is the reference pattern for "always"-style
+  native dispatch and for the trigger wording other skills should mirror.
+
+## R8 — Cross-platform fallback
+
+- **Decision**: The shared selection rules MUST state: native Task/Agent sub-agents are Claude-only;
+  on Cursor/Gemini/Codex/Antigravity, skills either use `parallel_agent.py` (cross-platform) or run
+  the work inline. No skill may leave a non-Claude assistant without an executable path.
+- **Rationale**: Guidance that assumes the Task tool would silently fail on other assistants the
+  repo explicitly supports.
+- **Alternatives considered**: Claude-only guidance (rejected: repo is multi-assistant by design).

--- a/specs/367-sub-agent-dispatch-guidance/spec.md
+++ b/specs/367-sub-agent-dispatch-guidance/spec.md
@@ -1,0 +1,241 @@
+# Feature Specification: Sub-Agent Dispatch Guidance for Skills
+
+**Feature Branch**: `367-sub-agent-dispatch-guidance`
+
+**Created**: 2026-06-28
+
+**Status**: Draft
+
+**Input**: User description: "make appropriate use of sub-agents for these. specifically instruct when to."
+
+## Clarifications
+
+### Session 2026-06-28
+
+- Q: Which skills should gain sub-agent dispatch guidance? → A: All 89 skills (full audit).
+- Q: Which kind of sub-agent should the guidance cover? → A: Both Claude-native Task sub-agents and the existing `parallel_agent.py` external CLI agents, with explicit rules for choosing between them.
+- Q: Where is each skill's disposition recorded as the single source of truth? → A: Extend the existing `tool_policies` block in `command_config.yml` (add native-Task-subagent fields alongside `parallel_agents`); SKILL.md bodies carry the prose triggers that reference it.
+- Q: Where do the native-vs-`parallel_agent.py` selection rules live? → A: Centralized in one referenced location (orchestration guide / references doc); each skill body carries only its own concrete trigger and links to the shared rules.
+- Q: What canonical minimum-scale default gates "conditional" dispatch? → A: Dispatch only when ≥3 independent units of work exist, OR an existing per-skill scale threshold (e.g., `docs_improve_lines: 500`) is exceeded; fewer → inline.
+- Q: How is audit coverage and config/prose consistency enforced? → A: An automated test (bats/pytest) wired into CI asserts every skill has a `tool_policies` disposition and that prose triggers do not contradict it.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Skills tell the agent when to dispatch sub-agents (Priority: P1)
+
+An AI assistant (Claude, Cursor, Gemini, or Codex) invokes a skill that involves multiple
+independent steps (e.g., a multi-language refactor, a whole-repo audit, a docs refresh). The
+skill body contains an explicit, concrete instruction telling the agent **whether** to dispatch
+sub-agents, **when** the condition for dispatch is met, **how many** to dispatch, and **what each
+should do**. The agent reads this guidance inline and fans the work out instead of grinding through
+every step sequentially in one context.
+
+**Why this priority**: This is the core of the request ("specifically instruct when to"). Without
+concrete in-skill triggers, sub-agent use stays accidental and inconsistent. This story alone — even
+applied to only the heaviest skills — delivers the primary value: faster, more parallel, less
+context-starved skill execution.
+
+**Independent Test**: Pick any orchestration-heavy skill (e.g., `refactor-python`, `docs-all`,
+`repo-hygiene`), read its `SKILL.md`, and confirm it states a concrete dispatch trigger ("when N
+independent targets exist, dispatch one sub-agent per target to do X"). Execute the skill against a
+qualifying input and confirm the agent fans out as instructed; execute against a sub-threshold input
+and confirm it stays inline.
+
+**Acceptance Scenarios**:
+
+1. **Given** a skill whose work decomposes into 2+ independent units, **When** an agent runs it,
+   **Then** the skill provides an explicit condition under which to dispatch sub-agents and a
+   description of each sub-agent's task.
+2. **Given** a skill whose work is a single trivial step, **When** an agent runs it, **Then** the
+   skill explicitly states that sub-agents are NOT to be used (so dispatch is never ambiguous).
+3. **Given** a dispatch trigger in a skill, **When** the trigger is read, **Then** it is phrased as
+   a checkable condition (count, size, independence) rather than a vague suggestion ("consider...").
+
+---
+
+### User Story 2 - Selection rules choose the right sub-agent mechanism (Priority: P2)
+
+The repository exposes two sub-agent paradigms: Claude-native Task/Agent sub-agents (in-session,
+read-and-fan-out, Claude-only) and the external `parallel_agent.py` cross-verification harness
+(Gemini/Cursor/Codex/Antigravity, cross-platform). When a skill instructs dispatch, the agent needs
+to know **which** mechanism to use. Each skill's guidance (or a shared, referenced rule set) tells
+the agent which paradigm fits the task and the running platform.
+
+**Why this priority**: Picking the wrong mechanism wastes tokens or fails outright (e.g., invoking
+the Task tool on a platform that lacks it). Selection rules make the P1 guidance actionable across
+all supported assistants. It depends on P1 existing but is independently testable.
+
+**Independent Test**: For a skill that supports both mechanisms, confirm its guidance states the
+selection rule (e.g., "use native Task sub-agents for parallel reads/research; use `parallel_agent.py`
+for independent cross-model verification of a security-sensitive change"). Confirm the rule names the
+cross-platform fallback for non-Claude assistants.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task that is parallel information-gathering, **When** the selection rule is applied,
+   **Then** it directs the agent to native Task sub-agents (or the platform equivalent).
+2. **Given** a task that is independent cross-model verification, **When** the selection rule is
+   applied, **Then** it directs the agent to `parallel_agent.py`.
+3. **Given** a non-Claude assistant running the skill, **When** native Task sub-agents are
+   unavailable, **Then** the guidance names the cross-platform path so the skill still works.
+4. **Given** the existing per-skill parallel-agent policy in `command_config.yml`
+   (`tool_policies`, values always/conditional/never), **When** new guidance is written, **Then** it
+   is consistent with that policy and does not contradict it.
+
+---
+
+### User Story 3 - Every skill is audited with a recorded disposition (Priority: P3)
+
+A contributor needs assurance that the whole skill library (88 skill directories at time of
+writing; enumerated dynamically) was reviewed for sub-agent
+suitability, not just the obvious heavy hitters. Each skill receives a disposition — dispatch
+"always", "conditional", or "never" — and skills marked "never" carry a one-line rationale, so the
+audit is auditable and future skills inherit a clear pattern to follow.
+
+**Why this priority**: The user chose a full audit over a targeted subset. Coverage and an explicit
+rationale for non-dispatch skills prevent silent gaps and give the convention durability. It builds
+on P1/P2 conventions but is about completeness rather than the convention itself.
+
+**Independent Test**: Produce the audit result and confirm every skill directory under
+`.skillshare/skills/` appears with a disposition; spot-check that "never" skills have a rationale and
+"always"/"conditional" skills carry P1-style triggers.
+
+**Acceptance Scenarios**:
+
+1. **Given** the full skill list, **When** the audit completes, **Then** every skill has exactly one
+   recorded disposition.
+2. **Given** a skill dispositioned "never", **When** its entry is read, **Then** a brief rationale
+   explains why fan-out does not apply.
+3. **Given** a newly added skill after this feature, **When** a contributor consults the convention,
+   **Then** there is a documented pattern for how to express (or decline) sub-agent guidance.
+
+---
+
+### Edge Cases
+
+- **Token-economy tension**: Dispatching sub-agents has overhead. Guidance must not trigger fan-out
+  for work cheaper to do inline; triggers include a minimum-scale condition so small inputs stay
+  sequential.
+- **Nested dispatch / recursion**: A sub-agent must not itself fan out the same way (risk of agent
+  explosion). Guidance must state that dispatched sub-agents execute their task directly and do not
+  re-dispatch.
+- **Platform without native sub-agents**: Cursor/Gemini/Codex may lack the Task tool; the selection
+  rule must always offer a path that works on the running platform (or instruct skipping fan-out).
+- **Skills that already dispatch** (e.g., `docs-all`, `plan-manage`): existing guidance must be
+  reconciled, not duplicated or contradicted.
+- **Sensitive-change policy interaction**: The orchestration guide already mandates parallel agents
+  for security/architecture/large changes; per-skill guidance must defer to that mandate, not weaken
+  it.
+- **Conflicting instructions**: If a skill's body prose conflicts with its `tool_policies` entry in
+  `command_config.yml`, the **config is authoritative** (disposition and `subagent_trigger` value);
+  the enforcement test flags the divergence so the prose is corrected. The config is the single
+  source of truth; the body is a synced restatement, never an independent store.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Every skill directory under `.skillshare/skills/` (i.e., every directory containing a
+  `SKILL.md` — 88 at time of writing) MUST be reviewed and assigned exactly one sub-agent
+  disposition: "always", "conditional", or "never". Coverage MUST be enumerated dynamically, not
+  asserted against a hardcoded count.
+- **FR-002**: Skills dispositioned "always" or "conditional" MUST contain an explicit, in-skill
+  instruction stating the concrete condition under which to dispatch sub-agents (a checkable trigger:
+  count / size / independence threshold), how many to dispatch, and what each sub-agent does.
+- **FR-003**: Skills dispositioned "never" MUST carry a brief rationale explaining why sub-agent
+  fan-out does not apply.
+- **FR-004**: Dispatch guidance MUST cover both paradigms — Claude-native Task/Agent sub-agents and
+  the external `parallel_agent.py` harness — and MUST provide selection rules for choosing between
+  them based on task type and running platform.
+- **FR-005**: Selection rules MUST always yield a path that works on the assistant actually running
+  the skill (Claude, Cursor, Gemini, Codex, Antigravity), including the cross-platform fallback when
+  native sub-agents are unavailable.
+- **FR-006**: The existing `tool_policies` block in `command_config.yml` MUST be the single canonical
+  store for each skill's disposition; it MUST be extended with native-Task-subagent field(s)
+  alongside the current `parallel_agents` field rather than introducing a parallel store. New
+  guidance MUST also defer to the orchestration guide's mandatory-parallel-agent rules.
+- **FR-007**: The shared native-vs-`parallel_agent.py` selection rules (including the cross-platform
+  fallback) MUST live in ONE referenced, read-on-demand location —
+  `configs/claude/references/sub-agent-dispatch.md`, indexed by a one-line pointer in the
+  auto-loaded `configs/claude/CLAUDE.md` "Reference Index" (kept out of the auto-loaded body to
+  respect the context budget enforced by `context_budget.bats`). Each skill body MUST reference
+  those shared rules rather than restate them, and carry its own concrete
+  dispatch trigger as human-readable prose. The trigger's **structured threshold value** is stored
+  once in `command_config.yml` as `subagent_trigger` (mirroring the existing `trigger_condition`
+  field for the external harness); this config value is authoritative. The SKILL.md prose MUST agree
+  with it, and the enforcement test (FR-011) verifies they do not diverge. This is not a parallel
+  store: config holds the canonical machine-readable value, the body holds a human-facing
+  restatement kept in sync by the test.
+- **FR-008**: Guidance MUST instruct that dispatched sub-agents perform their assigned task directly
+  and do NOT recursively dispatch further sub-agents.
+- **FR-009**: Guidance MUST respect token-economy via a canonical minimum-scale default: a skill
+  dispatches only when ≥3 independent units of work exist, OR an existing per-skill scale threshold
+  (e.g., `docs_improve_lines: 500`) is exceeded; below that, work is handled inline.
+- **FR-010**: The phrasing of dispatch triggers MUST be directive and checkable ("when N independent
+  X exist, dispatch one agent per X"), not vague encouragement ("consider using agents").
+- **FR-011**: An automated test (bats/pytest, wired into CI) MUST assert that every skill has a
+  `tool_policies` disposition and that each skill's prose dispatch trigger does not contradict its
+  recorded disposition. The test doubles as the at-a-glance coverage record for all skills.
+- **FR-012**: Existing skills that already dispatch sub-agents MUST be reconciled with the new
+  convention rather than duplicated or contradicted.
+- **FR-013**: A documented convention describing how future skills express (or explicitly decline)
+  sub-agent guidance MUST exist in exactly ONE location — `configs/claude/references/sub-agent-dispatch.md`,
+  as a subsection beneath the shared selection rules — so the pattern is durable and co-located with
+  the rules it references.
+
+### Key Entities *(include if feature involves data)*
+
+- **Skill**: A unit in `.skillshare/skills/` with a `SKILL.md`. Gains a sub-agent disposition and,
+  where applicable, an in-body dispatch instruction.
+- **Disposition**: The classification of a skill's sub-agent suitability — one of "always",
+  "conditional", "never" — aligned with the `tool_policies` vocabulary already in
+  `command_config.yml`.
+- **Dispatch trigger**: The checkable condition embedded in a skill that tells the agent when to fan
+  out (scale, count, independence) and what each sub-agent should do.
+- **Selection rule**: The decision logic mapping a task + running platform to the correct sub-agent
+  mechanism (native Task sub-agents vs. `parallel_agent.py`), defined once in a shared referenced
+  location and linked from skills.
+- **Audit artifact**: The `tool_policies` block in `command_config.yml` (canonical dispositions) plus
+  the automated coverage/consistency test that verifies every skill is represented — together they
+  are the at-a-glance, enforced record.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of skill directories under `.skillshare/skills/` have a recorded sub-agent
+  disposition in the `tool_policies` block of `command_config.yml` (verified by the automated
+  coverage test, which enumerates skills dynamically).
+- **SC-002**: 100% of skills dispositioned "always" or "conditional" contain a checkable dispatch
+  trigger (a reviewer can point to the condition, count, and per-agent task in the skill body).
+- **SC-003**: 100% of skills dispositioned "never" carry a one-line rationale.
+- **SC-004**: Zero contradictions between in-skill prose triggers and the `tool_policies` dispositions
+  in `command_config.yml` — enforced by the automated consistency test passing in CI.
+- **SC-005**: Every skill that instructs native sub-agent dispatch also states a path that works on a
+  non-Claude assistant (no skill leaves a non-Claude platform without an executable option).
+- **SC-006**: For a representative heavy skill, running it on a qualifying (multi-target) input
+  results in observable fan-out, and running it on a sub-threshold input results in inline execution
+  — i.e., the trigger demonstrably gates behavior.
+- **SC-007**: A contributor can locate the "how to add sub-agent guidance to a new skill" convention
+  in one documented place — `configs/claude/references/sub-agent-dispatch.md`, beneath the shared
+  selection rules (pointed to from the CLAUDE.md Reference Index).
+
+## Assumptions
+
+- "These" refers to the full skill library (skill directories under `.skillshare/skills/` — 88 at
+  time of writing; the clarification's "89" was an `ls` count that included `README.md`), confirmed
+  via clarification; `configs/claude/skills` is the compat symlink to the same source of truth.
+- "Sub-agents" covers both Claude-native Task/Agent sub-agents and the repo's existing external
+  `parallel_agent.py` harness, confirmed via clarification.
+- The existing `tool_policies` block in `command_config.yml` (per-skill always/conditional/never
+  parallel-agent policy) is the canonical disposition store and is extended in place with
+  native-Task-subagent field(s) — never replaced by or duplicated into a parallel mechanism
+  (confirmed via clarification).
+- The orchestration guide's existing "ALWAYS use parallel agents for security/architecture/large
+  changes" rules remain authoritative; per-skill guidance defers to them.
+- Guidance is authored for AI assistants as the primary readers (consistent with how `SKILL.md`
+  bodies are written), with contributors as secondary readers.
+- Changes are confined to skill bodies, the audit artifact, and configuration/convention docs; no
+  change to `parallel_agent.py` behavior or the Task tool itself is in scope.
+- Cross-platform deployment (Cursor/Gemini/Codex/Antigravity) follows the existing symlink/rules
+  deployment model; no new deployment mechanism is introduced.

--- a/specs/367-sub-agent-dispatch-guidance/tasks.md
+++ b/specs/367-sub-agent-dispatch-guidance/tasks.md
@@ -1,0 +1,212 @@
+---
+description: "Task list for Sub-Agent Dispatch Guidance for Skills"
+---
+
+# Tasks: Sub-Agent Dispatch Guidance for Skills
+
+**Input**: Design documents from `specs/367-sub-agent-dispatch-guidance/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md (all present)
+
+**Tests**: The enforcement test is a first-class feature deliverable (FR-011), not optional TDD —
+it lives in Phase 6 (US3) because it verifies the full-coverage outcome.
+
+**Organization**: Grouped by user story. MVP = US1 (concrete triggers on the heaviest skills).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3 (Setup/Foundational/Polish carry no story label)
+- Exact file paths included. Repo root = `/Users/chrismandich/Documents/GitHub/Manifest/.claude/worktrees/sub-agent-use`
+
+## Path Conventions
+
+This is a configuration-as-code repo (no app runtime). Work touches:
+`configs/claude/config/command_config.yml`, `configs/claude/CLAUDE.md`,
+`.skillshare/skills/<skill>/SKILL.md`, and `tests/bats/`.
+
+⚠️ **Same-file serialization**: Many tasks edit the single file
+`configs/claude/config/command_config.yml`. Tasks editing it are **NOT** `[P]` with each other.
+Tasks editing distinct `SKILL.md` files **are** `[P]`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm a green baseline before any edits.
+
+- [X] T001 Confirm baseline is green: run `bats tests/bats/` and `yamllint configs/claude/config/command_config.yml`; record current pass state.
+- [X] T002 Confirm authoritative skill count dynamically: `find .skillshare/skills -mindepth 1 -maxdepth 1 -type d -exec test -f '{}/SKILL.md' \; -print | wc -l` (expect 88) and that 58 lack a `tool_policies` entry — capture the missing list for Phase 6.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared selection rules and the config schema convention. **Everything else links to
+these**, so they MUST land first.
+
+**⚠️ CRITICAL**: No US1/US2/US3 task may begin until T003–T004 are complete.
+
+- [X] T003 Author the shared **Sub-Agent Selection Rules** in a NEW read-on-demand reference `configs/claude/references/sub-agent-dispatch.md` (NOT inline in the auto-loaded CLAUDE.md — context_budget.bats allows only ~537 bytes headroom there). Content per research R2/R8 + data-model "Shared Selection Rules": native Task/Agent sub-agents vs `parallel_agent.py`; cross-platform fallback (Claude-only Task tool → inline or `parallel_agent.py` on Cursor/Gemini/Codex/Antigravity); no-recursion rule; ≥3-independent-unit default floor. Then add ONE pointer line to the "Reference Index" in `configs/claude/CLAUDE.md`.
+- [X] T004 Add the `subagents` schema convention as a header comment block at the top of the `tool_policies:` block in `configs/claude/config/command_config.yml`, per `contracts/tool_policies.subagents.schema.md` (documents `subagents`, `subagent_trigger`, `subagent_rationale`; states config is authoritative over body prose).
+
+**Checkpoint**: Shared rules + schema exist — skills can now reference them and record dispositions.
+
+---
+
+## Phase 3: User Story 1 - In-skill dispatch triggers (Priority: P1) 🎯 MVP
+
+**Goal**: The heaviest, obviously-decomposable skills carry a concrete, checkable in-body dispatch
+trigger that links the shared rules — proving the convention end-to-end on a representative set.
+
+**Independent Test**: Read each targeted `SKILL.md`; confirm a directive trigger (condition + count +
+per-agent task + link to shared rules) is present, and its threshold matches `subagent_trigger` in
+`command_config.yml`.
+
+- [X] T005 [US1] Set `subagents` (+ `subagent_trigger` where conditional) for the MVP set in `configs/claude/config/command_config.yml` (single-file, serial edit): `docs-all`=always; `deep-research`=always; `refactor-python`/`refactor-node`/`refactor-go`/`refactor-shell`/`refactor-terraform`=conditional `subagent_trigger: "independent_units >= 3"`; `repo-hygiene`=conditional; `pr-review`=conditional; `issue-triage`=conditional.
+- [X] T006 [P] [US1] Reconcile existing dispatch prose in `.skillshare/skills/docs-all/SKILL.md` into the standard trigger form (per `contracts/skill-trigger.format.md`), linking `#sub-agent-selection-rules`; do not duplicate the rules.
+- [X] T007 [P] [US1] Add dispatch trigger to `.skillshare/skills/deep-research/SKILL.md` (one sub-agent per independent search/source cluster).
+- [X] T008 [P] [US1] Add dispatch trigger to `.skillshare/skills/refactor-python/SKILL.md` (one sub-agent per independent module/dimension when ≥3).
+- [X] T009 [P] [US1] Add dispatch trigger to `.skillshare/skills/refactor-node/SKILL.md`.
+- [X] T010 [P] [US1] Add dispatch trigger to `.skillshare/skills/refactor-go/SKILL.md`.
+- [X] T011 [P] [US1] Add dispatch trigger to `.skillshare/skills/refactor-shell/SKILL.md`.
+- [X] T012 [P] [US1] Add dispatch trigger to `.skillshare/skills/refactor-terraform/SKILL.md`.
+- [X] T013 [P] [US1] Add dispatch trigger to `.skillshare/skills/repo-hygiene/SKILL.md` (one sub-agent per PR/branch batch).
+- [X] T014 [P] [US1] Add dispatch trigger to `.skillshare/skills/pr-review/SKILL.md` (one sub-agent per open PR when ≥3).
+- [X] T015 [P] [US1] Add dispatch trigger to `.skillshare/skills/issue-triage/SKILL.md` (one sub-agent per issue batch).
+- [X] T016 [US1] Verify each MVP trigger's threshold equals its `subagent_trigger` in config (manual cross-check; precursor to the automated test).
+
+**Checkpoint**: MVP — a representative set demonstrates the full convention and is independently reviewable.
+
+---
+
+## Phase 4: User Story 2 - Selection rules wired per skill (Priority: P2)
+
+**Goal**: Every dispatching skill points to the right mechanism (native Task vs `parallel_agent.py`)
+and always offers a path that works on the running assistant.
+
+**Independent Test**: For a dual-mechanism skill, confirm its trigger states the selection rule and
+names the cross-platform fallback; confirm a security/architectural skill routes cross-model
+verification to `parallel_agent.py`.
+
+- [X] T017 [US2] In `configs/claude/references/sub-agent-dispatch.md` selection-rules section, add the explicit mechanism-by-task-type table (parallel reads/research → native Task; independent cross-model verification of security/architecture/>200-line changes → `parallel_agent.py`; <3 units → inline) and the non-Claude fallback row.
+- [X] T018 [US2] Ensure the `refactor-*` skills keep `parallel_agents: always` (external cross-verification, constitution Tier-1) AND carry their native `subagents` trigger — verify the two fields coexist without contradiction in `command_config.yml`.
+- [X] T019 [P] [US2] In each MVP `SKILL.md` trigger (T006–T015), confirm the mechanism pointer + cross-platform fallback reference is present (amend any that only say "dispatch a sub-agent" without the selection link).
+- [X] T020 [US2] Add a note to the selection-rules reference (`configs/claude/references/sub-agent-dispatch.md`) that dispatched sub-agents never re-dispatch (no recursion), referenced by all triggers (FR-008/FR-007).
+
+**Checkpoint**: Mechanism selection is unambiguous and cross-platform-safe for every dispatching skill.
+
+---
+
+## Phase 5: User Story 3 - Full-coverage audit + enforcement (Priority: P3)
+
+**Goal**: Every one of the 88 skill directories has a disposition; "never" skills carry a rationale;
+an automated test enforces coverage + consistency; the contributor convention is documented once.
+
+**Independent Test**: Run the enforcement test — it passes and reports a disposition for every skill
+directory; spot-check rationales and triggers.
+
+### Audit (dogfood sub-agent fan-out — this is the "when to dispatch" instruction in action)
+
+- [X] T021 [US3] **Dispatch sub-agents to classify the remaining skills**: split the ~78 non-MVP skill directories into batches of ~10 and dispatch **one sub-agent per batch** (≥3 independent batches → fan out per the very rule this feature defines). Each sub-agent reads its batch's `SKILL.md` files and returns, per skill: proposed `subagents` disposition, `subagent_trigger` (if conditional), and a one-line rationale (if `never`). Consolidate into a single proposed-dispositions table. (Native Task sub-agents on Claude; inline/`parallel_agent.py` fallback otherwise.) Explicitly include the skills that **already** mention sub-agents — `plan-manage`, `ai-hooks-integration`, `speckit-implement-review` — so their existing dispatch prose is reconciled into the standard trigger form, not duplicated or contradicted (FR-012).
+- [X] T022 [US3] Review the consolidated proposals for consistency (same disposition vocabulary, threshold defaults), resolving any disagreements before writing config.
+
+### Write dispositions to the canonical store (single file → serial)
+
+- [X] T023 [US3] Backfill `tool_policies` entries for the 58 skills with no entry in `configs/claude/config/command_config.yml`, each with `subagents` (+ `subagent_trigger`/`subagent_rationale`) and required existing fields (`allowed`/`forbidden`/`validation_tier`, `parallel_agents` where applicable).
+- [X] T024 [US3] Add the `subagents` field to the 30 pre-existing `tool_policies` entries that lack it (not covered by T005), preserving their current `parallel_agents`/`trigger_condition`.
+
+### Rationales + triggers for the long tail (distinct files → parallelizable in batches)
+
+- [X] T025 [P] [US3] For every skill dispositioned `never`, ensure a one-line `subagent_rationale` (config) or `> Sub-agents: not used — <reason>.` marker in its `SKILL.md` body.
+- [X] T026 [P] [US3] For every non-MVP skill dispositioned `always`/`conditional`, add the in-body dispatch trigger (per `contracts/skill-trigger.format.md`) linking the shared rules.
+
+### Enforcement test + convention
+
+- [X] T027 [US3] Implement `tests/bats/subagent_policy.bats` per `contracts/enforcement-test.contract.md`: assertions T1–T7 (dynamic skill enumeration; every skill has `subagents`; conditional⇒trigger; never⇒rationale; always/conditional⇒body trigger linking shared rules; no never-skill body instructs dispatch; advisory threshold form).
+- [X] T028 [US3] Confirm the new test is auto-discovered by the existing CI bats job (`tests/bats/*.bats`); run `bats tests/bats/subagent_policy.bats` and make it pass.
+- [X] T029 [US3] Author the contributor convention as a subsection beneath the selection rules in `configs/claude/references/sub-agent-dispatch.md` (FR-013/SC-007), porting `quickstart.md` content (the one documented place).
+
+**Checkpoint**: 100% coverage, enforced in CI; convention is durable and discoverable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T030 Run `quickstart.md` end-to-end as a contributor would (add a throwaway dummy skill dir with no disposition → confirm T027 fails → remove it) to validate the forcing function. **Then demonstrate SC-006** on one `conditional` skill (e.g., `refactor-python`): trace that an input with ≥3 independent units triggers fan-out while a <3-unit input stays inline — confirming the trigger demonstrably gates behavior, not just that the threshold is recorded.
+- [X] T031 [P] Run full gate: `bats tests/bats/`, `pytest tests/python/`, `yamllint configs/claude/config/command_config.yml`, `markdownlint` on edited docs; fix any drift (e.g., `commands_doc_drift.bats`).
+- [X] T032 [P] Reconcile spec count note if any skill is added/removed during implementation (test is dynamic; just confirm no hardcoded number leaked into the test).
+- [X] T033 Self-review for constitution Tier-1 (Principle II): ran `parallel_agent.py --review` cross-verification on the diff (architecture-wide change >200 lines). 3 agents launched; claude + antigravity completed (gemini failed on `IneligibleTierError` — CLI deprecated for individuals, infra not code). Substantive checks all passed (security/error-handling/breaking-changes ✅, Tier-2 1.0); the `BLOCKED` verdict was a false block from the consensus metric collapsing on the gemini failure, not a finding. **One real bug caught & fixed**: `tests/bats/subagent_policy.bats` opened `SKILL.md`/config without `encoding="utf-8"` → `UnicodeDecodeError` on a C/POSIX-locale CI runner without `C.UTF-8` (reproduced with coercion disabled: `'ascii' codec can't decode byte 0xe2`). Fixed both `open()` calls; test passes under forced `C` locale. Antigravity's "broken doc links" finding was a non-issue (inline code spans using the repo-root path convention, not markdown link targets).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no deps — start immediately.
+- **Foundational (Phase 2)**: after Setup — **BLOCKS US1/US2/US3** (everything links the shared rules + schema).
+- **US1 (Phase 3)**: after Foundational. Delivers MVP.
+- **US2 (Phase 4)**: after Foundational; builds on US1's triggers (amends them) — run after US1 for the MVP set, but selection-rules table (T017/T020) can land alongside Foundational.
+- **US3 (Phase 5)**: after Foundational; T026 reuses the trigger format proven in US1; the enforcement test (T027) needs all dispositions (T023–T026) written first.
+- **Polish (Phase 6)**: after all desired stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: independent once Foundational done — the MVP.
+- **US2 (P2)**: logically refines US1 triggers + the shared table; independently testable.
+- **US3 (P3)**: full coverage + enforcement; the test depends on US1/US2/US3 dispositions existing.
+
+### Within Each Story
+
+- Config disposition (single file, serial) → SKILL.md triggers (distinct files, parallel) → verify.
+
+### Parallel Opportunities
+
+- T006–T015 (US1 SKILL.md triggers) — all `[P]` (distinct files).
+- T021 batches — sub-agents run concurrently (the canonical fan-out).
+- T025/T026 — `[P]` across distinct SKILL.md files.
+- T031/T032 — `[P]`.
+- ⚠️ All `command_config.yml` edits (T004, T005, T018, T023, T024) are **serial** — same file.
+
+---
+
+## Parallel Example: User Story 1 SKILL.md triggers
+
+```text
+# After T005 sets dispositions in config, dispatch trigger-writing in parallel (distinct files):
+Task: "Add dispatch trigger to .skillshare/skills/refactor-python/SKILL.md"
+Task: "Add dispatch trigger to .skillshare/skills/refactor-node/SKILL.md"
+Task: "Add dispatch trigger to .skillshare/skills/refactor-go/SKILL.md"
+Task: "Add dispatch trigger to .skillshare/skills/deep-research/SKILL.md"
+```
+
+## Parallel Example: User Story 3 audit fan-out (the feature, applied to itself)
+
+```text
+# T021 — one sub-agent per ~10-skill batch (≥3 batches → fan out):
+Task: "Classify subagent disposition for skills batch 1 (a11y-audit … ci-setup) — return table"
+Task: "Classify subagent disposition for skills batch 2 (ci-workflow… … health-check) — return table"
+Task: "Classify subagent disposition for skills batch 3 (help … pin-known-bug…) — return table"
+# Consolidate (T022) → write to config (T023/T024, serial).
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational (shared rules + schema) → 3. Phase 3 US1 →
+4. **STOP & VALIDATE**: heavy skills show concrete triggers, thresholds match config → demo.
+
+### Incremental Delivery
+
+US1 (MVP) → US2 (mechanism selection wired) → US3 (full audit + CI enforcement + convention).
+Each step is independently testable and adds value without breaking the prior.
+
+### Notes
+
+- `[P]` = distinct files, no deps. Config-YAML edits are never `[P]` together.
+- Commit after each phase; the enforcement test (T027) is the durable backstop.
+- T033 satisfies constitution Principle II (cross-verify architecture-wide change before PR).

--- a/tests/bats/subagent_policy.bats
+++ b/tests/bats/subagent_policy.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# Feature 367 — Sub-agent dispatch guidance enforcement.
+# Verifies every skill has a `subagents` disposition in tool_policies and that
+# SKILL.md prose triggers do not contradict it. Skills are enumerated
+# DYNAMICALLY (no hardcoded count), so a new skill without a disposition fails
+# here until it is classified. See configs/claude/references/sub-agent-dispatch.md.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# Run a named check implemented in the embedded Python helper; the helper exits
+# non-zero and prints offending skills on failure.
+run_check() {
+    python3 - "$REPO_ROOT" "$1" <<'PY'
+import os, sys
+import yaml
+
+repo, check = sys.argv[1], sys.argv[2]
+skills_dir = os.path.join(repo, ".skillshare/skills")
+cfg = os.path.join(repo, "configs/claude/config/command_config.yml")
+
+skills = sorted(
+    d for d in os.listdir(skills_dir)
+    if os.path.isfile(os.path.join(skills_dir, d, "SKILL.md"))
+)
+with open(cfg, encoding="utf-8") as fh:
+    tp = (yaml.safe_load(fh) or {}).get("tool_policies", {}) or {}
+VALID = {"always", "conditional", "never"}
+MARKER = "## Sub-agent dispatch"
+
+def body(s):
+    with open(os.path.join(skills_dir, s, "SKILL.md"), encoding="utf-8") as fh:
+        return fh.read()
+
+def entry(s):
+    return tp.get(s) or {}
+
+fail = []
+
+if check == "coverage":          # T1
+    for s in skills:
+        if "subagents" not in entry(s):
+            fail.append(f"{s}: no `subagents` disposition in tool_policies")
+elif check == "enum":            # T2
+    for s in skills:
+        v = entry(s).get("subagents")
+        if v is not None and v not in VALID:
+            fail.append(f"{s}: invalid subagents value {v!r}")
+elif check == "conditional_trigger":   # T3
+    for s in skills:
+        e = entry(s)
+        if e.get("subagents") == "conditional" and not e.get("subagent_trigger"):
+            fail.append(f"{s}: conditional but no subagent_trigger")
+elif check == "never_rationale":       # T4
+    for s in skills:
+        e = entry(s)
+        if e.get("subagents") == "never":
+            if not e.get("subagent_rationale") and "Sub-agents: not used" not in body(s):
+                fail.append(f"{s}: never but no rationale (config or SKILL.md)")
+elif check == "body_trigger":          # T5
+    for s in skills:
+        if entry(s).get("subagents") in ("always", "conditional"):
+            b = body(s)
+            if MARKER not in b:
+                fail.append(f"{s}: {entry(s)['subagents']} but no '{MARKER}' section")
+            elif "sub-agent-dispatch.md" not in b:
+                fail.append(f"{s}: dispatch section does not link the shared selection rules")
+elif check == "no_contradiction":      # T6
+    for s in skills:
+        if entry(s).get("subagents") == "never" and MARKER in body(s):
+            fail.append(f"{s}: never but body contains a '{MARKER}' section")
+else:
+    print(f"unknown check: {check}", file=sys.stderr)
+    sys.exit(2)
+
+if fail:
+    print(f"{len(fail)} violation(s) for check '{check}':", file=sys.stderr)
+    for f in fail:
+        print("  - " + f, file=sys.stderr)
+    sys.exit(1)
+print(f"check '{check}' OK ({len(skills)} skills)")
+PY
+}
+
+@test "every skill has a subagents disposition (dynamic coverage)" {
+    run run_check coverage
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "subagents values are valid enums" {
+    run run_check enum
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "conditional skills declare a subagent_trigger" {
+    run run_check conditional_trigger
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "never skills carry a rationale" {
+    run run_check never_rationale
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "always/conditional skills have an in-body trigger linking the shared rules" {
+    run run_check body_trigger
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "never skills do not instruct dispatch (no contradiction)" {
+    run run_check no_contradiction
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}


### PR DESCRIPTION
## Summary

Establishes a single source of truth for **when and how skills dispatch sub-agents**, and a CI-enforced gate so every skill carries an explicit disposition. Closes #367.

- **New reference** `configs/claude/references/sub-agent-dispatch.md` (read-on-demand, not auto-loaded): the two mechanisms (native Task sub-agents vs `parallel_agent.py`), selection rules by task type, the ≥3-independent-units threshold, the no-recursion rule, cross-platform fallback, and the contributor convention. Indexed from `configs/claude/CLAUDE.md`.
- **Schema** in `command_config.yml`: adds `subagents` / `subagent_trigger` / `subagent_rationale`; backfills a disposition for **all 88 skills**.
- **In-body triggers**: `## Sub-agent dispatch` sections on the always/conditional skills, each linking the shared rules (no rule duplication).
- **Enforcement test** `tests/bats/subagent_policy.bats`: dynamic coverage + consistency gate — every skill has a disposition; `conditional`⇒trigger; `never`⇒rationale; always/conditional⇒body trigger linking the rules; no contradictions.

## Cross-verification (constitution Tier-1)

Ran `parallel_agent.py --review` on the diff (claude + antigravity completed; gemini failed on `IneligibleTierError` — CLI deprecated, infra not code). Substantive checks all passed. It surfaced **one real latent bug, fixed here**: the enforcement test opened `SKILL.md`/config files without `encoding="utf-8"`, which would `UnicodeDecodeError` on a C/POSIX-locale CI runner lacking `C.UTF-8` (the files contain `≥`). Reproduced with locale coercion disabled, fixed both `open()` calls, and verified the test passes under a forced `C` locale. Also applied the cosmetic review nits (escape-hatch docs, template completeness, comment wording, `with`-blocks).

## Test plan

- [x] `bats tests/bats/subagent_policy.bats` — 6/6 pass
- [x] `bats tests/bats/` — full suite, 576 tests, 0 failures
- [x] Enforcement test passes under `LC_ALL=C` with locale coercion disabled
- [x] `yamllint configs/claude/config/command_config.yml` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)