### PR TITLE
🛠️ Forge: Remove JSON parsing heuristic fast-paths for maintainability

### DIFF
--- a/configs/claude/scripts/guidance_hint.py
+++ b/configs/claude/scripts/guidance_hint.py
@@ -163,10 +163,6 @@ def _command_from_payload(raw: str) -> str | None:
     `BeforeTool`-style `args.command`/top-level `command` shapes used by Gemini/
     Cursor via ai-hooks-integration). Unknown shapes return None (fail-open).
     """
-    # ⚡ Bolt: Fast-path bypass for string allocation overhead and slow
-    # ValueError/JSONDecodeError on json.loads for obvious non-JSON strings
-    if isinstance(raw, str) and raw and raw[0] not in " \t\n\r{[":
-        return None
     try:
         payload = json.loads(raw)
     except (json.JSONDecodeError, TypeError):

--- a/configs/claude/scripts/skillclaw_audit.py
+++ b/configs/claude/scripts/skillclaw_audit.py
@@ -289,14 +289,13 @@ def _parse_kv(pairs):
         if "=" not in p:
             continue
         k, v = p.split("=", 1)
-        v_s = v.lstrip()
-        # ⚡ Bolt: Fast-path to avoid slow ValueError on json.loads for obvious strings
-        if v_s and v_s[0] in '{["tfn0123456789-.':
-            try:
-                out[k] = json.loads(v)
-            except ValueError:
+        try:
+            parsed = json.loads(v)
+            if isinstance(parsed, (dict, list, int, float, bool, str)) or parsed is None:
+                out[k] = parsed
+            else:
                 out[k] = v
-        else:
+        except json.JSONDecodeError:
             out[k] = v
     return out
 

--- a/configs/claude/scripts/skillclaw_audit.py
+++ b/configs/claude/scripts/skillclaw_audit.py
@@ -291,7 +291,10 @@ def _parse_kv(pairs):
         k, v = p.split("=", 1)
         try:
             parsed = json.loads(v)
-            if isinstance(parsed, (dict, list, int, float, bool, str)) or parsed is None:
+            if (
+                isinstance(parsed, (dict, list, int, float, bool, str))
+                or parsed is None
+            ):
                 out[k] = parsed
             else:
                 out[k] = v

--- a/configs/claude/scripts/skillclaw_ingest.py
+++ b/configs/claude/scripts/skillclaw_ingest.py
@@ -92,17 +92,13 @@ def parse_transcript(
     turns: list[dict] = []
     with path.open(encoding="utf-8", errors="replace") as fh:
         for line in fh:
-            # ⚡ Bolt: Fast-path bypass for string allocation overhead (.strip) and
-            # json.loads exception overhead. The common case (no leading whitespace)
-            # skips allocation; a rare indented line falls back to lstrip so it is not
-            # silently dropped. json.loads tolerates surrounding whitespace/newline.
-            if not line or (line[0] != "{" and line.lstrip()[:1] != "{"):
+            if not line.strip():
                 continue
             try:
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue  # partial/corrupt line — skip
-            if type(obj) is not dict or obj.get("type") not in ("user", "assistant"):
+            if not isinstance(obj, dict) or obj.get("type") not in ("user", "assistant"):
                 continue
             session_id = obj.get("sessionId", session_id)
             cwd = obj.get("cwd", cwd)

--- a/configs/claude/scripts/skillclaw_ingest.py
+++ b/configs/claude/scripts/skillclaw_ingest.py
@@ -98,7 +98,10 @@ def parse_transcript(
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue  # partial/corrupt line — skip
-            if not isinstance(obj, dict) or obj.get("type") not in ("user", "assistant"):
+            if not isinstance(obj, dict) or obj.get("type") not in (
+                "user",
+                "assistant",
+            ):
                 continue
             session_id = obj.get("sessionId", session_id)
             cwd = obj.get("cwd", cwd)


### PR DESCRIPTION
removed JSON parsing heuristic fast-paths to prioritize maintainability and explicit type-checking over micro-optimizations. Ensured downstream components don't receive invalid JSON primitives. Evaluated fast-paths that avoided `json.loads` exception overhead but introduced brittle parsing logic across multiple tools. Replaced with robust `try/except json.JSONDecodeError` blocks. Included `str` explicitly in allowed valid primitives check to prevent regression.

---
*PR created automatically by Jules for task [14075411888216416278](https://jules.google.com/task/14075411888216416278) started by @RB-chrismandich*