### PR TITLE
🎨 Palette: Semantic markdown icons for agent status

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,9 +39,16 @@ intermediate states like warnings or manual review requests, confusing users
 when a process didn't fully fail but isn't fully approved.
 **Action:** Use a three-color semantic system (green=success, yellow=warning/review,
 red=error/blocked) for validation verdicts to provide nuanced visual feedback.
+
 ## 2026-06-21 - Semantic Colors for CLI States
-**Learning:** In CLI status tables (like `check_status.sh`), using a red cross (`✗`) for intentionally disabled services communicates a false error state, increasing cognitive overload. A three-color semantic system (green=success/enabled, yellow=warning/inactive/disabled, red=error/blocked) provides nuanced visual feedback and accurately reflects intermediate, non-error states.
-**Action:** When designing or refactoring CLI outputs, explicitly reserve red (`RED`) for critical failures or blocked states, and use yellow (`YELLOW`) with an appropriate icon (like `○` or `⚠`) for optional, inactive, or intentionally disabled components.
+
+**Learning:** In CLI status tables (like `check_status.sh`), using a red cross (`✗`) for intentionally disabled
+services communicates a false error state, increasing cognitive overload. A three-color semantic system
+(green=success/enabled, yellow=warning/inactive/disabled, red=error/blocked) provides nuanced visual
+feedback and accurately reflects intermediate, non-error states.
+**Action:** When designing or refactoring CLI outputs, explicitly reserve red (`RED`) for critical failures
+or blocked states, and use yellow (`YELLOW`) with an appropriate icon (like `○` or `⚠`) for optional,
+inactive, or intentionally disabled components.
 
 ## 2026-06-22 - Semantic Errors in CLI Logs
 
@@ -49,3 +56,10 @@ red=error/blocked) for validation verdicts to provide nuanced visual feedback.
 in with standard text, reducing the user's ability to quickly spot failures in busy output streams.
 **Action:** Consistently apply semantic red styling (`\033[0;31m`) to standard error messages in bash
 scripts to ensure they stand out visually and draw immediate attention.
+
+## 2026-06-23 - Semantic Icons in Markdown Reports
+
+**Learning:** When generating markdown summaries, using a failure icon (like a cross) for non-active or disabled
+states causes confusion. A binary pass/fail schema fails to represent intermediate neutral states correctly.
+**Action:** Always use a three-state semantic system (e.g., success, error, and neutral/disabled) for status icons
+in generated reports.

--- a/configs/claude/scripts/agents/orchestrator.py
+++ b/configs/claude/scripts/agents/orchestrator.py
@@ -412,7 +412,13 @@ class Orchestrator:
 
             f.write("## Agent Results\n\n")
             for agent_name, agent_result in result["agents"].items():
-                status_icon = "✓" if agent_result.get("status") == "complete" else "✗"
+                status = agent_result.get("status")
+                if status == "complete":
+                    status_icon = "✓"
+                elif status in ("failed", "error"):
+                    status_icon = "✗"
+                else:
+                    status_icon = "○"
                 f.write(f"### {status_icon} {agent_name.title()}\n\n")
                 f.write(f"- **Status**: {agent_result.get('status')}\n")
                 f.write(f"- **Model**: {agent_result.get('model', 'N/A')}\n")


### PR DESCRIPTION
💡 What: Replaced binary ✓/✗ status icons in Markdown summary generation with a three-state semantic system (✓ for complete, ✗ for error/failed, ○ for others like disabled/skipped).
🎯 Why: Using a cross (✗) for intentionally disabled or inactive agents creates a false error state, increasing cognitive overload. A neutral circle (○) accurately reflects intermediate, non-error states.
📸 Before/After: Before, non-complete agents (even if just disabled/skipped) showed `✗`. Now they show `○`.
♿ Accessibility: Reduces cognitive load and false error states for users reading the generated markdown reports.

---
*PR created automatically by Jules for task [10090870412456150473](https://jules.google.com/task/10090870412456150473) started by @RB-chrismandich*