### PR TITLE
Update meta-prompt-optimize skill template

### DIFF
--- a/.skillshare/skills/meta-prompt-optimize/SKILL.md
+++ b/.skillshare/skills/meta-prompt-optimize/SKILL.md
@@ -13,16 +13,24 @@ description: |
 
   <preliminary_context>
     Operate as a deterministic, machine-to-machine prompt refactoring pipeline handling payloads from the scheduled
-    task pipeline. Processing involves four cycles: Deconstruct, Normalize, Inject Safeguards, and Cleanse.
+    task pipeline. Execute these four processing cycles internally:
+
+    1. Deconstruct: Extract the underlying structural intent, execution environment context, and implicit boundary
+       limits.
+    2. Normalize: Map the intent into the mandatory XML-tag-demarcated schema below.
+    3. Inject Safeguards: Embed the absolute pathing, pythonic runtime rules, and idempotency constraints directly
+       into the generated payload.
+    4. Cleanse: Purge any introductory text ("Sure, here is your prompt"), markdown section commentary, or
+       conversational tags.
   </preliminary_context>
 
   <constraints>
     - Enforce absolute path strings; no raw tilde (~) directory configurations allowed.
     - Execute changes utilizing current Python-based utilities; explicitly omit deprecated shell (.sh) actions.
     - All actions must be structurally idempotent to prevent environmental state corruption during re-runs.
-    - Explicitly preserve any literal schema templates (like XML tags or JSON layouts) inside the refactored output. Do
-      not consume, delete, or over-summarize these structural templates during the normalization process, as they are
-      required instructions for downstream agents.
+    - Explicitly preserve any literal schema templates (like XML tags or JSON layouts) inside the refactored
+      output (e.g., within <desired_output>). Do not consume, delete, or over-summarize these structural templates
+      during the normalization process, as they are required instructions for downstream agents.
   </constraints>
 
   <desired_output>
@@ -52,8 +60,6 @@ description: |
     </problem_structure>
     ```
 
-    ## 5. Normalized Structural Blueprints
-
     Depending on the task classification parsed during the sequence, map the payload to one of these execution
     structures:
 
@@ -61,6 +67,7 @@ description: |
 
     Task: Enforce deterministic system configuration, file syncing, or environment updates.
     Format Requirements:
+
     1. **Risk Profiling**: Enumerate environment dependencies or state impacts.
     2. **Implementation Block**: Production-grade code or configuration values.
     3. **State Verification**: A machine-executable verification string (e.g., dry-run flag) to prove success.
@@ -69,6 +76,7 @@ description: |
 
     Objective: Ingest, filter, and calculate multi-variable metrics or quantitative signals.
     Format Requirements:
+
     1. **Schema Validation**: Explicit safety check for missing elements, null responses, or noise.
     2. **Compute Matrix**: Step-by-step logic calculating intermediate vectors before writing final fields.
     3. **Fallback Logic**: Precise execution paths if input data streams fail schema validation.
@@ -77,6 +85,7 @@ description: |
 
     Task: Orchestrate task states across multiple specialized tool wrappers or sub-agents.
     Format Requirements:
+
     1. **Constitution Compliance**: Immediate boundary verification before spawning worker threads.
     2. **State Payload Specification**: Strict definitions of variables passed across isolation boundaries.
     3. **Execution Telemetry JSON**:
@@ -89,3 +98,5 @@ description: |
       "telemetry": ""
     }
     ```
+  </desired_output>
+</problem_structure>


### PR DESCRIPTION
Refactors the meta-prompt-optimize SKILL.md template to explicitly preserve literal schema templates, constraints, and process cycles, without over-summarizing them.

---
*PR created automatically by Jules for task [10431757852281883900](https://jules.google.com/task/10431757852281883900) started by @RB-chrismandich*