### PR TITLE
fix(bootstrap): preserve user-added MCP servers across settings.local.json redeploy

### DIFF
--- a/bootstrap/lib/deploy.sh
+++ b/bootstrap/lib/deploy.sh
@@ -47,6 +47,18 @@ deploy_configs() {
     # user/runtime state (plugins, sessions, settings.json, …) from the backup.
     local restore_from=""
 
+    # Snapshot the live settings.local.json BEFORE any destructive path below
+    # (backup-and-replace mv, --force overwrite, or the repo copy). The repo
+    # ships its own settings.local.json that would otherwise clobber any MCP
+    # server the user added to their live file; merge_claude_mcp_servers unions
+    # the snapshot back in after the copy. Captured here (not in each branch) so
+    # it predates the "Backup and replace" mv that moves the live dir aside.
+    local preserved_mcp=""
+    if [[ -f "$TARGET_DIR/settings.local.json" ]]; then
+        preserved_mcp="$(mktemp)"
+        cp "$TARGET_DIR/settings.local.json" "$preserved_mcp"
+    fi
+
     # rsync is a hard dependency of every copy path below. Check it BEFORE the
     # destructive `mv` of ~/.claude — failing mid-deploy stranded all user
     # state in the timestamped backup with no recovery message (issue #320).
@@ -101,6 +113,11 @@ deploy_configs() {
                     rsync -av --ignore-existing --exclude '/skills' "$source_dir/" "$TARGET_DIR/"
                     deploy_home_skills "$SCRIPT_DIR/.skillshare/skills" "$TARGET_DIR/skills"
                     gate_graphify_skill "$TARGET_DIR/skills"
+                    # --ignore-existing keeps the user's settings.local.json as-is,
+                    # but if it was absent the repo copy lands fresh; union back any
+                    # MCP servers captured from the live file either way.
+                    merge_claude_mcp_servers "$preserved_mcp" "$TARGET_DIR/settings.local.json"
+                    [[ -n "$preserved_mcp" ]] && rm -f "$preserved_mcp"
                     print_success "Configurations merged"
                     # Still write services config
                     write_services_config
@@ -144,6 +161,11 @@ deploy_configs() {
     rsync -a --exclude '/skills' "$source_dir"/ "$TARGET_DIR/"
     # Copy dot-prefixed directories (e.g. .plans/) that the glob above skips
     cp -R "$source_dir"/.[!.]* "$TARGET_DIR/" 2> /dev/null || true
+
+    # Restore any user-added MCP servers captured before the copy above so the
+    # repo's default settings.local.json does not silently drop them.
+    merge_claude_mcp_servers "$preserved_mcp" "$TARGET_DIR/settings.local.json"
+    [[ -n "$preserved_mcp" ]] && rm -f "$preserved_mcp"
 
     # Deploy skills from the PHYSICAL skillshare source into ~/.claude/skills.
     # Must run before link_shared_assets (create_symlink skips missing targets).
@@ -278,6 +300,59 @@ PYEOF
         3) print_info "Existing settings.json already has repo hooks - preserved" ;;
         *) print_warning "Could not merge hooks into existing settings.json (manual merge may be needed)" ;;
     esac
+}
+
+# Preserve user-added MCP servers across a settings.local.json redeploy.
+#
+# The repo ships configs/claude/settings.local.json with a default mcpServers
+# block. The destructive copy in deploy_configs overwrites the live
+# ~/.claude/settings.local.json, which would silently drop any MCP server the
+# user added there (e.g. via `claude mcp add --scope local`). deploy_configs
+# snapshots the live file BEFORE the copy; this unions the snapshot's mcpServers
+# back into the freshly deployed file. The USER's entry wins on key conflicts so
+# their servers are kept intact — repo defaults only fill in servers the user
+# does not already have. Fail-open: parse errors leave the deployed file
+# untouched and warn.
+merge_claude_mcp_servers() {
+    local preserved="$1" tgt="$2"
+    [[ -n "$preserved" && -f "$preserved" ]] || return 0
+    [[ -f "$tgt" ]] || return 0
+    if ! command_exists python3; then
+        print_info "python3 unavailable — skipped MCP server preservation in settings.local.json"
+        return 0
+    fi
+    local rc=0
+    python3 - "$preserved" "$tgt" << 'PYEOF' || rc=$?
+import json, sys
+pre_path, tgt_path = sys.argv[1], sys.argv[2]
+try:
+    pre = json.load(open(pre_path))
+    tgt = json.load(open(tgt_path))
+except Exception:
+    sys.exit(2)
+user_servers = pre.get("mcpServers", {})
+if not isinstance(user_servers, dict) or not user_servers:
+    sys.exit(3)
+repo_servers = tgt.get("mcpServers", {})
+if not isinstance(repo_servers, dict):
+    repo_servers = {}
+merged = dict(repo_servers)
+for name, cfg in user_servers.items():
+    merged[name] = cfg  # user entry wins on conflict — keep their server intact
+if merged == repo_servers:
+    sys.exit(3)
+tgt["mcpServers"] = merged
+with open(tgt_path, "w") as f:
+    json.dump(tgt, f, indent=2)
+    f.write("\n")
+sys.exit(0)
+PYEOF
+    case $rc in
+        0) print_success "Preserved user MCP servers in settings.local.json" ;;
+        3) print_info "No user-added MCP servers to preserve in settings.local.json" ;;
+        *) print_warning "Could not preserve MCP servers in settings.local.json (manual merge may be needed)" ;;
+    esac
+    return 0
 }
 
 # Deploy Gemini CLI configuration (mirrors .claude with symlinks)

--- a/tests/bats/claude_mcp_preserve.bats
+++ b/tests/bats/claude_mcp_preserve.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+# merge_claude_mcp_servers(): user-added MCP servers in the live
+# ~/.claude/settings.local.json must survive a bootstrap redeploy. The repo
+# ships its own settings.local.json (with default mcpServers); the destructive
+# copy in deploy_configs would otherwise drop any server the user added.
+# User entries win on key conflicts — "keep them intact".
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+
+setup() {
+    TMPDIR_T="$(mktemp -d)"
+    PRESERVED="$TMPDIR_T/preserved.json"  # snapshot of live settings.local.json
+    TGT="$TMPDIR_T/tgt.json"              # freshly deployed repo copy
+
+    command_exists() { command -v "$1" > /dev/null 2>&1; }
+    print_info() { echo "INFO: $*"; }
+    print_success() { echo "OK: $*"; }
+    print_warning() { echo "WARN: $*"; }
+    export -f command_exists print_info print_success print_warning 2> /dev/null || true
+
+    # shellcheck disable=SC1091
+    source "$REPO_ROOT/bootstrap/lib/deploy.sh" 2> /dev/null || true
+
+    # Repo-shipped default (what the deploy just copied into place)
+    cat > "$TGT" <<'EOF'
+{
+  "mcpServers": {
+    "sentry": { "url": "https://mcp.sentry.dev/mcp" },
+    "linear": { "command": "npx", "args": ["-y", "mcp-remote", "https://mcp.linear.app/mcp"] }
+  }
+}
+EOF
+}
+
+teardown() {
+    rm -rf "$TMPDIR_T"
+}
+
+@test "user-added MCP server is restored into the deployed settings.local.json" {
+    cat > "$PRESERVED" <<'EOF'
+{
+  "mcpServers": {
+    "sentry": { "url": "https://mcp.sentry.dev/mcp" },
+    "linear": { "command": "npx", "args": ["-y", "mcp-remote", "https://mcp.linear.app/mcp"] },
+    "my-private": { "url": "https://mcp.internal.example/mcp" }
+  }
+}
+EOF
+    run merge_claude_mcp_servers "$PRESERVED" "$TGT"
+    assert_success
+    assert_output --partial "Preserved user MCP servers"
+
+    run python3 -c "
+import json
+d = json.load(open('$TGT'))
+assert d['mcpServers']['my-private']['url'] == 'https://mcp.internal.example/mcp'
+assert 'sentry' in d['mcpServers'] and 'linear' in d['mcpServers']
+print('user-server-preserved')"
+    assert_output --partial "user-server-preserved"
+}
+
+@test "user customization wins on key conflict (kept intact)" {
+    cat > "$PRESERVED" <<'EOF'
+{
+  "mcpServers": {
+    "sentry": { "url": "https://sentry.internal.example/custom" }
+  }
+}
+EOF
+    run merge_claude_mcp_servers "$PRESERVED" "$TGT"
+    assert_success
+
+    run python3 -c "
+import json
+d = json.load(open('$TGT'))
+assert d['mcpServers']['sentry']['url'] == 'https://sentry.internal.example/custom', d['mcpServers']['sentry']
+print('user-wins')"
+    assert_output --partial "user-wins"
+}
+
+@test "no user-added servers (live == repo defaults) is a clean no-op" {
+    cat > "$PRESERVED" <<'EOF'
+{
+  "mcpServers": {
+    "sentry": { "url": "https://mcp.sentry.dev/mcp" },
+    "linear": { "command": "npx", "args": ["-y", "mcp-remote", "https://mcp.linear.app/mcp"] }
+  }
+}
+EOF
+    local before
+    before=$(cat "$TGT")
+    run merge_claude_mcp_servers "$PRESERVED" "$TGT"
+    assert_success
+    assert_output --partial "No user-added MCP servers"
+    assert_equal "$(cat "$TGT")" "$before"
+}
+
+@test "missing preserved snapshot is a no-op (fresh install)" {
+    run merge_claude_mcp_servers "" "$TGT"
+    assert_success
+}
+
+@test "malformed preserved snapshot fails open (deployed file untouched, warning)" {
+    echo '{ not json' > "$PRESERVED"
+    local before
+    before=$(cat "$TGT")
+    run merge_claude_mcp_servers "$PRESERVED" "$TGT"
+    assert_success
+    assert_output --partial "WARN"
+    assert_equal "$(cat "$TGT")" "$before"
+}
+
+@test "preserved snapshot with no mcpServers key is a clean no-op" {
+    echo '{ "permissions": { "allow": [] } }' > "$PRESERVED"
+    local before
+    before=$(cat "$TGT")
+    run merge_claude_mcp_servers "$PRESERVED" "$TGT"
+    assert_success
+    assert_equal "$(cat "$TGT")" "$before"
+}

--- a/tests/bats/deploy_runtime_state_e2e.bats
+++ b/tests/bats/deploy_runtime_state_e2e.bats
@@ -51,6 +51,29 @@ setup() {
     # A stray top-level file that is NOT part of configs/claude is unknown user
     # content and must be preserved (safe default, same as plugins/sessions).
     echo 'keepme'                     > "$TARGET_DIR/my_personal_note.md"
+
+    # A live settings.local.json holding a USER-ADDED MCP server. The repo ships
+    # its own settings.local.json (with default mcpServers) that overwrites this
+    # on redeploy; the user's server must survive (kept intact).
+    cat > "$TARGET_DIR/settings.local.json" <<'JSON'
+{
+  "mcpServers": {
+    "my-private": { "url": "https://mcp.internal.example/mcp" }
+  }
+}
+JSON
+}
+
+# The user-added MCP server survived AND the repo defaults were deployed.
+assert_user_mcp_preserved() {
+    run python3 -c "
+import json
+d = json.load(open('$TARGET_DIR/settings.local.json'))
+s = d.get('mcpServers', {})
+assert s.get('my-private', {}).get('url') == 'https://mcp.internal.example/mcp', s
+assert 'sentry' in s, s  # repo default still present
+print('mcp-preserved')"
+    assert_output --partial "mcp-preserved"
 }
 
 teardown() {
@@ -83,6 +106,7 @@ assert_config_deployed() {
 
     assert_runtime_preserved
     assert_config_deployed
+    assert_user_mcp_preserved
 
     # Stale config inside a repo-owned dir was dropped (the whole point of
     # option 1 vs merge) — proving owned config was genuinely replaced.
@@ -103,6 +127,7 @@ assert_config_deployed() {
 
     assert_runtime_preserved
     assert_config_deployed
+    assert_user_mcp_preserved
     # --force is additive (no mv), so even the stale file remains — that's fine;
     # the data-loss bug was only ever the mv path.
 }
@@ -114,4 +139,12 @@ assert_config_deployed() {
     assert_runtime_preserved
     [ -f "$TARGET_DIR/CLAUDE.md" ]
     [ -d "$TARGET_DIR/skills/code-quality" ]
+
+    # Merge keeps the user's settings.local.json (and its MCP server) intact.
+    run python3 -c "
+import json
+s = json.load(open('$TARGET_DIR/settings.local.json')).get('mcpServers', {})
+assert s.get('my-private', {}).get('url') == 'https://mcp.internal.example/mcp', s
+print('mcp-intact')"
+    assert_output --partial "mcp-intact"
 }


### PR DESCRIPTION
## Problem

`bootstrap`'s `deploy_configs` overwrites the live `~/.claude/settings.local.json` with the repo's default copy on every redeploy. Any MCP server the user added locally (e.g. via `claude mcp add --scope local`) was **silently dropped** — the repo's default `mcpServers` block clobbered the user's.

## Fix

- Snapshot the live `settings.local.json` **before** any destructive path (backup-and-replace `mv`, `--force` overwrite, or the repo copy), captured once up front so it predates the `mv`.
- New `merge_claude_mcp_servers()` unions the snapshot's `mcpServers` back into the freshly deployed file after the copy.
- **User entry wins** on key conflict (their server kept intact); repo defaults only fill in servers the user doesn't already have.
- **Fail-open**: parse errors leave the deployed file untouched and warn; missing snapshot / no user servers / python3 absent are clean no-ops.
- Wired into all three deploy paths: merge (`--ignore-existing` rsync), backup-and-replace, and `--force`.

## Tests

- `tests/bats/claude_mcp_preserve.bats` — 6 unit tests (restore, user-wins, no-op when live==defaults, missing snapshot, malformed-fails-open, no-mcpServers-key).
- `tests/bats/deploy_runtime_state_e2e.bats` — 3 e2e assertions proving the user's server survives across all deploy modes alongside repo defaults.

## Verification

- `shfmt -i 4 -ci -sr -ln bash` clean, `shellcheck -S warning` clean.
- 9/9 bats green on the post-#443-merge base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)